### PR TITLE
Added new global configuration directive shutdown_script.

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -40,6 +40,9 @@ and
  smtp_connect_timeout 30 # integer, seconds
  router_id my_hostname   # string identifying the machine,
                          # (doesn't have to be hostname).
+
+ # Script to run on keepalived shutdown
+ shutdown_script "/bin/true arg1 arg2"
  }
 
 

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -80,6 +80,12 @@ email_handler(vector strvec)
 	free_strvec(email_vec);
 }
 
+static void
+shutdown_script_handler (vector strvec) {
+	FREE_PTR(data->shutdown_script);
+	data->shutdown_script = set_value(strvec);
+}
+
 void
 global_init_keywords(void)
 {
@@ -92,4 +98,5 @@ global_init_keywords(void)
 	install_keyword("smtp_server", &smtpip_handler);
 	install_keyword("smtp_connect_timeout", &smtpto_handler);
 	install_keyword("notification_email", &email_handler);
+	install_keyword("shutdown_script", &shutdown_script_handler);
 }

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -51,6 +51,7 @@ typedef struct _conf_data {
 	struct sockaddr_storage smtp_server;
 	long smtp_connection_to;
 	list email;
+	char *shutdown_script;
 } conf_data_t;
 
 /* Global vars exported */


### PR DESCRIPTION
This patch adds new global configuration directive "shutdown_script". Using this directive one can, for example, easily shutdown any services started by notitfy_\* directive scripts when daemon is shut down.

Example: Run /bin/true on daemon shutdown.
 shutdown_script "/bin/true arg1 arg2"
