### PR TITLE
Added a separate timeout parameter for vrrp_script checks

### DIFF
--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -40,6 +40,7 @@
 
 /* VRRP script tracking defaults */
 #define VRRP_SCRIPT_DI 1       /* external script track interval (in sec) */
+#define VRRP_SCRIPT_DT 1       /* external script track timeout (in sec) */
 #define VRRP_SCRIPT_DW 0       /* external script default weight */
 
 /* VRRP script tracking results.
@@ -58,6 +59,7 @@ typedef struct _vrrp_script {
 	char *sname;		/* instance name */
 	char *script;		/* the command to be called */
 	int interval;		/* interval between script calls */
+	int timeout;		/* seconds before script timeout */
 	int weight;		/* weight associated to this script */
 	int result;		/* result of last call to this script: 0..R-1 = KO, R..R+F-1 = OK */
 	int inuse;		/* how many users have weight>0 ? */

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -116,6 +116,7 @@ dump_vscript(void *data)
 	log_message(LOG_INFO, " VRRP Script = %s", vscript->sname);
 	log_message(LOG_INFO, "   Command = %s", vscript->script);
 	log_message(LOG_INFO, "   Interval = %d sec", vscript->interval / TIMER_HZ);
+	log_message(LOG_INFO, "   Timeout = %d sec", vscript->timeout / TIMER_HZ);
 	log_message(LOG_INFO, "   Weight = %d", vscript->weight);
 	log_message(LOG_INFO, "   Rise = %d", vscript->rise);
 	log_message(LOG_INFO, "   Fall = %d", vscript->fall);
@@ -377,6 +378,7 @@ alloc_vrrp_script(char *sname)
 	new->sname = (char *) MALLOC(size + 1);
 	memcpy(new->sname, sname, size + 1);
 	new->interval = VRRP_SCRIPT_DI * TIMER_HZ;
+	new->timeout = VRRP_SCRIPT_DT * TIMER_HZ;
 	new->weight = VRRP_SCRIPT_DW;
 	new->result = VRRP_SCRIPT_STATUS_INIT;
 	new->inuse = 0;

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -426,6 +426,14 @@ vrrp_vscript_interval_handler(vector strvec)
 		vscript->interval = TIMER_HZ;
 }
 static void
+vrrp_vscript_timeout_handler(vector strvec)
+{
+	vrrp_script *vscript = LIST_TAIL_DATA(vrrp_data->vrrp_script);
+	vscript->timeout = atoi(VECTOR_SLOT(strvec, 1)) * TIMER_HZ;
+	if (vscript->timeout < TIMER_HZ)
+		vscript->timeout = TIMER_HZ;
+}
+static void
 vrrp_vscript_weight_handler(vector strvec)
 {
 	vrrp_script *vscript = LIST_TAIL_DATA(vrrp_data->vrrp_script);
@@ -502,6 +510,7 @@ vrrp_init_keywords(void)
 	install_keyword_root("vrrp_script", &vrrp_script_handler);
 	install_keyword("script", &vrrp_vscript_script_handler);
 	install_keyword("interval", &vrrp_vscript_interval_handler);
+	install_keyword("timeout", &vrrp_vscript_timeout_handler);
 	install_keyword("weight", &vrrp_vscript_weight_handler);
 	install_keyword("rise", &vrrp_vscript_rise_handler);
 	install_keyword("fall", &vrrp_vscript_fall_handler);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -957,7 +957,7 @@ vrrp_script_thread(thread_t * thread)
 	/* In case of this is parent process */
 	if (pid) {
 		long timeout;
-		timeout = vscript->interval;
+		timeout = vscript->timeout;
 		thread_add_child(thread->master, vrrp_script_child_thread,
 				 vscript, pid, timeout);
 		return 0;


### PR DESCRIPTION
I've added a timeout parameter to the vrrp check scripts which allow you to have the check timeout different to the interval.

To explain the reasoning: We wanted to have check scripts time out faster than our check interval. Doing the check we need to perform is a little load intensive and so we don't want to perform it every few seconds. With this patch we set an interval of 60 seconds but a timeout of 5 seconds (if the check takes more than a few seconds then the service is not working correctly).
