### PR TITLE
Remove unnecessary KERNEL variable.

### DIFF
--- a/keepalived/check/Makefile.in
+++ b/keepalived/check/Makefile.in
@@ -4,13 +4,12 @@
 #
 # Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
 
-KERNEL   = @KERN@
 CC	 = @CC@
 SNMP_FLAG = @SNMP_SUPPORT@
 INCLUDES = -I../include -I../../lib
 CFLAGS	 = @CFLAGS@ @CPPFLAGS@ $(INCLUDES) \
 	   -Wall -Wunused -Wstrict-prototypes
-DEFS	 = -D$(KERNEL) -D@IPVS_SUPPORT@ -D@IPVS_SYNCD@ -D@VRRP_SUPPORT@ -D@SNMP_SUPPORT@ @DFLAGS@
+DEFS	 = -D@KERN@ -D@IPVS_SUPPORT@ -D@IPVS_SYNCD@ -D@VRRP_SUPPORT@ -D@SNMP_SUPPORT@ @DFLAGS@
 COMPILE	 = $(CC) $(CFLAGS) $(DEFS)
 
 OBJS = 	check_daemon.o check_data.o check_parser.o \


### PR DESCRIPTION
The Makefile.in file can use the @KERN@ variable directly, so there is no need for the KERNEL variable. This is also consistent with other Makefile.in files.

Signed-off-by: Ryan O'Hara rohara@redhat.com
