### PR TITLE
Prevent overriding port option of VirtualHost in HTTP checker

### DIFF
--- a/genhash/http.h
+++ b/genhash/http.h
@@ -43,7 +43,7 @@
 /* GET processing command */
 #define REQUEST_TEMPLATE "GET %s HTTP/1.0\r\n" \
 			 "User-Agent: GenHash (Linux powered)\r\n" \
-			 "Host: %s:%d\r\n\r\n"
+			 "Host: %s%s\r\n\r\n"
 
 /* Output delimiters */
 #define DELIM_BEGIN "-----------------------["

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -83,7 +83,7 @@ typedef struct _http_checker {
 /* GET processing command */
 #define REQUEST_TEMPLATE "GET %s HTTP/1.0\r\n" \
                          "User-Agent:KeepAliveClient\r\n" \
-                         "Host: %s:%d\r\n\r\n"
+                         "Host: %s%s\r\n\r\n"
 /* macro utility */
 #define HTTP_ARG(X) ((X)->arg)
 #define HTTP_REQ(X) ((X)->req)


### PR DESCRIPTION
This patch prevents HTTP checker from overriding port option 
in VirtualHost string.

Host's port being specified in HTTP GET request 
only if `VirtualHost` option is not defined, otherwise used `VirtualHost` option itself.

For example if VirtualHost not defined and RealServer is example.com:80 then
HTTP GET Host will be like "Host: example.com:80".
But if VirtualHost is defined as virtual.com:8080 then 
HTTP GET Host will be like "virtual.com:8080". 
In current master branch the second situation will result in HTTP GET
Host like "Host: virtual.com:8080:80" which is incorrect.
This patch fixes this behaviour.
