### PR TITLE
Please pull: minor pidfile fix

### DIFF
--- a/doc/man/man8/keepalived.8
+++ b/doc/man/man8/keepalived.8
@@ -61,6 +61,15 @@ Display a short inlined help screen.
 .TP
 --version, -v    
 Display the version number.
+.TP
+--pid, -p    pidfile
+Use the specified pidfile for keepalived (default=/var/run/keepalived.pid)
+.TP
+--checkers_pid, -c checkers_pidfile
+Use the specified pidfile for the checkers process (default=/var/run/checkers.pid)
+.TP
+--vrrp_pid, -r vrrp_pidfile 
+Use the specified pidfile for the vrrp process (default=/var/run/vrrp.pid)
 
 .SH FILES
 .BR /etc/keepalived/keepalived.conf

--- a/keepalived/include/pidfile.h
+++ b/keepalived/include/pidfile.h
@@ -32,8 +32,6 @@
 
 /* lock pidfile */
 #define KEEPALIVED_PID_FILE "/var/run/keepalived.pid"
-#define KEEPALIVED_VRRP_PID_FILE "/var/run/keepalived_vrrp.pid"
-#define KEEPALIVED_CHECKERS_PID_FILE "/var/run/keepalived_checkers.pid"
 #define VRRP_PID_FILE "/var/run/vrrp.pid"
 #define CHECKERS_PID_FILE "/var/run/checkers.pid"
 


### PR DESCRIPTION
The pidfile options were missing from the manual page and
the macros KEEPALIVED_VRRP_PID_FILE and KEEPALIVED_CHECKERS_PID_FILE
were not used.

This patch adds the missing option to the manual page and removes
the spurious defines.

Signed-off-by: Arnd Hannemann arnd@arndnet.de
