### PR TITLE
Fix configure.in. Library crypt is needed.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -50,6 +50,7 @@ AC_CHECK_DECL([ETHERTYPE_IPV6],[],[CFLAGS="$CFLAGS -DETHERTYPE_IPV6=0x86dd"],
   [[@%:@include <net/ethernet.h>]])
 
 dnl ----[ Checks for libraries ]----
+AC_CHECK_LIB(crypt, crypt,,AC_MSG_ERROR([crypt() function is required]))
 AC_CHECK_LIB(crypto, MD5_Init,,AC_MSG_ERROR([OpenSSL libraries are required]))
 AC_CHECK_LIB(ssl, SSL_CTX_new,,AC_MSG_ERROR([OpenSSL libraries are required]))
 AC_CHECK_LIB(popt, poptGetContext,,AC_MSG_ERROR([Popt libraries is required]))


### PR DESCRIPTION
Hi acassen

I could not compile keepalived without -lcrypt .
so I modify "configure.in".

Junpei Yoshino.
