### PR TITLE
Fixes for RETVAL inside init.d script

### DIFF
--- a/keepalived/etc/init.d/keepalived.init
+++ b/keepalived/etc/init.d/keepalived.init
@@ -68,7 +68,7 @@ case "$1" in
         ;;
     *)
         echo "Usage: $0 {start|stop|reload|restart|condrestart|status}"
-        exit 1
+        RETVAL=1
 esac
 
 exit $RETVAL


### PR DESCRIPTION
Had some problems with `service keepalived status` not returning the correct value when keeplived was not running.  In CentOS 6, it was always returning value of 0 instead of the expect value 3 to indicated the service was not running. This was due to the RETVAL not being set after `status keepalived` is run in the case statement.  

Also made a changed to the catch-all to have it use RETVAL instead of exit like all the other case statements.

~Rob
