### PR TITLE
Fix invalid use of sizeof

### DIFF
--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -115,7 +115,7 @@ dump_ipaddress(void *if_data)
 	} else {
 		inet_ntop(AF_INET, &ipaddr->u.sin.sin_addr, addr_str, 41);
 		if (ipaddr->u.sin.sin_brd.s_addr)
-			snprintf(broadcast, sizeof(broadcast), " brd %s",
+			snprintf(broadcast, 21, " brd %s",
 				 inet_ntop2(ipaddr->u.sin.sin_brd.s_addr));
 	}
 

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -54,7 +54,7 @@ netlink_socket(nl_handle_t *nl, unsigned long groups)
 	socklen_t addr_len;
 	int ret;
 
-	memset(nl, 0, sizeof (nl));
+	memset(nl, 0, sizeof (*nl));
 
 	nl->fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
 	if (nl->fd < 0) {


### PR DESCRIPTION
Fix two invalid uses of sizeof in keepalived/vrrp/vrrp_ipaddress.c and keepalived/vrrp/vrrp_netlink.c.
