### PR TITLE
Faster sync group transition

### DIFF
--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -131,6 +131,11 @@ typedef struct _vrrp_t {
 
 	int			debug;			/* Debug level 0-4 */
 
+	int			quick_sync;		/* Will be set when waiting for the other members
+							 * in the sync group to become master.
+							 * If set the next check will occur in one interval
+							 * instead of three intervals.
+							 */
 	/* State transition notification */
 	int			smtp_alert;
 	int			notify_exec;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -772,8 +772,15 @@ vrrp_state_goto_master(vrrp_t * vrrp)
 	 * Send an advertisement. To force a new master
 	 * election.
 	 */
-        if (vrrp->sync && !vrrp_sync_goto_master(vrrp))
-	      return;
+	if (vrrp->sync && !vrrp_sync_goto_master(vrrp)) {
+		/*
+		 * Set quick sync flag to enable faster transition, i.e. check
+		 * again in the next interval instead of waiting three.
+		 */
+		vrrp->quick_sync = 1;
+		return;
+	}
+
 	vrrp_send_adv(vrrp, vrrp->effective_priority);
 
 	vrrp->state = VRRP_STATE_MAST;

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -334,6 +334,7 @@ alloc_vrrp(char *iname)
 	new->adver_int = TIMER_HZ;
 	new->iname = (char *) MALLOC(size + 1);
 	memcpy(new->iname, iname, size);
+	new->quick_sync = 0;
 
 	list_add(vrrp_data->vrrp, new);
 }

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -862,6 +862,18 @@ vrrp_dispatcher_read_to(int fd)
 	 * compute new sands timer safely.
 	 */
 	vrrp_init_instance_sands(vrrp);
+
+	/*
+	 * If quick sync is set, refresh sands to one advert interval, i.e. the next
+	 * timeout will occur in one interval instead of three, and a check for a
+	 * possible transition check will perform more quickly.
+	 */
+	if (vrrp->quick_sync) {
+		vrrp->sands.tv_sec  = time_now.tv_sec  + vrrp->adver_int / TIMER_HZ;
+		vrrp->sands.tv_usec = time_now.tv_usec + vrrp->adver_int % TIMER_HZ;
+		vrrp->quick_sync = 0;
+        }
+
 	return vrrp->fd_in;
 }
 


### PR DESCRIPTION
Suggestion to speed up sync group transitions.

Send prio 0 when entering FAULT state:
This fix will send prio 0 (VRRP_PRIO_STOP) when the VRRP router transists from MASTER to FAULT state. This will make a sync group leave the MASTER state more quickly by notifying the backup router(s) instead of having them to wait for time out.

Quick sync group transition:
In a sync group, when waiting for all instances to want master state, this fix will check the instances for transition every advert interval instead of every third. This will make a sync group transition occur more quickly.
