### PR TITLE
Fix VRRP wrong interface flags corner case

### DIFF
--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -456,8 +456,10 @@ netlink_if_link_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 
 	/* Skip it if already exist */
 	ifp = if_get_by_ifname(name);
-	if (ifp)
+	if (ifp) {
+		ifp->flags = ifi->ifi_flags;
 		return 0;
+	}
 
 	/* Fill the interface structure */
 	ifp = (interface_t *) MALLOC(sizeof(interface_t));


### PR DESCRIPTION
If a link event arrives between the initial scanning for interfaces and configuration file parsing, the VRRP instance will enter an unrecoverable state. This fix will update the interface flags even when the interface exists, not only for the inital scan. Note that when all is up and running the link events will be properly handled by netlink, so this fix only fixes the special case when a link changes state during initalization/configuration.
