### PR TITLE
Let VMAC interface flags (up/down status) follow base interface.

### DIFF
--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -83,6 +83,8 @@ typedef struct _interface {
 	int			hw_addr_len;		/* MAC addresss length */
 	int			lb_type;		/* Interface regs selection */
 	int			linkbeat;		/* LinkBeat from MII BMSR req */
+	int			vmac;			/* Set if interface is a VMAC interface */
+	unsigned int		base_ifindex;		/* Base interface index (if interface is a VMAC interface) */
 } interface_t;
 
 /* Tracked interface structure definition */
@@ -106,6 +108,7 @@ typedef struct _tracked_if {
 
 /* prototypes */
 extern interface_t *if_get_by_ifindex(const int);
+extern interface_t *if_get_by_vmac_base_ifindex(const int);
 extern interface_t *if_get_by_ifname(const char *);
 extern int if_linkbeat(const interface_t *);
 extern int if_mii_probe(const char *);

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -79,6 +79,25 @@ if_get_by_ifindex(const int ifindex)
 	return NULL;
 }
 
+/* Return interface from VMAC base interface index */
+interface_t *
+if_get_by_vmac_base_ifindex(const int ifindex)
+{
+	interface_t *ifp;
+	element e;
+
+	if (LIST_ISEMPTY(if_queue) || !ifindex)
+		return NULL;
+
+	for (e = LIST_HEAD(if_queue); e; ELEMENT_NEXT(e)) {
+		ifp = ELEMENT_DATA(e);
+		if (ifp->vmac && ifp->base_ifindex == ifindex)
+			return ifp;
+	}
+
+	return NULL;
+}
+
 interface_t *
 if_get_by_ifname(const char *ifname)
 {

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -646,6 +646,13 @@ netlink_reflect_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 	if (ifi->ifi_type == ARPHRD_LOOPBACK)
 		return 0;
 
+	/* find the VMAC interface (if any) */
+	ifp = if_get_by_vmac_base_ifindex(ifi->ifi_index);
+
+	/* if found, reflect base interface flags on VMAC interface */
+	if (ifp)
+		ifp->flags = ifi->ifi_flags;
+
 	/* find the interface_t */
 	ifp = if_get_by_ifindex(ifi->ifi_index);
 	if (!ifp)


### PR DESCRIPTION
When using a VMAC interface, this fix will reflect the base interface flags, i.e. up/down status, to the VMAC interface. This is useful when using sync groups (in combination with VMAC) and a link for one of the members in the MASTER sync group goes down. Before this fix, this member will not detect the link fault, due to that the VMAC interface always is UP regardless of the actual status of the base interface, and the sync group will continue to
be MASTER as if nothing has happend. This fix will however reflect the status of the base interface onto the VMAC interface, so if the link goes down the member will transit to FAULT state, which will make the sync group transit to BACKUP state.
