### PR TITLE
Replace popt with getopt

### DIFF
--- a/configure
+++ b/configure
@@ -3896,53 +3896,6 @@ else
   as_fn_error $? "OpenSSL libraries are required" "$LINENO" 5
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for poptGetContext in -lpopt" >&5
-$as_echo_n "checking for poptGetContext in -lpopt... " >&6; }
-if ${ac_cv_lib_popt_poptGetContext+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpopt  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char poptGetContext ();
-int
-main ()
-{
-return poptGetContext ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_popt_poptGetContext=yes
-else
-  ac_cv_lib_popt_poptGetContext=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_popt_poptGetContext" >&5
-$as_echo "$ac_cv_lib_popt_poptGetContext" >&6; }
-if test "x$ac_cv_lib_popt_poptGetContext" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBPOPT 1
-_ACEOF
-
-  LIBS="-lpopt $LIBS"
-
-else
-  as_fn_error $? "Popt libraries is required" "$LINENO" 5
-fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_modify_cb in -lnl" >&5
 $as_echo_n "checking for nl_socket_modify_cb in -lnl... " >&6; }
 if ${ac_cv_lib_nl_nl_socket_modify_cb+:} false; then :

--- a/configure.in
+++ b/configure.in
@@ -55,7 +55,6 @@ dnl ----[ Checks for libraries ]----
 AC_CHECK_LIB(crypt, crypt,,AC_MSG_ERROR([crypt() function is required]))
 AC_CHECK_LIB(crypto, MD5_Init,,AC_MSG_ERROR([OpenSSL libraries are required]))
 AC_CHECK_LIB(ssl, SSL_CTX_new,,AC_MSG_ERROR([OpenSSL libraries are required]))
-AC_CHECK_LIB(popt, poptGetContext,,AC_MSG_ERROR([Popt libraries is required]))
 AC_CHECK_LIB(nl, nl_socket_modify_cb,
   [
     USE_NL="LIBIPVS_USE_NL"

--- a/genhash/main.h
+++ b/genhash/main.h
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <errno.h>
-#include <popt.h>
+#include <getopt.h>
 #include <openssl/ssl.h>
 
 /* local includes */

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -26,7 +26,7 @@
 /* global includes */
 #include <sys/stat.h>
 #include <sys/wait.h>
-#include <popt.h>
+#include <getopt.h>
 
 /* local includes */
 #include "daemon.h"


### PR DESCRIPTION
In a embedded environment you might not want to have to add yet another library dependency. This commit refactors parse_cmdline() to use getopt_long() instead och popt.
