### PR TITLE
Command line option to show VRRP status

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -162,6 +162,15 @@ sigend_check(void *v, int sig)
 		thread_add_terminate_event(master);
 }
 
+/* Dump handler */
+void
+sigdump_check(void *v, int sig)
+{
+	log_message(LOG_INFO, "Dumping Healthchecker config on signal");
+	dump_global_data(global_data);
+	dump_check_data(check_data);
+}
+
 /* CHECK Child signal handling */
 void
 check_signal_init(void)
@@ -170,6 +179,7 @@ check_signal_init(void)
 	signal_set(SIGHUP, sighup_check, NULL);
 	signal_set(SIGINT, sigend_check, NULL);
 	signal_set(SIGTERM, sigend_check, NULL);
+	signal_set(SIGUSR1, sigdump_check, NULL);
 	signal_ignore(SIGPIPE);
 }
 

--- a/keepalived/core/pidfile.c
+++ b/keepalived/core/pidfile.c
@@ -54,7 +54,7 @@ pidfile_rm(char *pid_file)
 	unlink(pid_file);
 }
 
-/* return the daemon running state */
+/* return the daemon pid, non-zero when running */
 int
 process_running(char *pid_file)
 {
@@ -79,15 +79,17 @@ process_running(char *pid_file)
 		return 0;
 	}
 
-	return 1;
+	return pid;
 }
 
 /* Return parent process daemon state */
 int
 keepalived_running(int mode)
 {
-	if (process_running(main_pidfile))
-		return 1;
+	int pid = process_running(main_pidfile);
+
+	if (pid)
+		return pid;
 	else if (mode & 1 || mode & 2)
 		return process_running((mode & 1) ? vrrp_pidfile :
 				       checkers_pidfile);

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -149,6 +149,11 @@ typedef struct _vrrp_t {
 	uint32_t		ms_down_timer;
 	timeval_t		sands;
 
+	/* Master router details */
+	uint32_t		ms_addr;		/* Current master IPv4 address */
+	uint8_t			ms_prio;		/* Current masters priority */
+	uint8_t			ms_adver_int;		/* Current masters advertisement interval */
+
 	/* Sending buffer */
 	char			*send_buffer;		/* Allocated send buffer */
 	int			send_buffer_size;

--- a/keepalived/include/vrrp_daemon.h
+++ b/keepalived/include/vrrp_daemon.h
@@ -31,6 +31,9 @@
 #define PROG_VRRP	"Keepalived_vrrp"
 #define WDOG_VRRP	"/tmp/.vrrp"
 
+/* Status file created by SIGUSR1 or --vrrp-status */
+#define VRRP_STATUS_FILE   "/var/lib/misc/vrrp.status"
+
 /* Prototypes */
 extern int start_vrrp_child(void);
 

--- a/keepalived/include/vrrp_data.h
+++ b/keepalived/include/vrrp_data.h
@@ -83,5 +83,6 @@ extern vrrp_data_t *alloc_vrrp_data(void);
 extern void free_vrrp_data(vrrp_data_t *);
 extern void dump_vrrp_data(vrrp_data_t *);
 extern void free_vrrp_sockpool(vrrp_data_t *);
+extern void status_vrrp_data(vrrp_data_t *);
 
 #endif

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -176,6 +176,13 @@ sigend_vrrp(void *v, int sig)
 		thread_add_terminate_event(master);
 }
 
+/* Dump status handler */
+void
+sigstatus_vrrp(void *v, int sig)
+{
+	status_vrrp_data(vrrp_data);
+}
+
 /* VRRP Child signal handling */
 void
 vrrp_signal_init(void)
@@ -184,6 +191,7 @@ vrrp_signal_init(void)
 	signal_set(SIGHUP, sighup_vrrp, NULL);
 	signal_set(SIGINT, sigend_vrrp, NULL);
 	signal_set(SIGTERM, sigend_vrrp, NULL);
+	signal_set(SIGUSR1, sigstatus_vrrp, NULL);
 	signal_ignore(SIGPIPE);
 }
 

--- a/lib/list.c
+++ b/lib/list.c
@@ -209,3 +209,24 @@ free_mlist(list l, int size)
 		free_melement(&l[i], l->free);
 	FREE(l);
 }
+
+/* list iterator functions */
+element
+list_iterator (list l)
+{
+	if (!l)
+		return NULL;
+
+	return LIST_HEAD(l);
+}
+
+element
+list_iterate (element iter, void (*op) (void *, void *), void *arg)
+{
+	if (!iter || !op)
+		return NULL;
+
+	op (iter->data, arg);
+
+	return ELEMENT_NEXT(iter);
+}

--- a/lib/list.h
+++ b/lib/list.h
@@ -61,5 +61,7 @@ extern void list_del(list l, void *data);
 extern list alloc_mlist(void (*free_func) (void *), void (*dump_func) (void *), int size);
 extern void dump_mlist(list l, int size);
 extern void free_mlist(list l, int size);
+extern element list_iterator (list list);
+extern element list_iterate (element iter, void (*op) (void *, void *), void *arg);
 
 #endif

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -41,6 +41,8 @@ void (*signal_SIGINT_handler) (void *, int sig);
 void *signal_SIGINT_v;
 void (*signal_SIGTERM_handler) (void *, int sig);
 void *signal_SIGTERM_v;
+void (*signal_SIGUSR1_handler) (void *, int sig);
+void *signal_SIGUSR1_v;
 void (*signal_SIGCHLD_handler) (void *, int sig);
 void *signal_SIGCHLD_v;
 
@@ -102,6 +104,10 @@ signal_set(int signo, void (*func) (void *, int), void *v)
 		signal_SIGTERM_handler = func;
 		signal_SIGTERM_v = v;
 		break;
+	case SIGUSR1:
+		signal_SIGUSR1_handler = func;
+		signal_SIGUSR1_v = v;
+		break;
 	case SIGCHLD:
 		signal_SIGCHLD_handler = func;
 		signal_SIGCHLD_v = v;
@@ -134,6 +140,7 @@ signal_handler_init(void)
 	signal_SIGHUP_handler = NULL;
 	signal_SIGINT_handler = NULL;
 	signal_SIGTERM_handler = NULL;
+	signal_SIGUSR1_handler = NULL;
 	signal_SIGCHLD_handler = NULL;
 }
 
@@ -150,12 +157,14 @@ signal_wait_handlers(void)
 	sigaction(SIGHUP, &sig, NULL);
 	sigaction(SIGINT, &sig, NULL);
 	sigaction(SIGTERM, &sig, NULL);
+	sigaction(SIGUSR1, &sig, NULL);
 	sigaction(SIGCHLD, &sig, NULL);
 
 	/* reset */
 	signal_SIGHUP_v = NULL;
 	signal_SIGINT_v = NULL;
 	signal_SIGTERM_v = NULL;
+	signal_SIGUSR1_v = NULL;
 	signal_SIGCHLD_v = NULL;
 }
 
@@ -165,6 +174,7 @@ void signal_reset(void)
 	signal_SIGHUP_handler = NULL;
 	signal_SIGINT_handler = NULL;
 	signal_SIGTERM_handler = NULL;
+	signal_SIGUSR1_handler = NULL;
 	signal_SIGCHLD_handler = NULL;
 }
 
@@ -204,6 +214,10 @@ signal_run_callback(void)
 			if (signal_SIGTERM_handler)
 				signal_SIGTERM_handler(signal_SIGTERM_v, SIGTERM);
 			break;	
+		case SIGUSR1:
+			if (signal_SIGUSR1_handler)
+				signal_SIGUSR1_handler(signal_SIGUSR1_v, SIGUSR1);
+			break;
 		case SIGCHLD:	
 			if (signal_SIGCHLD_handler)
 				signal_SIGCHLD_handler(signal_SIGCHLD_v, SIGCHLD);


### PR DESCRIPTION
This commit adds a new command line option, -s, --vrrp-status, which will show the status of VRRP instances.

Example output:

<pre>
  VRRP Instance             : VI_1
     Interface              : eth0
     Virtual Router ID      : 1
     State                  : BACKUP
     Virtual IP address     : 192.168.2.99
     Advertisement interval : 1.00 sec
     Preemption             : Disabled
     Multicast group        : 192.168.2.2
     Priority               : 100
     Effective Priority     : 100
     Master router          : 192.168.2.1 priority 150
     Master down interval   : 3.0
</pre>
