### PR TITLE
Add VRRPv3 support (RFC 5798)

### DIFF
--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -219,13 +219,16 @@ typedef struct _vrrp_t {
 #define VRRP_IS_BAD_VERSION(id)		((id)<2 || (id)>3)
 #define VRRP_IS_BAD_VID(id)		((id)<1 || (id)>255)	/* rfc2338.6.1.vrid */
 #define VRRP_IS_BAD_PRIORITY(p)		((p)<1 || (p)>255)	/* rfc2338.6.1.prio */
-#define VRRP_IS_BAD_ADVERT_INT(d) 	((d)<1)
+#define VRRP_IS_BAD_ADVERT_INT(svr, d)	((svr)->version == VRRP_VERSION_2 ? \
+                                         ((d)<TIMER_HZ) : ((d)<TIMER_CENTI_HZ))
 #define VRRP_IS_BAD_DEBUG_INT(d)	((d)<0 || (d)>4)
 #define VRRP_IS_BAD_PREEMPT_DELAY(d)	((d)<0 || (d)>TIMER_MAX_SEC)
 #define VRRP_SEND_BUFFER(V)		((V)->send_buffer)
 #define VRRP_SEND_BUFFER_SIZE(V)	((V)->send_buffer_size)
 
-#define VRRP_TIMER_SKEW(svr)	((256-(svr)->base_priority)*TIMER_HZ/256)
+#define VRRP_TIMER_SKEW(svr)	((svr)->version == VRRP_VERSION_3 ? \
+                                 ((256-(svr)->base_priority)*TIMER_CENTI_HZ/256) : ((256-(svr)->base_priority)*TIMER_HZ/256))
+
 #define VRRP_VIP_ISSET(V)	((V)->vipset)
 
 #define VRRP_MIN(a, b)	((a) < (b)?(a):(b))

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1124,6 +1124,12 @@ chk_min_cfg(vrrp_t * vrrp)
 		       vrrp->iname);
 		return 0;
 	}
+	/* VRRPv2 only supports advertisment interval in sec */
+	if ((vrrp->version == VRRP_VERSION_2 && vrrp->adver_int < TIMER_HZ) ||
+	    (vrrp->version == VRRP_VERSION_2 && (vrrp->adver_int % 100))) {
+		log_message(LOG_INFO, "VRRP_Instance(%s) Advertisment interval not supported in version 2!", vrrp->iname);
+		return 0;
+	}
 
 	return 1;
 }

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -89,8 +89,11 @@ static int
 vrrp_hd_len(vrrp_t * vrrp)
 {
 	int len = sizeof(vrrphdr_t);
-	if (vrrp->family == AF_INET)
-		len += VRRP_AUTH_LEN + ((!LIST_ISEMPTY(vrrp->vip)) ? LIST_SIZE(vrrp->vip) * sizeof (uint32_t) : 0);
+	if (vrrp->family == AF_INET) {
+		if (vrrp->version == VRRP_VERSION_2)
+			len += VRRP_AUTH_LEN;
+		len += ((!LIST_ISEMPTY(vrrp->vip)) ? LIST_SIZE(vrrp->vip) * sizeof (uint32_t) : 0);
+	}
         return len;
 }
 
@@ -229,6 +232,9 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 	unsigned char *vips;
 	ip_address_t *ipaddress;
 	element e;
+	ipv4phdr_t ipv4phdr;   /* FIXME: Add VRRPv3 support for IPv6 */
+	int adver_int = 0;
+	int acc_csum = 0;
 
 	/* IPv4 related */
 	if (vrrp->family == AF_INET) {
@@ -236,7 +242,7 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 		ip = (struct iphdr *) (buffer);
 		ihl = ip->ihl << 2;
 
-		if (vrrp->auth_type == VRRP_AUTH_AH) {
+		if (vrrp->version == VRRP_VERSION_2 && vrrp->auth_type == VRRP_AUTH_AH) {
 			ah = (ipsec_ah_t *) (buffer + ihl);
 			hd = (vrrphdr_t *) ((char *) ah + vrrp_ipsecah_len());
 		} else {
@@ -290,7 +296,7 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 		}
 
 		/* check the authentication if it is a passwd */
-		if (hd->auth_type == VRRP_AUTH_PASS) {
+		if (vrrp->version == VRRP_VERSION_2 && hd->v2.auth_type == VRRP_AUTH_PASS) {
 			char *pw = (char *) ip + ntohs(ip->tot_len)
 			    - sizeof (vrrp->auth_data);
 			if (memcmp(pw, vrrp->auth_data, sizeof(vrrp->auth_data)) != 0) {
@@ -300,7 +306,7 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 		}
 
 		/* check the authenicaion if it is ipsec ah */
-		if (hd->auth_type == VRRP_AUTH_AH)
+		if (vrrp->version == VRRP_VERSION_2 && hd->v2.auth_type == VRRP_AUTH_AH)
 			return (vrrp_in_chk_ipsecah(vrrp, buffer));
 
 		/* Set expected vrrp packet lenght */
@@ -316,14 +322,27 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 	}
 
 	/* MUST verify the VRRP version */
-	if ((hd->vers_type >> 4) != VRRP_VERSION) {
+	if ((hd->vers_type >> 4) != vrrp->version) {
 		log_message(LOG_INFO, "invalid version. %d and expect %d",
-		       (hd->vers_type >> 4), VRRP_VERSION);
+		       (hd->vers_type >> 4), vrrp->version);
 		return VRRP_PACKET_KO;
 	}
 
-	/* MUST verify the VRRP checksum */
-	if (in_csum((u_short *) hd, vrrphdr_len, 0)) {
+	/* MUST verify the VRRP checksum.
+	 * FIXME: Add VRRPv3 support for IPv6
+	 */
+	if (vrrp->family == AF_INET && vrrp->version == VRRP_VERSION_3) {
+		ip = (struct iphdr *) (buffer);
+		/* Create IPv4 pseudo-header */
+		ipv4phdr.src   = ip->saddr;
+		ipv4phdr.dst   = htonl(INADDR_VRRP_GROUP);
+		ipv4phdr.zero  = 0;
+		ipv4phdr.proto = IPPROTO_VRRP;
+		ipv4phdr.len   = htons(vrrp_hd_len(vrrp));
+
+		in_csum((u_short *) &ipv4phdr, sizeof(ipv4phdr), 0, &acc_csum);
+	}
+	if (in_csum((u_short *) hd, vrrphdr_len, acc_csum, NULL)) {
 		log_message(LOG_INFO, "Invalid vrrp checksum");
 		return VRRP_PACKET_KO;
 	}
@@ -332,9 +351,9 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 	 * MUST perform authentication specified by Auth Type 
 	 * check the authentication type
 	 */
-	if (vrrp->auth_type != hd->auth_type) {
+	if (vrrp->version == VRRP_VERSION_2 && vrrp->auth_type != hd->v2.auth_type) {
 		log_message(LOG_INFO, "receive a %d auth, expecting %d!",
-		       hd->auth_type, vrrp->auth_type);
+		       hd->v2.auth_type, vrrp->auth_type);
 		return VRRP_PACKET_KO;
 	}
 
@@ -355,9 +374,15 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 	 * MUST verify that the Adver Interval in the packet is the same as
 	 * the locally configured for this virtual router
 	 */
-	if (vrrp->adver_int / TIMER_HZ != hd->adver_int) {
+	if (vrrp->version == VRRP_VERSION_2) {
+		adver_int = hd->v2.adver_int * TIMER_HZ;
+	} else if (vrrp->version == VRRP_VERSION_3) {
+		adver_int = (ntohs(hd->v3.adver_int) & 0x0FFF) * TIMER_CENTI_HZ;
+	}
+
+	if (vrrp->adver_int != adver_int) {
 		log_message(LOG_INFO, "advertissement interval mismatch mine=%d rcved=%d",
-		       vrrp->adver_int, hd->adver_int);
+		       vrrp->adver_int, adver_int);
 		/* to prevent concurent VRID running => multiple master in 1 VRID */
 		return VRRP_PACKET_DROP;
 	}
@@ -385,12 +410,17 @@ vrrp_build_ip4(vrrp_t * vrrp, char *buffer, int buflen, uint32_t dst)
 	ip->ttl = VRRP_IP_TTL;
 
 	/* fill protocol type --rfc2402.2 */
-	ip->protocol = (vrrp->auth_type == VRRP_AUTH_AH) ? IPPROTO_IPSEC_AH : IPPROTO_VRRP;
+	if (vrrp->version == VRRP_VERSION_2) {
+		ip->protocol = (vrrp->auth_type == VRRP_AUTH_AH) ? IPPROTO_IPSEC_AH : IPPROTO_VRRP;
+	} else {
+		ip->protocol = IPPROTO_VRRP;
+	}
+
 	ip->saddr = VRRP_PKT_SADDR(vrrp);
 	ip->daddr = dst;
 
 	/* checksum must be done last */
-	ip->check = in_csum((u_short *) ip, ip->ihl * 4, 0);
+	ip->check = in_csum((u_short *) ip, ip->ihl * 4, 0, NULL);
 }
 
 /* build IPSEC AH header */
@@ -414,7 +444,7 @@ vrrp_build_ipsecah(vrrp_t * vrrp, char *buffer, int buflen)
 
 	/* update ip checksum */
 	ip->check = 0;
-	ip->check = in_csum((u_short *) ip, ip->ihl * 4, 0);
+	ip->check = in_csum((u_short *) ip, ip->ihl * 4, 0, NULL);
 
 	/* backup the ip mutable fields */
 	ip_mutable_fields->tos = ip->tos;
@@ -477,9 +507,9 @@ vrrp_build_ipsecah(vrrp_t * vrrp, char *buffer, int buflen)
 	FREE(digest);
 }
 
-/* build VRRP header */
+/* build VRRPv2 header */
 static int
-vrrp_build_vrrp(vrrp_t * vrrp, int prio, char *buffer)
+vrrp_build_vrrp_v2(vrrp_t * vrrp, int prio, char *buffer)
 {
 	int i = 0;
 	vrrphdr_t *hd = (vrrphdr_t *) buffer;
@@ -488,12 +518,12 @@ vrrp_build_vrrp(vrrp_t * vrrp, int prio, char *buffer)
 	ip_address_t *ip_addr;
 
 	/* Family independant */
-	hd->vers_type = (VRRP_VERSION << 4) | VRRP_PKT_ADVERT;
+	hd->vers_type = (VRRP_VERSION_2 << 4) | VRRP_PKT_ADVERT;
 	hd->vrid = vrrp->vrid;
 	hd->priority = prio;
 	hd->naddr = (!LIST_ISEMPTY(vrrp->vip)) ? LIST_SIZE(vrrp->vip) : 0;
-	hd->auth_type = vrrp->auth_type;
-	hd->adver_int = vrrp->adver_int / TIMER_HZ;
+	hd->v2.auth_type = vrrp->auth_type;
+	hd->v2.adver_int = vrrp->adver_int / TIMER_HZ;
 
 	/* Family specific */
 	if (vrrp->family == AF_INET) {
@@ -518,9 +548,70 @@ vrrp_build_vrrp(vrrp_t * vrrp, int prio, char *buffer)
 	}
 
 	/* finaly compute vrrp checksum */
-	hd->chksum = in_csum((u_short *) hd, vrrp_hd_len(vrrp), 0);
+	hd->chksum = in_csum((u_short *) hd, vrrp_hd_len(vrrp), 0, NULL);
 
 	return 0;
+}
+
+/* build VRRPv3 header */
+static int
+vrrp_build_vrrp_v3(vrrp_t * vrrp, int prio, char *buffer)
+{
+	int i = 0;
+	vrrphdr_t *hd = (vrrphdr_t *) buffer;
+	uint32_t *iparr;
+	element e;
+	ip_address_t *ip_addr;
+	ipv4phdr_t ipv4phdr;   /* FIXME: Add VRRPv3 support for IPv6 */
+	int acc_csum = 0;
+
+	/* Family independant */
+	hd->vers_type = (VRRP_VERSION_3 << 4) | VRRP_PKT_ADVERT;
+	hd->vrid = vrrp->vrid;
+	hd->priority = prio;
+	hd->naddr = (!LIST_ISEMPTY(vrrp->vip)) ? LIST_SIZE(vrrp->vip) : 0;
+	hd->v3.adver_int  = htons((vrrp->adver_int / TIMER_CENTI_HZ) & 0xFFF); /* zero reserved field */
+
+	/* Family specific */
+	if (vrrp->family == AF_INET) {
+		/* copy the ip addresses */
+		iparr = (uint32_t *) ((char *) hd + sizeof (*hd));
+		if (!LIST_ISEMPTY(vrrp->vip)) {
+			for (e = LIST_HEAD(vrrp->vip); e; ELEMENT_NEXT(e)) {
+				ip_addr = ELEMENT_DATA(e);
+				if (IP_IS6(ip_addr))
+					continue;
+				else
+					iparr[i++] = ip_addr->u.sin.sin_addr.s_addr;
+			}
+		}
+	}
+
+	/* Create IPv4 pseudo-header */
+	ipv4phdr.src   = VRRP_PKT_SADDR(vrrp);
+	ipv4phdr.dst   = htonl(INADDR_VRRP_GROUP);
+	ipv4phdr.zero  = 0;
+	ipv4phdr.proto = IPPROTO_VRRP;
+	ipv4phdr.len   = htons(vrrp_hd_len(vrrp));
+
+	/* finaly compute vrrp checksum */
+	in_csum((u_short *) &ipv4phdr, sizeof(ipv4phdr), 0, &acc_csum);
+	hd->chksum = in_csum((u_short *) hd, vrrp_hd_len(vrrp), acc_csum, NULL);
+
+	return 0;
+}
+
+/* build VRRP header */
+static int
+vrrp_build_vrrp(vrrp_t * vrrp, int prio, char *buffer)
+{
+	if (vrrp->version == VRRP_VERSION_2) {
+		return vrrp_build_vrrp_v2(vrrp, prio, buffer);
+	} else if (vrrp->version == VRRP_VERSION_3) {
+		return vrrp_build_vrrp_v3(vrrp, prio, buffer);
+	}
+
+        return 0;
 }
 
 /* build VRRP packet */
@@ -543,16 +634,16 @@ vrrp_build_pkt(vrrp_t * vrrp, int prio, struct sockaddr_storage *addr)
 		/* build the vrrp header */
 		vrrp->send_buffer += vrrp_iphdr_len(vrrp);
 
-		if (vrrp->auth_type == VRRP_AUTH_AH)
+		if (vrrp->version == VRRP_VERSION_2 && vrrp->auth_type == VRRP_AUTH_AH)
 			vrrp->send_buffer += vrrp_ipsecah_len();
 		vrrp->send_buffer_size -= vrrp_iphdr_len(vrrp);
 
-		if (vrrp->auth_type == VRRP_AUTH_AH)
+		if (vrrp->version == VRRP_VERSION_2 && vrrp->auth_type == VRRP_AUTH_AH)
 			vrrp->send_buffer_size -= vrrp_ipsecah_len();
 		vrrp_build_vrrp(vrrp, prio, vrrp->send_buffer);
 
 		/* build the IPSEC AH header */
-		if (vrrp->auth_type == VRRP_AUTH_AH) {
+		if (vrrp->version == VRRP_VERSION_2 && vrrp->auth_type == VRRP_AUTH_AH) {
 			vrrp->send_buffer_size += vrrp_iphdr_len(vrrp) + vrrp_ipsecah_len();
 			vrrp_build_ipsecah(vrrp, bufptr, VRRP_SEND_BUFFER_SIZE(vrrp));
 		}
@@ -616,7 +707,7 @@ vrrp_alloc_send_buffer(vrrp_t * vrrp)
 
 	if (vrrp->family == AF_INET) {
 		vrrp->send_buffer_size = vrrp_iphdr_len(vrrp) + vrrp_hd_len(vrrp);
-		if (vrrp->auth_type == VRRP_AUTH_AH)
+		if (vrrp->version == VRRP_VERSION_2 && vrrp->auth_type == VRRP_AUTH_AH)
 			vrrp->send_buffer_size += vrrp_ipsecah_len();
 	}
 
@@ -1135,7 +1226,11 @@ new_vrrp_socket(vrrp_t * vrrp)
 	/* close the desc & open a new one */
 	close_vrrp_socket(vrrp);
 	remove_vrrp_fd_bucket(vrrp);
-	proto = (vrrp->auth_type == VRRP_AUTH_AH) ? IPPROTO_IPSEC_AH : IPPROTO_VRRP;
+	if (vrrp->version == VRRP_VERSION_2) {
+		proto = (vrrp->auth_type == VRRP_AUTH_AH) ? IPPROTO_IPSEC_AH : IPPROTO_VRRP;
+	} else {
+		proto = IPPROTO_VRRP;
+	}
 	ifindex = IF_INDEX(vrrp->ifp);
 	unicast = !LIST_ISEMPTY(vrrp->unicast_peer);
 	vrrp->fd_in = open_vrrp_socket(vrrp->family, proto, ifindex, unicast);
@@ -1196,6 +1291,8 @@ vrrp_complete_instance(vrrp_t * vrrp)
 		vrrp->adver_int = VRRP_ADVER_DFL * TIMER_HZ;
 	if (!vrrp->effective_priority)
 		vrrp->effective_priority = VRRP_PRIO_DFL;
+	if (!vrrp->version)
+		vrrp->version = VRRP_VERSION_DFL;
 
 	return (chk_min_cfg(vrrp));
 }

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -239,8 +239,7 @@ dump_vrrp(void *data)
 	log_message(LOG_INFO, "   VRRP version = %d", vrrp->version);
 	log_message(LOG_INFO, "   Virtual Router ID = %d", vrrp->vrid);
 	log_message(LOG_INFO, "   Priority = %d", vrrp->base_priority);
-	log_message(LOG_INFO, "   Advert interval = %dsec",
-	       vrrp->adver_int / TIMER_HZ);
+	log_message(LOG_INFO, "   Advert interval = %.2fsec", (float)vrrp->adver_int / TIMER_HZ);
 	if (vrrp->nopreempt)
 		log_message(LOG_INFO, "   Preempt disabled");
 	if (vrrp->preempt_delay)

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -236,6 +236,7 @@ dump_vrrp(void *data)
 	if (vrrp->garp_delay)
 		log_message(LOG_INFO, "   Gratuitous ARP delay = %d",
 		       vrrp->garp_delay/TIMER_HZ);
+	log_message(LOG_INFO, "   VRRP version = %d", vrrp->version);
 	log_message(LOG_INFO, "   Virtual Router ID = %d", vrrp->vrid);
 	log_message(LOG_INFO, "   Priority = %d", vrrp->base_priority);
 	log_message(LOG_INFO, "   Advert interval = %dsec",
@@ -245,7 +246,7 @@ dump_vrrp(void *data)
 	if (vrrp->preempt_delay)
 		log_message(LOG_INFO, "   Preempt delay = %ld secs",
 		       vrrp->preempt_delay / TIMER_HZ);
-	if (vrrp->auth_type) {
+	if (vrrp->version == VRRP_VERSION_2 && vrrp->auth_type) {
 		log_message(LOG_INFO, "   Authentication type = %s",
 		       (vrrp->auth_type ==
 			VRRP_AUTH_AH) ? "IPSEC_AH" : "SIMPLE_PASSWORD");

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -255,16 +255,17 @@ static void
 vrrp_adv_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
-	vrrp->adver_int = atoi(vector_slot(strvec, 1));
+	vrrp->adver_int = atof(vector_slot(strvec, 1)) * TIMER_HZ;
 
-	if (VRRP_IS_BAD_ADVERT_INT(vrrp->adver_int)) {
+	/* Try to check setting.
+	 * If no VRRP version set, use VRRPv3 min advert interval as min valid advert interval.
+	 */
+	if (VRRP_IS_BAD_ADVERT_INT(vrrp, vrrp->adver_int)) {
 		log_message(LOG_INFO, "VRRP Error : Advert interval not valid !");
-		log_message(LOG_INFO,
-		       "             must be between less than 1sec.");
+		log_message(LOG_INFO, "             must be >= 1sec for VRRPv2 or >= 0.01sec for VRRPv3.");
 		log_message(LOG_INFO, "             Using default value : 1sec");
-		vrrp->adver_int = 1;
+		vrrp->adver_int = TIMER_HZ;
 	}
-	vrrp->adver_int *= TIMER_HZ;
 }
 static void
 vrrp_debug_handler(vector_t *strvec)

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -224,6 +224,19 @@ vrrp_vrid_handler(vector_t *strvec)
 	}
 }
 static void
+vrrp_version_handler(vector_t *strvec)
+{
+	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	vrrp->version = atoi(vector_slot(strvec, 1));
+
+	if (VRRP_IS_BAD_VERSION(vrrp->version)) {
+		log_message(LOG_INFO, "VRRP Error : VRRP version not valid !\n");
+		log_message(LOG_INFO, "             must be 2 or 3. reconfigure !\n");
+		log_message(LOG_INFO, "             Using default value : ", VRRP_VERSION_DFL);
+		vrrp->version = VRRP_VERSION_DFL;
+	}
+}
+static void
 vrrp_prio_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
@@ -504,6 +517,7 @@ vrrp_init_keywords(void)
 	install_keyword("track_script", &vrrp_track_scr_handler);
 	install_keyword("mcast_src_ip", &vrrp_mcastip_handler);
 	install_keyword("virtual_router_id", &vrrp_vrid_handler);
+	install_keyword("version", &vrrp_version_handler);
 	install_keyword("priority", &vrrp_prio_handler);
 	install_keyword("advert_int", &vrrp_adv_handler);
 	install_keyword("virtual_ipaddress", &vrrp_vip_handler);

--- a/keepalived/vrrp/vrrp_sync.c
+++ b/keepalived/vrrp/vrrp_sync.c
@@ -41,7 +41,7 @@ vrrp_init_instance_sands(vrrp_t * vrrp)
 	    vrrp->state == VRRP_STATE_GOTO_FAULT  ||
 	    vrrp->wantstate == VRRP_STATE_GOTO_MASTER) {
 		vrrp->sands.tv_sec = time_now.tv_sec + vrrp->adver_int / TIMER_HZ;
- 		vrrp->sands.tv_usec = time_now.tv_usec;
+		vrrp->sands.tv_usec = time_now.tv_usec + vrrp->adver_int % TIMER_HZ;
 		return;
 	}
 

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -33,6 +33,7 @@ extern timeval_t time_now;
 /* Some defines */
 #define TIME_MAX_FORWARD_US	2000000
 #define TIMER_HZ		1000000
+#define TIMER_CENTI_HZ		10000
 #define TIMER_MAX_SEC		1000
 
 /* Some usefull macros */

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -70,7 +70,7 @@ dump_buffer(char *buff, int count)
 
 /* Compute a checksum */
 u_short
-in_csum(u_short * addr, int len, u_short csum)
+in_csum(u_short * addr, int len, unsigned int csum, int * acc)
 {
 	register int nleft = len;
 	const u_short *w = addr;
@@ -91,6 +91,9 @@ in_csum(u_short * addr, int len, u_short csum)
 	/* mop up an odd byte, if necessary */
 	if (nleft == 1)
 		sum += htons(*(u_char *) w << 8);
+
+	if (acc)
+		*acc = sum;
 
 	/*
 	 * add back carry outs from top 16 bits to low 16 bits

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -46,7 +46,7 @@ extern int debug;
 
 /* Prototypes defs */
 extern void dump_buffer(char *, int);
-extern u_short in_csum(u_short *, int, u_short);
+extern u_short in_csum(u_short *, int, unsigned int, int *);
 extern char *inet_ntop2(uint32_t);
 extern char *inet_ntoa2(uint32_t, char *);
 extern uint8_t inet_stom(char *);


### PR DESCRIPTION
Adds a VRRP version configuration option:
<pre>version &lt;VERSION&gt;</pre>
where version can be "2" or "3".
Using version 2, which is the default, will send packets in VRRPv2 format (RFC 3768), i.e. unchanged behavior from previously. By using version 3, the packets will be send in VRRPv3 format instead (RFC 5798).

Adds support for centiseconds advertisement interval for VRRPv3. To configure an interval in centiseconds, a value between 0.01 and 40.95 can be used.
<pre>advert_int &lt;FLOAT&gt;</pre>
Note that an interval in centiseconds is only available for VRRPv3.
