### PR TITLE
If the prefixlength of an IPv6 VRRP VIP is 128, add the VIP as a depreca...

### DIFF
--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -58,6 +58,9 @@ netlink_ipaddress(ip_address_t *ipaddress, int cmd)
 			cinfo.ifa_prefered = 0;
 		}
 		cinfo.ifa_valid = 0xFFFFFFFFU;
+		#ifdef IFA_F_NODAD
+			req.ifa.ifa_flags |= IFA_F_NODAD;
+		#endif
 		addattr_l(&req.n, sizeof(req), IFA_CACHEINFO, &cinfo,
 				  sizeof(cinfo));
 


### PR DESCRIPTION
...ted address so Linux won't use it as a source address. If the prefixlength is other than 128, allow it to be used as a sourceaddress

Basically copied from http://marc.info/?l=keepalived-devel&m=130200733315039, by Leo Baltus.

Please note that I normally do not code anything else than Perl/Python/Shell. Commit does work as intended though.
