### PR TITLE
Allow VRRP unicast to be routed.

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -605,7 +605,7 @@ vrrp_send_pkt(vrrp_t * vrrp, struct sockaddr_storage *addr)
 	}
 
 	/* Send the packet */
-	return sendmsg(vrrp->fd_out, &msg, MSG_DONTROUTE);
+	return sendmsg(vrrp->fd_out, &msg, (addr) ? 0 : MSG_DONTROUTE);
 }
 
 /* Allocate the sending buffer */


### PR DESCRIPTION
Did some more digging into issue #44. While doing a strace on keepalived, I saw `sendmsg` was being invoked with a `MSG_DONTROUTE`.

I've tested this pull request on my setup with multicast and unicast and it works like a charm.
