### PR TITLE
Zero out VRRP checksum before calculating.

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -518,6 +518,7 @@ vrrp_build_vrrp(vrrp_t * vrrp, int prio, char *buffer)
 	}
 
 	/* finaly compute vrrp checksum */
+	hd->chksum = 0;
 	hd->chksum = in_csum((u_short *) hd, vrrp_hd_len(vrrp), 0);
 
 	return 0;


### PR DESCRIPTION
When running in unicast mode with multiple peers, the checksum was being calculated into itself for consequent peers, causing incorrect checksums.
