### PR TITLE
literal ipv6 addresses should be enclosed by brackets

### DIFF
--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -84,6 +84,11 @@ typedef struct _http_checker {
 #define REQUEST_TEMPLATE "GET %s HTTP/1.0\r\n" \
                          "User-Agent:KeepAliveClient\r\n" \
                          "Host: %s%s\r\n\r\n"
+
+#define REQUEST_TEMPLATE_IPV6 "GET %s HTTP/1.0\r\n" \
+                         "User-Agent:KeepAliveClient\r\n" \
+                         "Host: [%s]:%s\r\n\r\n"
+
 /* macro utility */
 #define HTTP_ARG(X) ((X)->arg)
 #define HTTP_REQ(X) ((X)->req)


### PR DESCRIPTION
Nginx will truncate the ipv6 address after the first `:`. With this patch this issue is repaired.
Before:
`2a00 2a00:1630:13:1::b0 - - [27/Nov/2013:11:35:17 +0100]  "GET / HTTP/1.0" 200 233 "-" "KeepAliveClient" - - 141906 0.000`

After
`[2a00:1630:13:1::b2] 2a00:1630:13:1::b1 - - [27/Nov/2013:11:39:01 +0100]  "GET / HTTP/1.0" 200 233 "-" "KeepAliveClient" - - 142290 0.00 1`
