### PR TITLE
genhash can throw a segmentation fault when not providing an argument

### DIFF
--- a/genhash/main.c
+++ b/genhash/main.c
@@ -94,11 +94,11 @@ parse_cmdline(int argc, char **argv, REQ * req_obj)
 		{"help",            no_argument,       0, 'h'},
 		{"verbose",         no_argument,       0, 'v'},
 		{"use-ssl",         no_argument,       0, 'S'},
-		{"server",          optional_argument, 0, 's'},
-		{"hash",            optional_argument, 0, 'H'},
-		{"use-virtualhost", optional_argument, 0, 'V'},
-		{"port",            optional_argument, 0, 'p'},
-		{"url",             optional_argument, 0, 'u'},
+		{"server",          required_argument, 0, 's'},
+		{"hash",            required_argument, 0, 'H'},
+		{"use-virtualhost", required_argument, 0, 'V'},
+		{"port",            required_argument, 0, 'p'},
+		{"url",             required_argument, 0, 'u'},
 		{0, 0, 0, 0}
 	};
 


### PR DESCRIPTION
Before:
(gdb) run --server 127.1.0.1
Starting program: /usr/bin/genhash --server 127.1.0.1
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
0x0000000000406968 in inet_ston ()

after:
`genhash --port 80 --server=127.0.0.1`
MD5SUM = d41d8cd98f00b204e9800998ecf8427e
