### PR TITLE
genhash: make url default value /, same as curl/wget

### DIFF
--- a/genhash/main.c
+++ b/genhash/main.c
@@ -197,6 +197,11 @@ main(int argc, char **argv)
 
 	/* Preset (potentially) non-zero defaults */
 	req->hash = hash_default;
+	char *url_default = malloc(2);
+	url_default[0] = '/';
+	url_default[1] = '\0';
+
+	req->url = url_default;
 
 	/* Command line parser */
 	if (!parse_cmdline(argc, argv, req)) {
@@ -244,6 +249,7 @@ main(int argc, char **argv)
 			    req->url, req->response_time - req->ref_time);
 
 	/* exit cleanly */
+	FREE(url_default);
 	SSL_CTX_free(req->ctx);
 	free_sock(sock);
 	freeaddrinfo(req->dst);


### PR DESCRIPTION
Before:
`127.0.0.1 - - [02/Dec/2013:13:12:53 +0100] "GET (null) HTTP/1.0" 400 172 "-" "-"`

After:
`127.0.0.1 - - [02/Dec/2013:16:16:30 +0100] "GET / HTTP/1.0" 200 151 "-" "GenHash (Linux powered)"`
`127.0.0.1 - - [02/Dec/2013:16:19:49 +0100] "GET /pietje HTTP/1.0" 200 151 "-" "GenHash (Linux powered)"`

Wget/Curl example:
`127.0.0.1 - - [02/Dec/2013:16:20:25 +0100] "GET / HTTP/1.1" 200 151 "-" "Wget/1.13.4 (linux-gnu)"`
`127.0.0.1 - - [02/Dec/2013:16:20:55 +0100] "GET / HTTP/1.1" 200 151 "-" "curl/7.26.0"`
