### PR TITLE
vrrp: Support xmit VRRP packets from base VMAC interface.

### DIFF
--- a/doc/NOTE_vrrp_vmac.txt
+++ b/doc/NOTE_vrrp_vmac.txt
@@ -21,10 +21,14 @@ http://git.kernel.org/?p=linux/kernel/git/torvalds/linux.git;a=commitdiff;h=729e
 
 By default MACVLAN interface are in VEPA mode which filters out received
 packets whose MAC source address matches that of the MACVLAN interface. Setting
-MACVLAN interface in private mode will not filter based on source MAC address.  
+MACVLAN interface in private mode will not filter based on source MAC address.
 
-You also need to tweak your physical interfaces to play around with well knwon
-ARP issue. I would recommand using the following configurations :
+Alternatively, you can specify 'vmac_xmit_base' which will cause the VRRP
+messages to be transmitted and received on the underlying interface whilst ARP
+will happen  from the the VMAC interface.
+
+You may also need to tweak your physical interfaces to play around with well
+known ARP issues. If you have issues, try the following configurations :
 
 1) Global configuration
 

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -146,6 +146,7 @@ Important: for a SYNC group to run reliably, it is vital that all instances in
 
 vrrp_instance <STRING> {		# VRRP instance declaration
     use_vmac				# Use VRRP Virtual MAC
+    vmac_xmit_base			# Send/Recv VRRP messages from base interface instead of VMAC interface
     native_ipv6				# Force instance to use IPv6
 					#  when using mixed IPv4&IPv6 conf
     state MASTER|BACKUP			# Start-up default state

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -133,6 +133,9 @@ which will transition together on any state change.
     # Use VRRP Virtual MAC.
     use_vmac <VMAC_INTERFACE>
 
+    # Send/Recv VRRP messages from base interface instead of VMAC interface
+    vmac_xmit_base
+
     # Ignore VRRP interface faults (default unset)
     dont_track_primary
 

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -130,6 +130,7 @@ typedef struct _vrrp_t {
 	int			wantstate;		/* user explicitly wants a state (back/mast) */
 	int			fd_in;			/* IN socket descriptor */
 	int			fd_out;			/* OUT socket descriptor */
+	int			fd_out_base;		/* OUT base socket descriptor (for vmac) */
 
 	int			debug;			/* Debug level 0-4 */
 

--- a/keepalived/include/vrrp_data.h
+++ b/keepalived/include/vrrp_data.h
@@ -43,9 +43,12 @@ typedef struct _sock {
 	sa_family_t		family;
 	int			proto;
 	int			ifindex;
+	int			base_ifindex;
 	int			unicast;
 	int			fd_in;
 	int			fd_out;
+	int			fd_out_base;
+	int			vmac;
 } sock_t;
 
 /* Configuration data root */

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -110,7 +110,7 @@ static void
 vrrp_vmac_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
-	vrrp->vmac = 1;
+	vrrp->vmac |= 1;
 	if (!vrrp->saddr)
 		vrrp->saddr  = IF_ADDR(vrrp->ifp);
 	if (vector_size(strvec) == 2) {
@@ -134,6 +134,12 @@ vrrp_vmac_handler(vector_t *strvec)
 
         /* flag interface as a VMAC interface */
         vrrp->ifp->vmac = 1;
+}
+static void
+vrrp_vmac_xmit_base_handler(vector_t *strvec)
+{
+	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	vrrp->vmac |= 4;
 }
 static void
 vrrp_unicast_peer_handler(vector_t *strvec)
@@ -501,6 +507,7 @@ vrrp_init_keywords(void)
 	install_keyword("global_tracking", &vrrp_gglobal_tracking_handler);
 	install_keyword_root("vrrp_instance", &vrrp_handler);
 	install_keyword("use_vmac", &vrrp_vmac_handler);
+	install_keyword("vmac_xmit_base", &vrrp_vmac_xmit_base_handler);
 	install_keyword("unicast_peer", &vrrp_unicast_peer_handler);
 	install_keyword("native_ipv6", &vrrp_native_ipv6_handler);
 	install_keyword("state", &vrrp_state_handler);


### PR DESCRIPTION
This provides a new option to use in conjunction with the VMAC
functionality which will result in VRRP advertisements being sent and
received over the underlying interface (and therefore having the source
MAC of that interface rather than the VMAC device)

With this new functionality enabled, VRRP messages will not affect the
switch MAC address table since the non-unique VMAC address is now used
only for sending a gratuitous ARP, thereby ensuring that in conditions
of VRRP message loss, a probing partner will not inadvertently take over
traffic.

This also resolves issues where VRRP messages are not successfully being
seen on the VMAC interface as with the new option, the underlying
interface is also used to listen out for VRRP messages.

Signed-off-by: Oliver Smith oliver@8.c.9.b.0.7.4.0.1.0.0.2.ip6.arpa
