### PR TITLE
vrrp: add default case in getopt_long

### DIFF
--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -243,6 +243,9 @@ parse_cmdline(int argc, char **argv)
 			snmp = 1;
 			break;
 #endif
+		default:
+			exit(0);
+			break;
 		}
 	}
 


### PR DESCRIPTION
 when starting keepalived with an option without an argument that
 requires an argument keepalived should not be started.

```
$ strace /usr/sbin/keepalived -n -f /etc/keepalived/keepalived.conf --log-facility
execve("/usr/sbin/keepalived", ["/usr/sbin/keepalived", "-n", "-f", "/etc/keepalived/keepalived.conf", "--log-facility"], [/* 24 vars */]) = 0
[...]
write(2, "/usr/sbin/keepalived: option '--"..., 67/usr/sbin/keepalived: option '--log-facility' requires an argument
) = 67
exit_group(0)
```
