### PR TITLE
Added the facility to set the multicast address different to the rfc specified.

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -32,6 +32,8 @@ global_defs {				# Block identification
     smtp_connect_timeout <INTEGER>	   # Number of seconds timeout connect
  					   #  remote SMTP server
     router_id <STRING>			   # String identifying router
+    mcast_group4 <IPV4 ADDRESS>   # optional, default 224.0.0.18
+    mcast_group6 <IPV6 ADDRESS>   # optional, default ff02::12
 }
 
 linkbeat_use_polling	# Use media link failure detection polling fashion

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -41,6 +41,8 @@ and
  router_id my_hostname   # string identifying the machine,
                          # (doesn't have to be hostname).
  enable_traps            # enable SNMP traps
+ mcast_group4   224.0.0.18 # optional set the ipv4 multicast address
+ mcast_group6   ff02::12   # optional set the ipv6 multicast address
  }
 
 

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -76,6 +76,15 @@ set_default_email_from(data_t * data)
 }
 
 static void
+set_default_mcast_group(data_t * data)
+{
+	if (inet_pton(AF_INET, "224.0.0.12", &data->mcast_group4) <= 0)
+		log_message(LOG_ERR, "can not parse 'AF_INET:224.0.0.12' to binary");
+	if (inet_pton(AF_INET6, "ff02::12", &data->mcast_group6) <= 0)
+		log_message(LOG_ERR, "can not parse 'AF_INET6:ff02::12' to binary");
+}
+
+static void
 set_default_smtp_connection_timeout(data_t * data)
 {
 	data->smtp_connection_to = DEFAULT_SMTP_CONNECTION_TIMEOUT;
@@ -90,6 +99,7 @@ set_default_values(data_t * data)
 	set_default_router_id(data);
 	set_default_smtp_connection_timeout(data);
 	set_default_email_from(data);
+	set_default_mcast_group(data);
 }
 
 /* email facility functions */
@@ -143,6 +153,7 @@ free_global_data(data_t * data)
 void
 dump_global_data(data_t * data)
 {
+	char out[INET_ADDRSTRLEN];
 	if (!data)
 		return;
 
@@ -164,6 +175,10 @@ dump_global_data(data_t * data)
 		       data->email_from);
 		dump_list(data->email);
 	}
+	log_message(LOG_INFO, " Multicast Group ipv4 = %s",
+		inet_ntop(AF_INET, &data->mcast_group4, out, sizeof(out)));
+	log_message(LOG_INFO, " Multicast Group ipv6 = %s",
+		inet_ntop(AF_INET6, &data->mcast_group6, out, sizeof(out)));
 #ifdef _WITH_SNMP_
 	if (data->enable_traps)
 		log_message(LOG_INFO, " SNMP Trap enabled");

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -29,6 +29,7 @@
 #include "parser.h"
 #include "memory.h"
 #include "smtp.h"
+#include "logger.h"
 #include "utils.h"
 
 /* data handlers */
@@ -79,6 +80,26 @@ email_handler(vector_t *strvec)
 
 	free_strvec(email_vec);
 }
+static void
+mcast_group4(vector_t *strvec)
+{
+	char *str = vector_slot(strvec, 1);
+	struct in_addr tmp;
+	if (inet_pton(AF_INET, str, &tmp) <= 0)
+		log_message(LOG_ERR, "can not parse 'AF_INET:%s' to binary", str);
+	else
+		global_data->mcast_group4 = tmp;
+}
+static void
+mcast_group6(vector_t *strvec)
+{
+	char *str = vector_slot(strvec, 1);
+	struct in6_addr tmp;
+	if (inet_pton(AF_INET6, str, &tmp) <= 0)
+		log_message(LOG_ERR, "can not parse 'AF_INET6:%s' to binary", str);
+	else
+		global_data->mcast_group6 = tmp;
+}
 #ifdef _WITH_SNMP_
 static void
 trap_handler(vector_t *strvec)
@@ -99,6 +120,8 @@ global_init_keywords(void)
 	install_keyword("smtp_server", &smtpip_handler);
 	install_keyword("smtp_connect_timeout", &smtpto_handler);
 	install_keyword("notification_email", &email_handler);
+	install_keyword("mcast_group4", &mcast_group4);
+	install_keyword("mcast_group6", &mcast_group6);
 #ifdef _WITH_SNMP_
 	install_keyword("enable_traps", &trap_handler);
 #endif

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -44,15 +44,17 @@ typedef struct _email {
 
 /* Configuration data root */
 typedef struct _data {
-	int				linkbeat_use_polling;
+	int					linkbeat_use_polling;
 	char				*router_id;
 	char				*plugin_dir;
 	char				*email_from;
 	struct sockaddr_storage		smtp_server;
-	long				smtp_connection_to;
-	list				email;
+	long 				smtp_connection_to;
+	list 				email;
+	struct in_addr 		mcast_group4;
+	struct in6_addr 	mcast_group6;
 #ifdef _WITH_SNMP_
-	int				enable_traps;
+	int					enable_traps;
 #endif
 } data_t;
 

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -51,7 +51,6 @@ typedef struct _vrrphdr {			/* rfc2338.5.1 */
 } vrrphdr_t;
 
 /* protocol constants */
-#define INADDR_VRRP_GROUP	0xe0000012	/* multicast addr - rfc2338.5.2.2 */
 #define VRRP_IP_TTL		255		/* in and out pkt ttl -- rfc2338.5.2.3 */
 #define IPPROTO_VRRP		112		/* IP protocol number -- rfc2338.5.2.4 */
 #define VRRP_VERSION		2		/* current version -- rfc2338.5.3.1 */

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -538,7 +538,7 @@ vrrp_build_pkt(vrrp_t * vrrp, int prio, struct sockaddr_storage *addr)
 
 	if (vrrp->family == AF_INET) {
 		/* build the ip header */
-		dst = (addr) ? inet_sockaddrip4(addr) : htonl(INADDR_VRRP_GROUP);
+		dst = (addr) ? inet_sockaddrip4(addr) : global_data->mcast_group4.s_addr;
 		vrrp_build_ip4(vrrp, bufptr, len, dst);
 
 		/* build the vrrp header */
@@ -609,14 +609,13 @@ vrrp_send_pkt(vrrp_t * vrrp, struct sockaddr_storage *addr)
 	} else if (vrrp->family == AF_INET) { /* Multicast sending path */
 		memset(&dst4, 0, sizeof(dst4));
 		dst4.sin_family = AF_INET;
-		dst4.sin_addr.s_addr = htonl(INADDR_VRRP_GROUP);
+		dst4.sin_addr = global_data->mcast_group4;
 		msg.msg_name = &dst4;
 		msg.msg_namelen = sizeof(dst4);
 	} else if (vrrp->family == AF_INET6) {
 		memset(&dst6, 0, sizeof(dst6));
 		dst6.sin6_family = AF_INET6;
-		dst6.sin6_addr.s6_addr16[0] = htons(0xff02);
-		dst6.sin6_addr.s6_addr16[7] = htons(0x12);
+		dst6.sin6_addr = global_data->mcast_group6;
 		msg.msg_name = &dst6;
 		msg.msg_namelen = sizeof(dst6);
 	}

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -448,7 +448,7 @@ if_join_vrrp_group(sa_family_t family, int *sd, interface_t *ifp, int proto)
 
 	if (family == AF_INET) {
 		memset(&imr, 0, sizeof(imr));
-		imr.imr_multiaddr.s_addr = htonl(INADDR_VRRP_GROUP);
+		imr.imr_multiaddr = global_data->mcast_group4;
 		imr.imr_address.s_addr = IF_ADDR(ifp);
 		imr.imr_ifindex = IF_INDEX(ifp);
 
@@ -459,8 +459,7 @@ if_join_vrrp_group(sa_family_t family, int *sd, interface_t *ifp, int proto)
 				 (char *) &imr, sizeof(struct ip_mreqn));
 	} else {
 		memset(&imr6, 0, sizeof(imr6));
-		imr6.ipv6mr_multiaddr.s6_addr16[0] = htons(0xff02);
-		imr6.ipv6mr_multiaddr.s6_addr16[7] = htons(0x12);
+		imr6.ipv6mr_multiaddr = global_data->mcast_group6;
 		imr6.ipv6mr_interface = IF_INDEX(ifp);
 		ret = setsockopt(*sd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP,
 				 (char *) &imr6, sizeof(struct ipv6_mreq));
@@ -491,18 +490,14 @@ if_leave_vrrp_group(sa_family_t family, int sd, interface_t *ifp)
 	if (family == AF_INET) {
 		memset(&imr, 0, sizeof(imr));
 		/* FIXME: change this to use struct ip_mreq */
-		imr.imr_multiaddr.s_addr = htonl(INADDR_VRRP_GROUP);
+		imr.imr_multiaddr = global_data->mcast_group4;
 		imr.imr_address.s_addr = IF_ADDR(ifp);
 		imr.imr_ifindex = IF_INDEX(ifp);
 		ret = setsockopt(sd, IPPROTO_IP, IP_DROP_MEMBERSHIP,
 				 (char *) &imr, sizeof (struct ip_mreqn));
 	} else {
 		memset(&imr6, 0, sizeof(imr6));
-		/* rfc5798.5.1.2.2 : destination IPv6 mcast group is
-		 * ff02:0:0:0:0:0:0:12.
-		 */
-		imr6.ipv6mr_multiaddr.s6_addr16[0] = htons(0xff02);
-		imr6.ipv6mr_multiaddr.s6_addr16[7] = htons(0x12);
+		imr6.ipv6mr_multiaddr = global_data->mcast_group6;
 		imr6.ipv6mr_interface = IF_INDEX(ifp);
 		ret = setsockopt(sd, IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP,
 				 (char *) &imr6, sizeof(struct ipv6_mreq));

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -240,7 +240,7 @@ vrrp_vrid_handler(vector_t *strvec)
 		if (vrrp->vmac_flags & VRRP_VMAC_FL_SET && strlen(vrrp->vmac_ifname) == 0) {
 			snprintf(vrrp->vmac_ifname, IFNAMSIZ, "vrrp.%d"
 						  , vrrp->vrid);
-			log_message(LOG_INFO, "vmac_ifname=%s for vrrp_instace %s"
+			log_message(LOG_INFO, "vmac_ifname=%s for vrrp_instance %s"
 					    , vrrp->vmac_ifname
 					    , vrrp->iname);
 		}


### PR DESCRIPTION
The address could be set for ipv4 and ipv6 in the global_defs config
section using the keywords mcast_group4 and mcast_group6.
I need this of course there are some stupid switches which does
a special processing to 224.0.0.0/8 multicast packets which causes
packets drop from queue overflows in environments which creates
100 and more multicast control plane packets a second.
