### PR TITLE
Fix libnl/libnl-3 logic in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -3896,50 +3896,8 @@ else
   as_fn_error $? "OpenSSL libraries are required" "$LINENO" 5
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_modify_cb in -lnl" >&5
-$as_echo_n "checking for nl_socket_modify_cb in -lnl... " >&6; }
-if ${ac_cv_lib_nl_nl_socket_modify_cb+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lnl  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char nl_socket_modify_cb ();
-int
-main ()
-{
-return nl_socket_modify_cb ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_nl_nl_socket_modify_cb=yes
-else
-  ac_cv_lib_nl_nl_socket_modify_cb=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nl_nl_socket_modify_cb" >&5
-$as_echo "$ac_cv_lib_nl_nl_socket_modify_cb" >&6; }
-if test "x$ac_cv_lib_nl_nl_socket_modify_cb" = xyes; then :
-
-    USE_NL="LIBIPVS_USE_NL"
-    CFLAGS="$CFLAGS -DFALLBACK_LIBNL1"
-    LIBS="$LIBS -lnl"
-
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_alloc in -lnl-3" >&5
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_alloc in -lnl-3" >&5
 $as_echo_n "checking for nl_socket_alloc in -lnl-3... " >&6; }
 if ${ac_cv_lib_nl_3_nl_socket_alloc+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -3977,10 +3935,7 @@ fi
 $as_echo "$ac_cv_lib_nl_3_nl_socket_alloc" >&6; }
 if test "x$ac_cv_lib_nl_3_nl_socket_alloc" = xyes; then :
 
-      USE_NL="LIBIPVS_USE_NL"
-      CFLAGS="$CFLAGS $(pkg-config --libs --cflags libnl-3.0)"
-      LIBS="$LIBS -lnl-3"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for genl_connect in -lnl-genl-3" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for genl_connect in -lnl-genl-3" >&5
 $as_echo_n "checking for genl_connect in -lnl-genl-3... " >&6; }
 if ${ac_cv_lib_nl_genl_3_genl_connect+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -4018,19 +3973,65 @@ fi
 $as_echo "$ac_cv_lib_nl_genl_3_genl_connect" >&6; }
 if test "x$ac_cv_lib_nl_genl_3_genl_connect" = xyes; then :
 
-         LIBS="$LIBS -lnl-3 -lnl-genl-3"
+        USE_NL="LIBIPVS_USE_NL"
+        CFLAGS="$CFLAGS $(pkg-config libnl-genl-3.0)"
+	LIBS="$LIBS $(pkg-config --libs libnl-genl-3.0)"
 
 else
 
-         as_fn_error $? "libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3." "$LINENO" 5
+        as_fn_error $? "libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3." "$LINENO" 5
 
 fi
 
 
 else
 
-      USE_NL="LIBIPVS_DONTUSE_NL"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: keepalived will be built without libnl support." >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_modify_cb in -lnl" >&5
+$as_echo_n "checking for nl_socket_modify_cb in -lnl... " >&6; }
+if ${ac_cv_lib_nl_nl_socket_modify_cb+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lnl  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char nl_socket_modify_cb ();
+int
+main ()
+{
+return nl_socket_modify_cb ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_nl_nl_socket_modify_cb=yes
+else
+  ac_cv_lib_nl_nl_socket_modify_cb=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nl_nl_socket_modify_cb" >&5
+$as_echo "$ac_cv_lib_nl_nl_socket_modify_cb" >&6; }
+if test "x$ac_cv_lib_nl_nl_socket_modify_cb" = xyes; then :
+
+        USE_NL="LIBIPVS_USE_NL"
+        CFLAGS="$CFLAGS -DFALLBACK_LIBNL1"
+        LIBS="$LIBS $(pkg-config --libs libnl-1)"
+
+else
+
+        USE_NL="LIBIPVS_DONTUSE_NL"
+        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: keepalived will be built without libnl support." >&5
 $as_echo "$as_me: WARNING: keepalived will be built without libnl support." >&2;}
 
 fi

--- a/configure.in
+++ b/configure.in
@@ -55,29 +55,30 @@ dnl ----[ Checks for libraries ]----
 AC_CHECK_LIB(crypt, crypt,,AC_MSG_ERROR([crypt() function is required]))
 AC_CHECK_LIB(crypto, MD5_Init,,AC_MSG_ERROR([OpenSSL libraries are required]))
 AC_CHECK_LIB(ssl, SSL_CTX_new,,AC_MSG_ERROR([OpenSSL libraries are required]))
-AC_CHECK_LIB(nl, nl_socket_modify_cb,
+
+AC_CHECK_LIB(nl-3, nl_socket_alloc,
   [
-    USE_NL="LIBIPVS_USE_NL"
-    CFLAGS="$CFLAGS -DFALLBACK_LIBNL1"
-    LIBS="$LIBS -lnl"
+    AC_CHECK_LIB(nl-genl-3, genl_connect,
+      [
+        USE_NL="LIBIPVS_USE_NL"
+        CFLAGS="$CFLAGS $(pkg-config libnl-genl-3.0)"
+	LIBS="$LIBS $(pkg-config --libs libnl-genl-3.0)"
+      ],
+      [
+        AC_MSG_ERROR([libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3.])
+      ])
   ],
-  [AC_CHECK_LIB(nl-3, nl_socket_alloc,
-    [
-      USE_NL="LIBIPVS_USE_NL"
-      CFLAGS="$CFLAGS $(pkg-config --libs --cflags libnl-3.0)"
-      LIBS="$LIBS -lnl-3"
-      AC_CHECK_LIB(nl-genl-3, genl_connect,
-       [
-         LIBS="$LIBS -lnl-3 -lnl-genl-3"
-       ],
-       [
-         AC_MSG_ERROR([libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3.])
-       ])
-    ],
-    [
-      USE_NL="LIBIPVS_DONTUSE_NL"
-      AC_MSG_WARN([keepalived will be built without libnl support.])
-    ])
+  [
+    AC_CHECK_LIB(nl, nl_socket_modify_cb,
+      [
+        USE_NL="LIBIPVS_USE_NL"
+        CFLAGS="$CFLAGS -DFALLBACK_LIBNL1"
+        LIBS="$LIBS $(pkg-config --libs libnl-1)"
+      ],
+      [                                                                                           
+        USE_NL="LIBIPVS_DONTUSE_NL"
+        AC_MSG_WARN([keepalived will be built without libnl support.])
+      ])
   ])
 
 dnl ----[ Kernel version check ]----


### PR DESCRIPTION
This patch causes the configure script to prefer libnl-3 over
libnl(1). The configure script will first check for libnl-3 and
libnl-genl-3. If both are found, use them. If not, check for
libnl(1). This is useful when building on systems that have both
libnl-3 and libnl(1) installed. It also fixes some redundant libraries
in LIBS.
