### PR TITLE
vrrp: Use the standard unsigned int types

### DIFF
--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -23,11 +23,11 @@
 /* global include */
 #include <unistd.h>
 #include <string.h>
-#include <sys/types.h>
-typedef __uint64_t u64;
-typedef __uint32_t u32;
-typedef __uint16_t u16;
-typedef __uint8_t u8;
+#include <stdint.h>
+typedef uint64_t u64;
+typedef uint32_t u32;
+typedef uint16_t u16;
+typedef uint8_t u8;
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>


### PR DESCRIPTION
This fixes building with musl libc, which does not expose the internal
__uint\* defines.

Signed-off-by: Natanael Copa ncopa@alpinelinux.org
