### PR TITLE
VMAC and base interface status flags can be out of sync

### DIFF
--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -666,8 +666,13 @@ netlink_reflect_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 	if (!ifp)
 		return -1;
 
-	/* Update flags */
-	ifp->flags = ifi->ifi_flags;
+	/*
+	 * Update flags.
+	 * VMAC interfaces should never update it own flags, only be reflected
+	 * by the base interface flags, see above.
+	 */
+	if (!ifp->vmac)
+		ifp->flags = ifi->ifi_flags;
 
 	return 0;
 }


### PR DESCRIPTION
There is a chance that the VMAC interface status flags (up/down) could be different from the base interface flags. This patch will only change the VMAC interface status flags when the base interface is changed.
