### PR TITLE
Fix initial interface status flag value for VMAC interface

### DIFF
--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -195,6 +195,7 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 	if (!ifp)
 		return -1;
 	base_ifindex = vrrp->ifp->ifindex;
+	ifp->flags = vrrp->ifp->flags; /* Copy base interface flags */
 	vrrp->ifp = ifp;
 	vrrp->ifp->base_ifindex = base_ifindex;
 	vrrp->ifp->vmac = 1;


### PR DESCRIPTION
I'm sorry, I missed a part in commit a05a503. No inital value for the VMAC interface status flag was set.
Due to that the VMAC interface flags shall follow the base interface, the base interface status flags value shall be copied to the VMAC interface status flags after the VMAC interface has been created.
