### PR TITLE
Proper restore of VMAC interface properties on SIGHUP

### DIFF
--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -157,6 +157,10 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 	 * by a previous instance.
 	 */
 	if (reload && (ifp = if_get_by_ifname(ifname))) {
+		/* (re)set VMAC properties (if deleted on reload) */
+		ifp->base_ifindex = vrrp->ifp->ifindex;
+		ifp->vmac = 1;
+		ifp->flags = vrrp->ifp->flags; /* Copy base interface flags */
 		vrrp->ifp = ifp;
 		/* Save ifindex for use on delete */
 		vrrp->vmac_ifindex = IF_INDEX(vrrp->ifp);


### PR DESCRIPTION
On SIGHUP the VMAC flag and base ifindex for a VMAC interface is lost and needs to be set again.
