### PR TITLE
clarify the type of 'warmup' struct member

### DIFF
--- a/keepalived/include/check_api.h
+++ b/keepalived/include/check_api.h
@@ -49,7 +49,7 @@ typedef struct _checker {
 	checker_id_t			id;	/* Checker identifier */
 	int				enabled;/* Activation flag */
 	conn_opts_t			*co; /* connection options */
-	unsigned int			warmup;	/* max random timeout to start checker */
+	long				warmup;	/* max random timeout to start checker */
 } checker_t;
 
 /* Checkers queue */


### PR DESCRIPTION
Initially the warmup field of the checker struct contained number of seconds
and was typed as unsigned int. Then it was changed to store timer ticks, but
the type was not changed to long as for other variables storing timer ticks.

This commit fixes this minor arch-specific issue.
