### PR TITLE
Add SNMP subsystem option to man page

### DIFF
--- a/doc/man/man8/keepalived.8
+++ b/doc/man/man8/keepalived.8
@@ -91,6 +91,9 @@ the VRRP child process is "/var/run/keepalived_vrrp.pid".
 Use specified pidfile for checkers child process. The default pidfile
 for the checker child process is "/var/run/keepalived_checkers.pid".
 .TP
+\fB -x, --snmp\fP
+Enable SNMP subsystem.
+.TP
 \fB -v, --version\fP
 Display the version and exit.
 .TP


### PR DESCRIPTION
The keepalived(8) man page did not mention the -x option to enable the
SNMP subsystem. This patch adds the -x (and --smmp) options to the
keepalived(8) man page, as described in the keepalived help message.
