### PR TITLE
vrrp: fix preempt and state BACKUP when prio 255

### DIFF
--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -230,8 +230,7 @@ vrrp_init_state(list l)
 					 vrrp, vrrp->adver_int);
 		}
 
-		if (vrrp->base_priority == VRRP_PRIO_OWNER ||
-		    vrrp->wantstate == VRRP_STATE_MAST) {
+		if (vrrp->wantstate == VRRP_STATE_MAST) {
 #ifdef _HAVE_IPVS_SYNCD_
 			/* Check if sync daemon handling is needed */
 			if (vrrp->lvs_syncd_if)


### PR DESCRIPTION
This makes it so that keepalived will respect various settings that
should prevent it from assuming the MASTER role for a vrrp_instance
unconditionally and immediately, even if the priority of the
vrrp_instance in question is set to 255 (VRRP_PRIO_OWNER). These
settings include:

  state BACKUP
  preempt_delay <N>
  nopreempt
