### PR TITLE
add arp_sleep to throttle gratuitous arp

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -32,6 +32,7 @@ global_defs {				# Block identification
     smtp_connect_timeout <INTEGER>	   # Number of seconds timeout connect
  					   #  remote SMTP server
     router_id <STRING>			   # String identifying router
+    arp_sleep <INTEGER>                    # Sleep between Gratuitous ARP (in ms)
     vrrp_mcast_group4 <IPv4 ADDRESS>	   # optional, default 224.0.0.18
     vrrp_mcast_group6 <IPv6 ADDRESS>	   # optional, default ff02::12
 }

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -40,6 +40,7 @@ and
  smtp_connect_timeout 30      # integer, seconds
  router_id my_hostname        # string identifying the machine,
                               # (doesn't have to be hostname).
+ arp_sleep 100                # integer, ms
  vrrp_mcast_group4 224.0.0.18 # optional, default 224.0.0.18
  vrrp_mcast_group6 ff02::12   # optional, default ff02::12
  enable_traps                 # enable SNMP traps

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -53,6 +53,12 @@ set_default_router_id(data_t * data)
 }
 
 static void
+set_default_arp_sleep(data_t * data)
+{
+	data->arp_sleep = 0;
+}
+
+static void
 set_default_email_from(data_t * data)
 {
 	struct passwd *pwd = NULL;
@@ -95,6 +101,7 @@ set_default_values(data_t * data)
 	if (!data)
 		return;
 	set_default_router_id(data);
+	set_default_arp_sleep(data);
 	set_default_smtp_connection_timeout(data);
 	set_default_email_from(data);
 	set_default_mcast_group(data);
@@ -160,6 +167,8 @@ dump_global_data(data_t * data)
 	}
 	if (data->router_id)
 		log_message(LOG_INFO, " Router ID = %s", data->router_id);
+	if (data->arp_sleep)
+		log_message(LOG_INFO, " Arp sleep = %d", data->arp_sleep);
 	if (data->plugin_dir)
 		log_message(LOG_INFO, " Plugin dir = %s", data->plugin_dir);
 	if (data->smtp_server.ss_family)

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -46,6 +46,11 @@ routerid_handler(vector_t *strvec)
 	global_data->router_id = set_value(strvec);
 }
 static void
+arpsleep_handler(vector_t *strvec)
+{
+	global_data->arp_sleep = atoi(vector_slot(strvec, 1));
+}
+static void
 plugin_handler(vector_t *strvec)
 {
 	global_data->plugin_dir = set_value(strvec);
@@ -119,6 +124,7 @@ global_init_keywords(void)
 	install_keyword_root("linkbeat_use_polling", use_polling_handler);
 	install_keyword_root("global_defs", NULL);
 	install_keyword("router_id", &routerid_handler);
+	install_keyword("arp_sleep", &arpsleep_handler);
 	install_keyword("plugin_dir", &plugin_handler);
 	install_keyword("notification_email_from", &emailfrom_handler);
 	install_keyword("smtp_server", &smtpip_handler);

--- a/keepalived/etc/keepalived/keepalived.conf
+++ b/keepalived/etc/keepalived/keepalived.conf
@@ -10,6 +10,7 @@ global_defs {
    smtp_server 192.168.200.1
    smtp_connect_timeout 30
    router_id LVS_DEVEL
+   arp_sleep 0
 }
 
 vrrp_instance VI_1 {

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -46,6 +46,7 @@ typedef struct _email {
 typedef struct _data {
 	int				linkbeat_use_polling;
 	char				*router_id;
+	int				arp_sleep;
 	char				*plugin_dir;
 	char				*email_from;
 	struct sockaddr_storage		smtp_server;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -744,6 +744,7 @@ vrrp_send_link_update(vrrp_t * vrrp, int rep)
 			for (e = LIST_HEAD(vrrp->vip); e; ELEMENT_NEXT(e)) {
 				ipaddress = ELEMENT_DATA(e);
 				vrrp_send_update(vrrp, ipaddress, j);
+				usleep(global_data->arp_sleep);
 			}
 		}
 
@@ -751,6 +752,7 @@ vrrp_send_link_update(vrrp_t * vrrp, int rep)
 			for (e = LIST_HEAD(vrrp->evip); e; ELEMENT_NEXT(e)) {
 				ipaddress = ELEMENT_DATA(e);
 				vrrp_send_update(vrrp, ipaddress, j);
+				usleep(global_data->arp_sleep);
 			}
 		}
 	}


### PR DESCRIPTION
Hi,

I created this small patch to resolve an issue we are having with keepalived.
On servers with alot of virtual IP's, we have issues that our switches throttle the gratuitous arp packages.

This can't be changed on switch level (hardcoded), so we had to find some 'workaround'/'fix' for this.
So I implemented the following patch.

The patch makes you able to configure an 'arp_sleep' variable.
This will cause a small usleep between the arp's, which causes to resolve the throttling.

If you don't want the feature, you can just not set it (default = 0), and it won't affect anything (except a call to usleep with 0.

I tested this already, and its working fine.

Thanks!
Jean-Louis
