### PR TITLE
check if interface is known when using use_vmac

### DIFF
--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -111,8 +111,14 @@ vrrp_vmac_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
 	vrrp->vmac_flags |= VRRP_VMAC_FL_SET;
-	if (!vrrp->saddr.ss_family && vrrp->family == AF_INET)
-		inet_ip4tosockaddr(IF_ADDR(vrrp->ifp), &vrrp->saddr);
+	if (!vrrp->saddr.ss_family && vrrp->family == AF_INET) {
+		if(vrrp->ifp == NULL) {
+			log_message(LOG_INFO, "Please define interface keyword before use_vmac keyword");
+			return;
+		} else {
+			inet_ip4tosockaddr(IF_ADDR(vrrp->ifp), &vrrp->saddr);
+		}
+	}
 	if (vector_size(strvec) == 2) {
 		strncpy(vrrp->vmac_ifname, vector_slot(strvec, 1),
 			IFNAMSIZ - 1);


### PR DESCRIPTION
vrrp->ifp is NULL when use_vmac keyword is defined before the
interface keyword. This would result in a segfault
(http://sourceforge.net/p/keepalived/mailman/message/33083027/).

I think it's better to show a message than segfaulting. Not sure if it's better to log to ERR instead of INFO. Not 100% sure if this solution is the best way to go. Let me know if this pull request needs to be changed.
