### PR TITLE
STR(SMTP_PORT) returns "SMTP_PORT", not "25"

### DIFF
--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -64,7 +64,7 @@ smtpto_handler(vector_t *strvec)
 static void
 smtpip_handler(vector_t *strvec)
 {
-	inet_stosockaddr(vector_slot(strvec, 1), STR(SMTP_PORT), &global_data->smtp_server);
+	inet_stosockaddr(vector_slot(strvec, 1), SMTP_PORT_STR, &global_data->smtp_server);
 }
 static void
 email_handler(vector_t *strvec)

--- a/keepalived/include/smtp.h
+++ b/keepalived/include/smtp.h
@@ -34,7 +34,7 @@
 #include "vrrp.h"
 
 /* global defs */
-#define SMTP_PORT		25
+#define SMTP_PORT_STR		"25"
 #define SMTP_BUFFER_LENGTH	512
 #define SMTP_BUFFER_MAX		1024
 #define SMTP_MAX_FSM_STATE	10


### PR DESCRIPTION
SMTP client is broken in keepalived 1.2.14:

```
Keepalived_healthcheckers[14971]: Timeout reading data to remote SMTP server [192.168.0.1]:0
```

Wrong argument is passed to inet_stosockaddr() in smtpip_handler():

```
Breakpoint 1, inet_stosockaddr (ip=0x7f81618e5c50 "192.168.0.1", port=0x7f81600ebc6e "SMTP_PORT", addr=0x7f81618e35e0) at utils.c:164
```
