### PR TITLE
Fixes acassen/keepalived#104 and acassen/keepalived#114

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -190,12 +190,12 @@ reload_check_thread(thread_t * thread)
 	signal_handler_destroy();
 
 	/* Destroy master thread */
-	kernel_netlink_close();
 	thread_destroy_master(master);
 	master = thread_make_master();
 	free_global_data(global_data);
 	free_checkers_queue();
 #ifdef _WITH_VRRP_
+	kernel_netlink_close();
 	free_interface_queue();
 #endif
 	free_ssl();


### PR DESCRIPTION
Each time check_child recieves SIGHUP two netlink channels are being opened in kernel_netlink_init(): nl_cmd and nl_kernel. nl_kernel is being attached to a kernel_netlink thread and is being closed when thread_destroy_master() is called from reload_check_thread(). nl_cmd channel has no thread attached, therefore it leaks.
