### PR TITLE
Checker child crashes on reload if kernel_netlink_close() called after m...

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -190,12 +190,14 @@ reload_check_thread(thread_t * thread)
 	signal_handler_destroy();
 
 	/* Destroy master thread */
+#ifdef _WITH_VRRP_
+	kernel_netlink_close();
+#endif
 	thread_destroy_master(master);
 	master = thread_make_master();
 	free_global_data(global_data);
 	free_checkers_queue();
 #ifdef _WITH_VRRP_
-	kernel_netlink_close();
 	free_interface_queue();
 #endif
 	free_ssl();


### PR DESCRIPTION
...aster thread destruction