### PR TITLE
getaddrinfo should be used instead of gethostbyname

### DIFF
--- a/lib/utils.c
+++ b/lib/utils.c
@@ -439,16 +439,23 @@ inet_cidrtomask(uint8_t cidr)
 char *
 get_local_name(void)
 {
-	struct hostent *host;
 	struct utsname name;
+	struct addrinfo hints, *res = NULL;
+	char *canonname;
+
+	memset(&hints, '\0', sizeof hints);
+	hints.ai_flags = AI_CANONNAME;
 
 	if (uname(&name) < 0)
 		return NULL;
 
-	if (!(host = gethostbyname(name.nodename)))
+	if (getaddrinfo(name.nodename, NULL, &hints, &res) != 0)
 		return NULL;
 
-	return host->h_name;
+	canonname = res->ai_canonname;
+	freeaddrinfo(res);
+
+	return canonname;
 }
 
 /* String compare with NULL string handling */


### PR DESCRIPTION
`The gethostbyname*() functions are obsolete; with the advent of IPv6, recent applications use getaddrinfo() instead.`

Patch created because of CVE-2015-0235 GHOST: glibc gethostbyname buffer overflow.

I'm not 100% sure if this is correct for the 3 cases that it's used for right now. I created a small script to test output and it's the same. Compiling also worked and keepalived is able to run.