### PR TITLE
A bunch of fixes to the ipvs part

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -122,6 +122,12 @@ start_check(void)
 		return;
 	}
 
+	/* fill 'vsg' members of the virtual_server_t structure.
+	 * We must do that after parsing config, because
+	 * vs and vsg declarations may appear in any order
+	 */
+	link_vsg_to_vs();
+
 	/* Processing differential configuration parsing */
 	if (reload)
 		clear_diff_services();

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -123,10 +123,8 @@ start_check(void)
 	}
 
 	/* Processing differential configuration parsing */
-	if (reload) {
+	if (reload)
 		clear_diff_services();
-		copy_srv_states();
-	}
 
 	/* Initialize IPVS topology */
 	if (!init_services()) {

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -312,12 +312,12 @@ timeout_epilog(thread_t * thread, char *smtp_msg, char *debug_msg)
 {
 	checker_t *checker = THREAD_ARG(thread);
 
-	log_message(LOG_INFO, "Timeout %s server %s."
-			    , debug_msg
-			    , FMT_HTTP_RS(checker));
 
 	/* check if server is currently alive */
 	if (svr_checker_up(checker->id, checker->rs)) {
+		log_message(LOG_INFO, "Timeout %s server %s."
+				    , debug_msg
+				    , FMT_HTTP_RS(checker));
 		smtp_alert(checker->rs, NULL, NULL,
 			   "DOWN", smtp_msg);
 		update_svr_checker_state(DOWN, checker->id

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -140,9 +140,9 @@ ipvs_group_range_cmd(int cmd, virtual_server_group_entry_t *vsg_entry)
 
 /* set IPVS group rules */
 static int
-ipvs_group_cmd(int cmd, list vs_group, real_server_t * rs, char * vsgname)
+ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 {
-	virtual_server_group_t *vsg = ipvs_get_group_by_name(vsgname, vs_group);
+	virtual_server_group_t *vsg = vs->vsg;
 	virtual_server_group_entry_t *vsg_entry;
 	list l;
 	element e;
@@ -234,7 +234,7 @@ ipvs_set_rule(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 /* Set/Remove a RS from a VS */
 int
-ipvs_cmd(int cmd, list vs_group, virtual_server_t * vs, real_server_t * rs)
+ipvs_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 {
 	int err = 0;
 
@@ -257,7 +257,7 @@ ipvs_cmd(int cmd, list vs_group, virtual_server_t * vs, real_server_t * rs)
 
 	/* Set vs rule and send to kernel */
 	if (vs->vsgname) {
-		err = ipvs_group_cmd(cmd, vs_group, rs, vs->vsgname);
+		err = ipvs_group_cmd(cmd, vs, rs);
 	} else {
 		if (vs->vfwmark) {
 			urule->vfwmark = vs->vfwmark;
@@ -454,9 +454,9 @@ ipvs_group_range_cmd(int cmd, virtual_server_group_entry_t *vsg_entry)
 
 /* set IPVS group rules */
 static void
-ipvs_group_cmd(int cmd, list vs_group, real_server_t * rs, virtual_server_t * vs)
+ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 {
-	virtual_server_group_t *vsg = ipvs_get_group_by_name(vs->vsgname, vs_group);
+	virtual_server_group_t *vsg = vs->vsg;
 	virtual_server_group_entry_t *vsg_entry;
 	list l;
 	element e;
@@ -570,7 +570,7 @@ ipvs_set_rule(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 /* Set/Remove a RS from a VS */
 int
-ipvs_cmd(int cmd, list vs_group, virtual_server_t * vs, real_server_t * rs)
+ipvs_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 {
 	/* Allocate the room */
 	memset(srule, 0, sizeof(ipvs_service_t));
@@ -592,7 +592,7 @@ ipvs_cmd(int cmd, list vs_group, virtual_server_t * vs, real_server_t * rs)
 
 	/* Set vs rule and send to kernel */
 	if (vs->vsgname) {
-		ipvs_group_cmd(cmd, vs_group, rs, vs);
+		ipvs_group_cmd(cmd, vs, rs);
 	} else {
 		if (vs->vfwmark) {
 			srule->af = AF_INET;

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -296,9 +296,8 @@ update_quorum_state(virtual_server_t * vs)
 	/* If we have just lost quorum for the VS, we need to consider
 	 * VS notify_down and sorry_server cases
 	 */
-	if (vs->quorum_state == UP && (
-		!weight_sum ||
-	    weight_sum < down_threshold)
+	if (vs->quorum_state == UP &&
+	    (!weight_sum || weight_sum < down_threshold)
 	) {
 		vs->quorum_state = DOWN;
 		log_message(LOG_INFO, "Lost quorum %lu-%lu=%li > %lu for VS %s"

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -687,3 +687,16 @@ clear_diff_services(void)
 
 	return 1;
 }
+
+void
+link_vsg_to_vs(void)
+{
+	element e;
+	virtual_server_t *vs;
+
+	for (e = LIST_HEAD(check_data->vs); e; ELEMENT_NEXT(e)) {
+		vs = ELEMENT_DATA(e);
+		if (vs->vsgname)
+			vs->vsg = ipvs_get_group_by_name(vs->vsgname, check_data->vs_group);
+	}
+}

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -35,12 +35,12 @@
 static void update_quorum_state(virtual_server_t * vs);
 
 /* Returns the sum of all RS weight in a virtual server. */
-long unsigned
+static long
 weigh_live_realservers(virtual_server_t * vs)
 {
 	element e;
 	real_server_t *svr;
-	long unsigned count = 0;
+	long count = 0;
 
 	for (e = LIST_HEAD(vs->rs); e; ELEMENT_NEXT(e)) {
 		svr = ELEMENT_DATA(e);
@@ -56,8 +56,8 @@ clear_service_rs(list vs_group, virtual_server_t * vs, list l)
 {
 	element e;
 	real_server_t *rs;
-	long unsigned weight_sum;
-	long signed down_threshold = vs->quorum - vs->hysteresis;
+	long weight_sum;
+	long down_threshold = vs->quorum - vs->hysteresis;
 
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		rs = ELEMENT_DATA(e);
@@ -255,15 +255,15 @@ perform_quorum_state(virtual_server_t *vs, int add)
 static void
 update_quorum_state(virtual_server_t * vs)
 {
-	long unsigned weight_sum = weigh_live_realservers(vs);
-	long signed up_threshold = vs->quorum + vs->hysteresis;
-	long signed down_threshold = vs->quorum - vs->hysteresis;
+	long weight_sum = weigh_live_realservers(vs);
+	long up_threshold = vs->quorum + vs->hysteresis;
+	long down_threshold = vs->quorum - vs->hysteresis;
 
 	/* If we have just gained quorum, it's time to consider notify_up. */
 	if (vs->quorum_state == DOWN &&
 	    weight_sum >= up_threshold) {
 		vs->quorum_state = UP;
-		log_message(LOG_INFO, "Gained quorum %lu+%lu=%li <= %lu for VS %s"
+		log_message(LOG_INFO, "Gained quorum %lu+%lu=%li <= %li for VS %s"
 				    , vs->quorum
 				    , vs->hysteresis
 				    , up_threshold
@@ -300,7 +300,7 @@ update_quorum_state(virtual_server_t * vs)
 	    (!weight_sum || weight_sum < down_threshold)
 	) {
 		vs->quorum_state = DOWN;
-		log_message(LOG_INFO, "Lost quorum %lu-%lu=%li > %lu for VS %s"
+		log_message(LOG_INFO, "Lost quorum %lu-%lu=%li > %li for VS %s"
 				    , vs->quorum
 				    , vs->hysteresis
 				    , down_threshold

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -111,6 +111,7 @@ typedef struct _virtual_server_group {
 /* Virtual Server definition */
 typedef struct _virtual_server {
 	char				*vsgname;
+	virtual_server_group_t		*vsg;
 	struct sockaddr_storage		addr;
 	real_server_t			*s_svr;
 	uint32_t			vfwmark;

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -99,6 +99,7 @@ typedef struct _virtual_server_group_entry {
 	uint8_t				range;
 	uint32_t			vfwmark;
 	int				alive;
+	int				reloaded;
 } virtual_server_group_entry_t;
 
 typedef struct _virtual_server_group {

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -83,7 +83,7 @@ typedef struct _real_server {
 	int				alive;
 	list				failed_checkers;/* List of failed checkers */
 	int				set;		/* in the IPVS table */
-	int				reloaded;   /* active state was copied from old config while reloading */
+	int				reloaded;	/* active state was copied from old config while reloading */
 #if defined(_WITH_SNMP_) && defined(_KRNL_2_6_) && defined(_WITH_LVS_)
 	/* Statistics */
 	uint32_t			activeconns;	/* active connections */
@@ -134,7 +134,7 @@ typedef struct _virtual_server {
 
 	long unsigned			hysteresis;	/* up/down events "lag" WRT quorum. */
 	unsigned			quorum_state;	/* Reflects result of the last transition done. */
-	int					reloaded;   /* quorum_state was copied from old config while reloading */
+	int				reloaded;	/* quorum_state was copied from old config while reloading */
 #if defined(_WITH_SNMP_) && defined(_KRNL_2_6_) && defined(_WITH_LVS_)
 	/* Statistics */
 	time_t				lastupdated;

--- a/keepalived/include/ipvswrapper.h
+++ b/keepalived/include/ipvswrapper.h
@@ -92,6 +92,7 @@ do {						\
 extern int ipvs_start(void);
 extern void ipvs_stop(void);
 extern virtual_server_group_t *ipvs_get_group_by_name(char *, list);
+extern int ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge);
 extern int ipvs_group_remove_entry(virtual_server_t *, virtual_server_group_entry_t *);
 extern int ipvs_cmd(int, virtual_server_t *, real_server_t *);
 extern int ipvs_syncd_cmd(int, char *, int, int);

--- a/keepalived/include/ipvswrapper.h
+++ b/keepalived/include/ipvswrapper.h
@@ -93,7 +93,7 @@ extern int ipvs_start(void);
 extern void ipvs_stop(void);
 extern virtual_server_group_t *ipvs_get_group_by_name(char *, list);
 extern int ipvs_group_remove_entry(virtual_server_t *, virtual_server_group_entry_t *);
-extern int ipvs_cmd(int, list, virtual_server_t *, real_server_t *);
+extern int ipvs_cmd(int, virtual_server_t *, real_server_t *);
 extern int ipvs_syncd_cmd(int, char *, int, int);
 extern void ipvs_syncd_master(char *, int);
 extern void ipvs_syncd_backup(char *, int);

--- a/keepalived/include/ipwrapper.h
+++ b/keepalived/include/ipwrapper.h
@@ -56,6 +56,5 @@ extern void update_svr_checker_state(int, checker_id_t, virtual_server_t *, real
 extern int init_services(void);
 extern int clear_services(void);
 extern int clear_diff_services(void);
-extern int copy_srv_states(void);
 
 #endif

--- a/keepalived/include/ipwrapper.h
+++ b/keepalived/include/ipwrapper.h
@@ -56,5 +56,6 @@ extern void update_svr_checker_state(int, checker_id_t, virtual_server_t *, real
 extern int init_services(void);
 extern int clear_services(void);
 extern int clear_diff_services(void);
+extern void link_vsg_to_vs(void);
 
 #endif


### PR DESCRIPTION
These issues are fixed:
- infinitely repeating logging of an HTTP real server timed-out
- quorum < hysteresis: wrong comparison result
- vs_groups lose quorum on config reload
- adding existing RS to a new vs group item on config reload