### PR TITLE
ICMPv6

### DIFF
--- a/keepalived/vrrp/vrrp_ndisc.c
+++ b/keepalived/vrrp/vrrp_ndisc.c
@@ -85,8 +85,8 @@ ndisc_icmp6_cksum(const struct ip6hdr *ip6, const struct icmp6hdr *icp, uint32_t
 
 	/* pseudo-header */
 	memset(&phu, 0, sizeof(phu));
-	phu.ph.ph_src = ip6->saddr;
-	phu.ph.ph_dst = ip6->daddr;
+	memcpy(&phu.ph.ph_src, &ip6->saddr, sizeof(struct in6_addr));
+	memcpy(&phu.ph.ph_dst, &ip6->daddr, sizeof(struct in6_addr));
 	phu.ph.ph_len = htonl(len);
 	phu.ph.ph_nxt = IPPROTO_ICMPV6;
 
@@ -142,7 +142,7 @@ ndisc_send_unsolicited_na(ip_address_t *ipaddress)
 	ip6h->payload_len = htons(sizeof(struct ndhdr) + sizeof(struct nd_opt_hdr) + ETH_ALEN);
 	ip6h->nexthdr = NEXTHDR_ICMP;
 	ip6h->hop_limit = NDISC_HOPLIMIT;
-	ip6h->saddr = ipaddress->u.sin6_addr;
+	memcpy(&ip6h->saddr, &ipaddress->u.sin6_addr, sizeof(struct in6_addr));
 	ip6h->daddr.s6_addr16[0] = htons(0xff02);
 	ip6h->daddr.s6_addr16[7] = htons(1);
 


### PR DESCRIPTION
Hi,

I use Keepalived 1.2.16, with native_ipv6 flag.

This week, I noticed that when my master turned off, my backup became master almost instantly (;D), but my IPv6 virtual addresses were not "pingable" until about 30-45 seconds. 

I did it once again with wireshark, in order to check the ICMPv6 packets sent by Keepalived, and saw that the packet was not considered as ICMPv6, but was unknown : the "next header" field was not NEXTHDR_ICMP (58), but was an unknwon value. It means that nobody around was able to understand the notification sent from the new master.

After having debugged a little into the file keepalived/vrrp/vrrp_ndisc.c, I found out that my problem was while copying the source address into the IPv6 header. The copy of this address was overwriting the two previous bytes ("next header" and "hop limit").

To resolve my problem, I replaced the copy with memcpy (and did the same into the ICMPv6 checsum calculation), and the ICMPv6 packets are now recognized by all the neighbours.

I don't know if the problem exists for everybody, or if it's just because of my cross-compilation toolchain (?). By the way, if it can helps in any way, here is my patch.

Romain Laniece.