### PR TITLE
vrrp: sync status flag (up/down) for _all_ VMAC interfaces

### DIFF
--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -112,8 +112,8 @@ typedef struct _tracked_if {
 
 /* prototypes */
 extern interface_t *if_get_by_ifindex(const int);
-extern interface_t *if_get_by_vmac_base_ifindex(const int);
 extern interface_t *if_get_by_ifname(const char *);
+extern void if_vmac_reflect_flags(const int, const unsigned long);
 extern int if_linkbeat(const interface_t *);
 extern int if_mii_probe(const char *);
 extern int if_ethtool_probe(const char *);

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -79,25 +79,6 @@ if_get_by_ifindex(const int ifindex)
 	return NULL;
 }
 
-/* Return interface from VMAC base interface index */
-interface_t *
-if_get_by_vmac_base_ifindex(const int ifindex)
-{
-	interface_t *ifp;
-	element e;
-
-	if (LIST_ISEMPTY(if_queue) || !ifindex)
-		return NULL;
-
-	for (e = LIST_HEAD(if_queue); e; ELEMENT_NEXT(e)) {
-		ifp = ELEMENT_DATA(e);
-		if (ifp->vmac && ifp->base_ifindex == ifindex)
-			return ifp;
-	}
-
-	return NULL;
-}
-
 interface_t *
 if_get_by_ifname(const char *ifname)
 {
@@ -113,6 +94,27 @@ if_get_by_ifname(const char *ifname)
 			return ifp;
 	}
 	return NULL;
+}
+
+/*
+ * Reflect base interface flags on VMAC interfaces.
+ * VMAC interfaces should never update it own flags, only be reflected
+ * by the base interface flags.
+ */
+void
+if_vmac_reflect_flags(const int ifindex, const unsigned long flags)
+{
+	interface_t *ifp;
+	element e;
+
+	if (LIST_ISEMPTY(if_queue) || !ifindex)
+		return;
+
+	for (e = LIST_HEAD(if_queue); e; ELEMENT_NEXT(e)) {
+		ifp = ELEMENT_DATA(e);
+		if (ifp->vmac && ifp->base_ifindex == ifindex)
+			ifp->flags = flags;
+	}
 }
 
 /* MII Transceiver Registers poller functions */

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -244,25 +244,6 @@ netlink_scope_a2n(char *scope)
 	return -1;
 }
 
-/*
- * Reflect base interface flags on VMAC interface.
- * VMAC interfaces should never update it own flags, only be reflected
- * by the base interface flags.
- */
-static void
-vmac_reflect_flags(struct ifinfomsg *ifi)
-{
-	interface_t *ifp;
-
-	/* find the VMAC interface (if any) */
-	ifp = if_get_by_vmac_base_ifindex(ifi->ifi_index);
-
-	/* if found, reflect base interface flags on VMAC interface */
-	if (ifp) {
-		ifp->flags = ifi->ifi_flags;
-	}
-}
-
 /* Our netlink parser */
 static int
 netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
@@ -484,7 +465,7 @@ netlink_if_link_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 	ifp = if_get_by_ifname(name);
 	if (ifp) {
 		if (!ifp->vmac) {
-			vmac_reflect_flags(ifi);
+			if_vmac_reflect_flags(ifi->ifi_index, ifi->ifi_flags);
 			ifp->flags = ifi->ifi_flags;
 		}
 		return 0;
@@ -498,7 +479,7 @@ netlink_if_link_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 	ifp->hw_type = ifi->ifi_type;
 
 	if (!ifp->vmac) {
-		vmac_reflect_flags(ifi);
+		if_vmac_reflect_flags(ifi->ifi_index, ifi->ifi_flags);
 		ifp->flags = ifi->ifi_flags;
 		ifp->base_ifindex = ifi->ifi_index;
 	}
@@ -693,7 +674,7 @@ netlink_reflect_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 	 * by the base interface flags.
 	 */
 	if (!ifp->vmac) {
-		vmac_reflect_flags(ifi);
+		if_vmac_reflect_flags(ifi->ifi_index, ifi->ifi_flags);
 		ifp->flags = ifi->ifi_flags;
 	}
 


### PR DESCRIPTION
When using VMAC and running multiple instances on the same interface, only one of the VMAC interfaces will get its status flag synched.
This commit will update the status flag for _all_ VMAC interfaces attached to a base interface.