### PR TITLE
snmp: don't hardcode AgentX socket location

### DIFF
--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -241,12 +241,6 @@ snmp_agent_init(void)
 			       SNMP_CALLBACK_SESSION_INIT,
 			       snmp_setup_session_cb, NULL);
 	/*
-	 * We need to tell the local SNMP library how to connect to AgentX
-	 * "tcp:localhost:705" is the default setting
-	 */
-	netsnmp_ds_set_string(NETSNMP_DS_APPLICATION_ID,
-			      NETSNMP_DS_AGENT_X_SOCKET, "tcp:localhost:705");
-	/*
 	 * Ping AgentX less often than every 15 seconds: pinging can
 	 * block keepalived. We check every 2 minutes.
 	 */


### PR DESCRIPTION
The default location should be `/var/agentx/master` (as per RFC2741 and
this is also the default for NetSNMP, including on Debian-based
distributions). This default location is set at configure-time for
NetSNMP and subagent will use it automatically (it is also available
through `net-snmp-config.h`).

A useful feature would be to have a flag to change that if the user
change this settings in the master agent. This commit just reverts this
change to let SNMP subsystem work as expected for most users.

Signed-off-by: Vincent Bernat <vincent@bernat.im>