### PR TITLE
VRRP incorrectly sets receive interface to vmac after reload

### DIFF
--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -102,7 +102,6 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 			ifp->base_ifindex = vrrp->ifp->ifindex;
 			ifp->vmac = 1;
 			ifp->flags = vrrp->ifp->flags; /* Copy base interface flags */
-			vrrp->ifp = ifp;
 			/* Save ifindex for use on delete */
 			vrrp->vmac_ifindex = IF_INDEX(ifp);
 			__set_bit(VRRP_VMAC_UP_BIT, &vrrp->vmac_flags);


### PR DESCRIPTION
When VRRP is reloaded after initially being configured with
the use_vmac option, VRRP sets its receiving interface pointer
to point to the vmac interface which is incorrect.

For transmitting, VRRP should be using the vmac interface that
results in frames being sent onto the wire with the vMAC address.
For receiving, VRRP should continue to use the base/real
interface.

This fix removes the line that incorrectly sets the receiving
interface pointer. This means VRRP will continue to use the
real interface for receiving traffic as the pointer was correctly
set before reload and this persists after reload.