### PR TITLE
Use /etc/iproute2/rt_tables for lookups to allow better readable table names in VRRP virtual routes

### DIFF
--- a/keepalived/include/vrrp_iproute.h
+++ b/keepalived/include/vrrp_iproute.h
@@ -67,5 +67,7 @@ extern void dump_iproute(void *);
 extern void alloc_route(list, vector_t *);
 extern void clear_diff_routes(list, list);
 extern void clear_diff_sroutes(void);
+extern void load_rt_tables(void);
+extern void free_rt_tables(void);
 
 #endif

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -89,6 +89,7 @@ stop_vrrp(void)
 	thread_destroy_master(master);
 	gratuitous_arp_close();
 	ndisc_close();
+	free_rt_tables();
 
 #ifdef _DEBUG_
 	keepalived_free_final("VRRP Child process");
@@ -117,6 +118,7 @@ start_vrrp(void)
 #endif
 
 	/* Parse configuration file */
+	load_rt_tables();
 	global_data = alloc_global_data();
 	vrrp_data = alloc_vrrp_data();
 	alloc_vrrp_buffer();
@@ -240,7 +242,6 @@ reload_vrrp_thread(thread_t * thread)
 	free_vrrp_buffer();
 	gratuitous_arp_close();
 	ndisc_close();
-
 #ifdef _WITH_LVS_
 	if (vrrp_ipvs_needed()) {
 		/* Clean ipvs related */


### PR DESCRIPTION
Currently keepalived only support numerical representations of virtual routes in config files. This patch (based on iproute2 code snippets) allows to specify character representations of tables by reading /etc/iproute2/rt_tables.