### PR TITLE
Fix vrrp removes incorrect IPv4 address when VIPs are removed

### DIFF
--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -86,6 +86,9 @@ netlink_ipaddress(ip_address_t *ipaddress, int cmd)
 	} else {
 		addattr_l(&req.n, sizeof(req), IFA_LOCAL,
 			  &ipaddress->u.sin.sin_addr, sizeof(ipaddress->u.sin.sin_addr));
+		if (cmd == IPADDRESS_DEL)
+			addattr_l(&req.n, sizeof(req), IFA_ADDRESS,
+			  &ipaddress->u.sin.sin_addr, sizeof(ipaddress->u.sin.sin_addr));
 		if (ipaddress->u.sin.sin_brd.s_addr)
 			addattr_l(&req.n, sizeof(req), IFA_BROADCAST,
 				  &ipaddress->u.sin.sin_brd, sizeof(ipaddress->u.sin.sin_brd));


### PR DESCRIPTION
When vrrp has an IPv4 VIP that matches the primary interface
address, when the VIP is removed from the interface, the original
address ends up getting removed instead of the VIP.

The kernel receives a netlink message instructing it to remove
address x from a particular interface. For IPv4, address x can
be configured multiple times providing the prefix lengths differ.
If the IFA_ADDRESS attribute is not specified in a RTM_DELADDR
message, the kernel will delete the first address it finds a
match on, prefix length is not taken into account.

This fix therefore adds the IFA_ADDRESS attribute when deleting
IPv4 addresses so that the address removed is actually the VIP.