### PR TITLE
fix build failure with musl libc

### DIFF
--- a/lib/utils.h
+++ b/lib/utils.h
@@ -31,6 +31,7 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 #include <sys/param.h>
+#include <sys/types.h>
 #include <sys/utsname.h>
 #include <netdb.h>
 


### PR DESCRIPTION
 * Add missing sys/types.h include to provide u_short type under musl

Signed-off-by: Jo-Philipp Wich <jow@openwrt.org>
Signed-off-by: Nicolas Thill <nico@openwrt.org>