### PR TITLE
Avoided leaked useless memory

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -307,7 +307,7 @@ read_line(char *buf, int size)
 
 	do {
 		int count = 0;
-		memset(buf, 0, MAXBUF);
+		memset(buf, 0, size);
 		while ((ch = fgetc(current_stream)) != EOF && (int) ch != '\n'
 			   && (int) ch != '\r') {
 			if (count < size)

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -239,6 +239,7 @@ void read_conf_file(char *conf_file)
 			log_message(LOG_INFO, "chdir(%s) error (%s)"
 					    , confpath, strerror(errno));
 		}
+		free(confpath);
 		process_stream(current_keywords);
 		fclose(stream);
 


### PR DESCRIPTION
Avoided leaked useless memory in `read_conf_file` and fixed parameter of `memset` in `read_line`.