### PR TITLE
memory: get rid of `xfree()`

### DIFF
--- a/lib/memory.c
+++ b/lib/memory.c
@@ -54,14 +54,6 @@ zalloc(unsigned long size)
 	return mem;
 }
 
-void
-xfree(void *p)
-{
-	/* sizeof p is the size of the pointer, not the pointed */
-	free(p);
-	p = NULL;
-}
-
 /* KeepAlived memory management. in debug mode,
  * help finding eventual memory leak.
  * Allocation memory types manipulated are :
@@ -213,7 +205,7 @@ keepalived_free(void *buffer, char *file, char *function, int line)
 	}
 
 	if (buffer != NULL)
-		xfree(buffer);
+		free(buffer);
 
 	if (__test_bit(LOG_CONSOLE_BIT, &debug))
 		printf("free  [%3d:%3d], %p, %4ld at %s, %3d, %s\n",

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -35,7 +35,6 @@
 extern unsigned long mem_allocated;
 extern void *xalloc(unsigned long size);
 extern void *zalloc(unsigned long size);
-extern void xfree(void *p);
 
 /* Global alloc macro */
 #define ALLOC(n) (xalloc(n))
@@ -61,7 +60,7 @@ extern void keepalived_free_final(char *);
 #else
 
 #define MALLOC(n)    (zalloc(n))
-#define FREE(p)      (xfree(p))
+#define FREE(p)      (free(p))
 #define REALLOC(p,n) (realloc((p),(n)))
 
 #endif


### PR DESCRIPTION
Its effect is just the same as `free()`. Setting `p` to `NULL` is
useless as this parameter is passed by value. To work as expected, it
should have been a macro.

Given the comment in the function, I think in the past it did something else (memset maybe?). I can also convert it to a macro if needed (so that `p = NULL` has an effect).