### PR TITLE
Only install MIBs when built with snmp.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,9 +62,11 @@ uninstall:
 install:
 	$(MAKE) -C keepalived install
 	$(MAKE) -C genhash install
-	mkdir -p $(DESTDIR)/usr/share/snmp/mibs/
-	cp -f doc/VRRP-MIB $(DESTDIR)/usr/share/snmp/mibs/
-	cp -f doc/KEEPALIVED-MIB $(DESTDIR)/usr/share/snmp/mibs/
+ifeq (@SNMP_SUPPORT@, _WITH_SNMP_)
+        mkdir -p $(DESTDIR)/usr/share/snmp/mibs/
+        cp -f doc/VRRP-MIB $(DESTDIR)/usr/share/snmp/mibs/
+        cp -f doc/KEEPALIVED-MIB $(DESTDIR)/usr/share/snmp/mibs/
+endif
 
 tarball: mrproper
 	mkdir keepalived-@VERSION@


### PR DESCRIPTION
Current git wants to install MIB always even when built without SNMP support.

This patch fixes this behaviour.