### PR TITLE
changes to ipvs checkers

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -358,6 +358,9 @@ A virtual_server can be a declaration of one of
     # Script to launch when quorum is lost.
     quorum_down <STRING>|<QUOTED-STRING>
 
+    # IP family for a fwmark service (optional)
+    ip_family inet|inet6
+
 
     # setup realserver(s)
 

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -465,6 +465,11 @@ A virtual_server can be a declaration of one of
                # checks to the same RS. Enabled by default, with
                # the maximum at delay_loop. Specify 0 to disable
                warmup <INT>
+               # Retry count to make additional checks if check
+               # of an alive server fails. Default: 1
+               retry <INT>
+               # Delay in seconds before retrying. Default: 1
+               delay_before_retry <INT>
            } #TCP_CHECK
 
            # SMTP healthchecker

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -236,6 +236,7 @@ alloc_vs(char *ip, char *port)
 		new->vfwmark = atoi(port);
 	} else {
 		inet_stosockaddr(ip, port, &new->addr);
+		new->af = new->addr.ss_family;
 	}
 
 	new->delay_loop = KEEPALIVED_DEFAULT_DELAY;
@@ -262,6 +263,9 @@ alloc_ssvr(char *ip, char *port)
 	vs->s_svr->weight = 1;
 	vs->s_svr->iweight = 1;
 	inet_stosockaddr(ip, port, &vs->s_svr->addr);
+
+	if (! vs->af)
+		vs->af = vs->s_svr->addr.ss_family;
 }
 
 /* Real server facility functions */
@@ -315,6 +319,9 @@ alloc_rs(char *ip, char *port)
 	if (LIST_ISEMPTY(vs->rs))
 		vs->rs = alloc_list(free_rs, dump_rs);
 	list_add(vs->rs, new);
+
+	if (! vs->af)
+		vs->af = new->addr.ss_family;
 }
 
 /* data facility functions */

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -249,21 +249,42 @@ epilog(thread_t * thread, int method, int t, int c)
 		http->retry_it += c ? c : -http->retry_it;
 	}
 
+	if (method == 1 && http->url_it >= LIST_SIZE(http_get_check->url)) {
+		/* All the url have been successfully checked.
+		 * Check completed.
+		 * check if server is currently alive.
+		 */
+		if (!svr_checker_up(checker->id, checker->rs)) {
+			log_message(LOG_INFO, "Remote Web server %s succeed on service."
+					    , FMT_HTTP_RS(checker));
+			smtp_alert(checker->rs, NULL, NULL, "UP",
+				   "=> CHECK succeed on service <=");
+			update_svr_checker_state(UP, checker->id
+						   , checker->vs
+						   , checker->rs);
+		}
+
+		/* Reset it counters */
+		http->url_it = 0;
+		http->retry_it = 0;
+	}
 	/*
 	 * The get retry implementation mean that we retry performing
 	 * a GET on the same url until the remote web server return 
 	 * html buffer. This is sometime needed with some applications
 	 * servers.
 	 */
-	if (http->retry_it > http_get_check->nb_get_retry-1) {
+	else if (method == 2 && http->retry_it > http_get_check->nb_get_retry) {
 		if (svr_checker_up(checker->id, checker->rs)) {
-			log_message(LOG_INFO, "Check on service %s failed after %d retry."
-			       , FMT_HTTP_RS(checker)
-			       , http->retry_it);
+			if (http_get_check->nb_get_retry)
+				log_message(LOG_INFO
+				   , "Check on service %s failed after %d retry."
+				   , FMT_HTTP_RS(checker)
+				   , http->retry_it - 1);
 			smtp_alert(checker->rs, NULL, NULL,
 				   "DOWN",
 				   "=> CHECK failed on service"
-				   " : MD5 digest mismatch <=");
+				   " : HTTP request failed <=");
 			update_svr_checker_state(DOWN, checker->id
 						     , checker->vs
 						     , checker->rs);
@@ -277,11 +298,7 @@ epilog(thread_t * thread, int method, int t, int c)
 	/* register next timer thread */
 	switch (method) {
 	case 1:
-		if (req)
-			delay = checker->vs->delay_loop;
-		else
-			delay =
-			    http_get_check->delay_before_retry;
+		delay = checker->vs->delay_loop;
 		break;
 	case 2:
 		if (http->url_it == 0 && http->retry_it == 0)
@@ -308,23 +325,21 @@ epilog(thread_t * thread, int method, int t, int c)
 }
 
 int
-timeout_epilog(thread_t * thread, char *smtp_msg, char *debug_msg)
+timeout_epilog(thread_t * thread, char *debug_msg)
 {
 	checker_t *checker = THREAD_ARG(thread);
-
+	http_checker_t *http_get_check = CHECKER_ARG(checker);
+	http_t *http = HTTP_ARG(http_get_check);
 
 	/* check if server is currently alive */
 	if (svr_checker_up(checker->id, checker->rs)) {
-		log_message(LOG_INFO, "Timeout %s server %s."
+		log_message(LOG_INFO, "%s server %s."
 				    , debug_msg
 				    , FMT_HTTP_RS(checker));
-		smtp_alert(checker->rs, NULL, NULL,
-			   "DOWN", smtp_msg);
-		update_svr_checker_state(DOWN, checker->id
-					     , checker->vs
-					     , checker->rs);
+		return epilog(thread, 2, 0, 1);
 	}
 
+	/* do not retry if server is already known as dead */
 	return epilog(thread, 1, 0, 0);
 }
 
@@ -357,40 +372,12 @@ http_handle_response(thread_t * thread, unsigned char digest[16]
 
 	/* First check if remote webserver returned data */
 	if (empty_buffer)
-		return timeout_epilog(thread, "=> CHECK failed on service"
-				      " : empty buffer received <=\n\n",
-				      "Read, no data received from ");
+		return timeout_epilog(thread, "Read, no data received from ");
 
 	/* Next check the HTTP status code */
 	if (fetched_url->status_code) {
 		if (req->status_code != fetched_url->status_code) {
-			/* check if server is currently alive */
-			if (svr_checker_up(checker->id, checker->rs)) {
-				log_message(LOG_INFO,
-				       "HTTP status code error to %s url(%s)"
-				       ", status_code [%d].",
-				       FMT_HTTP_RS(checker),
-				       fetched_url->path,
-				       req->status_code);
-				smtp_alert(checker->rs, NULL, NULL,
-					   "DOWN",
-					   "=> CHECK failed on service"
-					   " : HTTP status code mismatch <=");
-				update_svr_checker_state(DOWN, checker->id
-							     , checker->vs
-							     , checker->rs);
-			} else {
-				DBG("HTTP Status_code to %s url(%d) = [%d]."
-				    , FMT_HTTP_RS(checker)
-				    , http->url_it + 1
-				    , req->status_code);
-				/*
-				 * We set retry iterator to max value to not retry
-				 * when service is already know as die.
-				 */
-				http->retry_it = http_get_check->nb_get_retry;
-			}
-			return epilog(thread, 2, 0, 1);
+			return timeout_epilog(thread, "HTTP status code error to");
 		} else {
 			last_success = on_status;
 		}
@@ -406,34 +393,8 @@ http_handle_response(thread_t * thread, unsigned char digest[16]
 		r = strcmp(fetched_url->digest, digest_tmp);
 
 		if (r) {
-			/* check if server is currently alive */
-			if (svr_checker_up(checker->id, checker->rs)) {
-				log_message(LOG_INFO,
-				       "MD5 digest error to %s url[%s]"
-				       ", MD5SUM [%s].",
-				       FMT_HTTP_RS(checker),
-				       fetched_url->path,
-				       digest_tmp);
-				smtp_alert(checker->rs, NULL, NULL,
-					   "DOWN",
-					   "=> CHECK failed on service"
-					   " : HTTP MD5SUM mismatch <=");
-				update_svr_checker_state(DOWN, checker->id
-							     , checker->vs
-							     , checker->rs);
-			} else {
-				DBG("MD5SUM to %s url(%d) = [%s]."
-				    , FMT_HTTP_RS(checker)
-				    , http->url_it + 1
-				    , digest_tmp);
-				/*
-				 * We set retry iterator to max value to not retry
-				 * when service is already know as die.
-				 */
-				http->retry_it = http_get_check->nb_get_retry;
-			}
 			FREE(digest_tmp);
-			return epilog(thread, 2, 0, 1);
+			return timeout_epilog(thread, "MD5 digest error to");
 		} else {
 			last_success = on_digest;
 			FREE(digest_tmp);
@@ -451,10 +412,10 @@ http_handle_response(thread_t * thread, unsigned char digest[16]
 				       , http->url_it + 1);
 				return epilog(thread, 1, 1, 0) + 1;
 			case on_digest:
-				if (!svr_checker_up(checker->id, checker->rs))
-					log_message(LOG_INFO, "MD5 digest success to %s url(%d)."
-						   , FMT_HTTP_RS(checker)
-						   , http->url_it + 1);
+				log_message(LOG_INFO,
+					"MD5 digest success to %s url(%d)."
+					, FMT_HTTP_RS(checker)
+					, http->url_it + 1);
 				return epilog(thread, 1, 1, 0) + 1;
 		}
 	}
@@ -503,8 +464,7 @@ http_read_thread(thread_t * thread)
 
 	/* Handle read timeout */
 	if (thread->type == THREAD_READ_TIMEOUT)
-		return timeout_epilog(thread, "=> HTTP CHECK failed on service"
-				      " : recevice data <=\n\n", "HTTP read");
+		return timeout_epilog(thread, "Timeout HTTP read");
 
 	/* Set descriptor non blocking */
 	val = fcntl(thread->u.fd, F_GETFL, 0);
@@ -534,19 +494,7 @@ http_read_thread(thread_t * thread)
 
 		if (r == -1) {
 			/* We have encourred a real read error */
-			if (svr_checker_up(checker->id, checker->rs)) {
-				log_message(LOG_INFO, "Read error with server %s: %s"
-				       , FMT_HTTP_RS(checker)
-				       , strerror(errno));
-				smtp_alert(checker->rs, NULL, NULL,
-					   "DOWN",
-					   "=> HTTP CHECK failed on service"
-					   " : cannot receive data <=");
-				update_svr_checker_state(DOWN, checker->id
-							     , checker->vs
-							     , checker->rs);
-			}
-			return epilog(thread, 1, 0, 0);
+			return timeout_epilog(thread, "Read error with");
 		}
 
 		/* Handle response stream */
@@ -583,8 +531,7 @@ http_response_thread(thread_t * thread)
 
 	/* Handle read timeout */
 	if (thread->type == THREAD_READ_TIMEOUT)
-		return timeout_epilog(thread, "=> CHECK failed on service"
-				      " : recevice data <=\n\n", "WEB read");
+		return timeout_epilog(thread, "Timeout WEB read");
 
 	/* Allocate & clean the get buffer */
 	req->buffer = (char *) MALLOC(MAX_BUFFER_LENGTH);
@@ -623,9 +570,7 @@ http_request_thread(thread_t * thread)
 
 	/* Handle read timeout */
 	if (thread->type == THREAD_WRITE_TIMEOUT)
-		return timeout_epilog(thread, "=> CHECK failed on service"
-				      " : read timeout <=\n\n",
-				      "Web read, timeout");
+		return timeout_epilog(thread, "Timeout WEB read");
 
 	/* Allocate & clean the GET string */
 	str_request = (char *) MALLOC(GET_BUFFER_LENGTH);
@@ -680,20 +625,7 @@ http_request_thread(thread_t * thread)
 	FREE(str_request);
 
 	if (!ret) {
-		log_message(LOG_INFO, "Cannot send get request to %s."
-				    , FMT_HTTP_RS(checker));
-
-		/* check if server is currently alive */
-		if (svr_checker_up(checker->id, checker->rs)) {
-			smtp_alert(checker->rs, NULL, NULL,
-				   "DOWN",
-				   "=> CHECK failed on service"
-				   " : cannot send data <=");
-			update_svr_checker_state(DOWN, checker->id
-						     , checker->vs
-						     , checker->rs);
-		}
-		return epilog(thread, 1, 0, 0);
+		return timeout_epilog(thread, "Cannot send get request to");
 	}
 
 	/* Register read timeouted thread */
@@ -721,25 +653,11 @@ http_check_thread(thread_t * thread)
 	status = tcp_socket_state(thread->u.fd, thread, http_check_thread);
 	switch (status) {
 	case connect_error:
-		/* check if server is currently alive */
-		if (svr_checker_up(checker->id, checker->rs)) {
-			log_message(LOG_INFO, "Error connecting server %s."
-					 , FMT_HTTP_RS(checker));
-			smtp_alert(checker->rs, NULL, NULL,
-				   "DOWN",
-				   "=> CHECK failed on service"
-				   " : connection error <=");
-			update_svr_checker_state(DOWN, checker->id
-						 , checker->vs
-						 , checker->rs);
-		}
-		return epilog(thread, 1, 0, 0);
+		return timeout_epilog(thread, "Error connecting");
 		break;
 
 	case connect_timeout:
-		return timeout_epilog(thread, "==> CHECK failed on service"
-				      " : connection timeout <=\n\n",
-				      "connect, timeout");
+		return timeout_epilog(thread, "Timeout connecting");
 		break;
 
 	case connect_success:{
@@ -755,9 +673,7 @@ http_check_thread(thread_t * thread)
 				    thread->type != THREAD_READ_TIMEOUT)
 					ret = ssl_connect(thread, new_req);
 				else {
-					return timeout_epilog(thread, "==> CHECK failed on service"
-							      " : connection timeout <=\n\n",
-							      "connect, timeout");
+					return timeout_epilog(thread, "Timeout connecting");
 				}
 
 				if (ret == -1) {
@@ -802,23 +718,8 @@ http_check_thread(thread_t * thread)
 					ssl_printerr(SSL_get_error
 						     (req->ssl, ret));
 #endif
-				if ((http_get_check->proto == PROTO_SSL) &&
-				    (svr_checker_up(checker->id, checker->rs))) {
-					log_message(LOG_INFO, "SSL handshake/communication error"
-							 " connecting to server"
-							 " (openssl errno: %d) %s."
-						       , SSL_get_error (http->req->ssl, ret)
-						       , FMT_HTTP_RS(checker));
-					smtp_alert(checker->rs, NULL, NULL,
-						   "DOWN",
-						   "=> CHECK failed on service"
-						   " : SSL connection error <=");
-					update_svr_checker_state(DOWN, checker->id
-								 , checker->vs
-								 , checker->rs);
-				}
-
-				return epilog(thread, 1, 0, 0);
+				return timeout_epilog(thread, "SSL handshake/communication error"
+							 " connecting to");
 			}
 		}
 		break;
@@ -832,7 +733,6 @@ http_connect_thread(thread_t * thread)
 {
 	checker_t *checker = THREAD_ARG(thread);
 	http_checker_t *http_get_check = CHECKER_ARG(checker);
-	http_t *http = HTTP_ARG(http_get_check);
 	conn_opts_t *co = checker->co;
 	url_t *fetched_url;
 	enum connect_result status;
@@ -848,26 +748,10 @@ http_connect_thread(thread_t * thread)
 		return 0;
 	}
 
-	/* Find eventual url end */
+	/* if there are no URLs in list, enable server w/o checking */
 	fetched_url = fetch_next_url(http_get_check);
-
-	if (!fetched_url) {
-		/* All the url have been successfully checked.
-		 * Check completed.
-		 * check if server is currently alive.
-		 */
-		if (!svr_checker_up(checker->id, checker->rs)) {
-			log_message(LOG_INFO, "Remote Web server %s succeed on service."
-					    , FMT_HTTP_RS(checker));
-			smtp_alert(checker->rs, NULL, NULL, "UP",
-				   "=> CHECK succeed on service <=");
-			update_svr_checker_state(UP, checker->id
-						   , checker->vs
-						   , checker->rs);
-		}
-		http->req = NULL;
-		return epilog(thread, 1, 0, 0) + 1;
-	}
+	if (!fetched_url)
+		return epilog(thread, 1, 1, 0) + 1;
 
 	/* Create the socket */
 	if ((fd = socket(co->dst.ss_family, SOCK_STREAM, IPPROTO_TCP)) == -1) {

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -220,7 +220,8 @@ misc_check_child_thread(thread_t * thread)
 			 * Catch legacy case of status being 0 but misc_dynamic being set.
 			 */
 			if (misck_checker->dynamic == 1 && status != 0)
-				update_svr_wgt(status - 2, checker->vs, checker->rs);
+				update_svr_wgt(status - 2, checker->vs,
+					       checker->rs, 1);
 
 			/* everything is good */
 			if (!svr_checker_up(checker->id, checker->rs)) {

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -74,6 +74,24 @@ vs_handler(vector_t *strvec)
 	alloc_vs(vector_slot(strvec, 1), vector_slot(strvec, 2));
 }
 static void
+vs_end_handler(void)
+{
+	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
+	if (! vs->af)
+		vs->af = AF_INET;
+}
+static void
+ip_family_handler(vector_t *strvec)
+{
+	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
+	if (vs->af)
+		return;
+	if (0 == strcmp(vector_slot(strvec, 1), "inet"))
+		vs->af = AF_INET;
+	else if (0 == strcmp(vector_slot(strvec, 1), "inet6"))
+		vs->af = AF_INET6;
+}
+static void
 delay_handler(vector_t *strvec)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
@@ -299,6 +317,7 @@ check_init_keywords(void)
 	/* Virtual server mapping */
 	install_keyword_root("virtual_server_group", &vsg_handler);
 	install_keyword_root("virtual_server", &vs_handler);
+	install_keyword("ip_family", &ip_family_handler);
 	install_keyword("delay_loop", &delay_handler);
 	install_keyword("lb_algo", &lbalgo_handler);
 	install_keyword("lvs_sched", &lbalgo_handler);
@@ -333,6 +352,8 @@ check_init_keywords(void)
 	install_keyword("inhibit_on_failure", &inhibit_handler);
 	install_keyword("notify_up", &notify_up_handler);
 	install_keyword("notify_down", &notify_down_handler);
+
+	install_sublevel_end_handler(&vs_end_handler);
 
 	/* Checkers mapping */
 	install_checkers_keyword();

--- a/keepalived/check/check_snmp.c
+++ b/keepalived/check/check_snmp.c
@@ -476,7 +476,7 @@ check_snmp_realserver_weight(int action,
 		if (action == RESERVE2)
 			break;
 		/* Commit: change values. There is no way to fail. */
-		update_svr_wgt((long)(*var_val), vs, rs);
+		update_svr_wgt((long)(*var_val), vs, rs, 1);
 		break;
 	}
 	return SNMP_ERR_NOERROR;

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -251,8 +251,7 @@ ssl_read_thread(thread_t * thread)
 
 	/* Handle read timeout */
 	if (thread->type == THREAD_READ_TIMEOUT && !req->extracted)
-		return timeout_epilog(thread, "=> SSL CHECK failed on service"
-				      " : recevice data <=\n\n", "SSL read");
+		return timeout_epilog(thread, "Timeout SSL read");
 
 	/* Set descriptor non blocking */
 	val = fcntl(thread->u.fd, F_GETFL, 0);
@@ -290,17 +289,7 @@ ssl_read_thread(thread_t * thread)
 		r = (req->error == SSL_ERROR_ZERO_RETURN) ? SSL_shutdown(req->ssl) : 0;
 
 		if (r && !req->extracted) {
-			/* check if server is currently alive */
-			if (svr_checker_up(checker->id, checker->rs)) {
-				smtp_alert(checker->rs, NULL, NULL,
-					   "DOWN",
-					   "=> SSL CHECK failed on service"
-					   " : cannot receive data <=\n\n");
-				update_svr_checker_state(DOWN, checker->id
-							     , checker->vs
-							     , checker->rs);
-			}
-			return epilog(thread, 1, 0, 0);
+			return timeout_epilog(thread, "SSL read error from");
 		}
 
 		/* Handle response stream */

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -37,21 +37,52 @@ void
 free_tcp_check(void *data)
 {
 	FREE(CHECKER_CO(data));
+	FREE(CHECKER_DATA(data));
 	FREE(data);
 }
 
 void
 dump_tcp_check(void *data)
 {
+	tcp_check_t *tcp_check = CHECKER_DATA(data);
+
 	log_message(LOG_INFO, "   Keepalive method = TCP_CHECK");
-	dump_conn_opts (CHECKER_GET_CO());
+	dump_conn_opts (CHECKER_CO(data));
+	if (tcp_check->n_retry) {
+		log_message(LOG_INFO, "     Retry count = %d"
+			    , tcp_check->n_retry);
+		log_message(LOG_INFO, "     Retry delay = %ld"
+			    , tcp_check->delay_before_retry / TIMER_HZ);
+	}
 }
 
 void
 tcp_check_handler(vector_t *strvec)
 {
+	tcp_check_t *tcp_check;
+
+	tcp_check = MALLOC(sizeof (tcp_check_t));
+	tcp_check->n_retry = 1;
+	tcp_check->delay_before_retry = 1 * TIMER_HZ;
+
 	/* queue new checker */
-	queue_checker(free_tcp_check, dump_tcp_check, tcp_connect_thread, NULL, CHECKER_NEW_CO());
+	queue_checker(free_tcp_check, dump_tcp_check, tcp_connect_thread
+		      ,tcp_check, CHECKER_NEW_CO());
+}
+
+void
+tcp_retry_handler(vector_t *strvec)
+{
+	tcp_check_t *tcp_check = CHECKER_GET();
+	tcp_check->n_retry = CHECKER_VALUE_INT(strvec);
+}
+
+void
+tcp_delay_before_retry_handler(vector_t *strvec)
+{
+	tcp_check_t *tcp_check = CHECKER_GET();
+	tcp_check->delay_before_retry =
+		(long)CHECKER_VALUE_INT(strvec) * TIMER_HZ;
 }
 
 void
@@ -59,9 +90,57 @@ install_tcp_check_keyword(void)
 {
 	install_keyword("TCP_CHECK", &tcp_check_handler);
 	install_sublevel();
+	install_keyword("retry", &tcp_retry_handler);
+	install_keyword("delay_before_retry", &tcp_delay_before_retry_handler);
 	install_connect_keywords();
 	install_keyword("warmup", &warmup_handler);
 	install_sublevel_end();
+}
+
+void
+tcp_eplilog(thread_t * thread, int is_success)
+{
+	checker_t *checker;
+	tcp_check_t *tcp_check;
+	long delay;
+
+	checker = THREAD_ARG(thread);
+	tcp_check = CHECKER_ARG(checker);
+
+	if (is_success || tcp_check->retry_it > tcp_check->n_retry - 1) {
+		delay = checker->vs->delay_loop;
+		tcp_check->retry_it = 0;
+
+		if (is_success && !svr_checker_up(checker->id, checker->rs)) {
+			log_message(LOG_INFO, "TCP connection to %s success."
+					, FMT_TCP_RS(checker));
+			smtp_alert(checker->rs, NULL, NULL,
+				   "UP",
+				   "=> TCP CHECK succeed on service <=");
+			update_svr_checker_state(UP, checker->id
+						   , checker->vs
+						   , checker->rs);
+		} else if (! is_success
+			   && svr_checker_up(checker->id, checker->rs)) {
+			if (tcp_check->n_retry)
+				log_message(LOG_INFO
+				    , "Check on service %s failed after %d retry."
+				    , FMT_TCP_RS(checker)
+				    , tcp_check->n_retry);
+			smtp_alert(checker->rs, NULL, NULL,
+				   "DOWN",
+				   "=> TCP CHECK failed on service <=");
+			update_svr_checker_state(DOWN, checker->id
+						     , checker->vs
+						     , checker->rs);
+		}
+	} else {
+		delay = tcp_check->delay_before_retry;
+		++tcp_check->retry_it;
+	}
+
+	/* Register next timer checker */
+	thread_add_timer(thread->master, tcp_connect_thread, checker, delay);
 }
 
 int
@@ -71,45 +150,32 @@ tcp_check_thread(thread_t * thread)
 	int status;
 
 	checker = THREAD_ARG(thread);
-
 	status = tcp_socket_state(thread->u.fd, thread, tcp_check_thread);
 
-	/* If status = connect_success, TCP connection to remote host is established.
+	/* If status = connect_in_progress, next thread is already registered.
+	 * If it is connect_success, the fd is still open.
 	 * Otherwise we have a real connection error or connection timeout.
 	 */
-	if (status == connect_success) {
+	switch(status) {
+	case connect_in_progress:
+		break;
+	case connect_success:
 		close(thread->u.fd);
-
-		if (!svr_checker_up(checker->id, checker->rs)) {
-			log_message(LOG_INFO, "TCP connection to %s success."
+		tcp_eplilog(thread, 1);
+		break;
+	case connect_timeout:
+		if (svr_checker_up(checker->id, checker->rs))
+			log_message(LOG_INFO, "TCP connection to %s timeout."
 					, FMT_TCP_RS(checker));
-			smtp_alert(checker->rs, NULL, NULL,
-				   "UP",
-				   "=> TCP CHECK succeed on service <=");
-			update_svr_checker_state(UP, checker->id
-						   , checker->vs
-						   , checker->rs);
-		}
-
-	} else {
-
-		if (svr_checker_up(checker->id, checker->rs)) {
-			log_message(LOG_INFO, "TCP connection to %s failed !!!"
+		tcp_eplilog(thread, 0);
+		break;
+	default:
+		if (svr_checker_up(checker->id, checker->rs))
+			log_message(LOG_INFO, "TCP connection to %s failed."
 					, FMT_TCP_RS(checker));
-			smtp_alert(checker->rs, NULL, NULL,
-				   "DOWN",
-				   "=> TCP CHECK failed on service <=");
-			update_svr_checker_state(DOWN, checker->id
-						     , checker->vs
-						     , checker->rs);
-		}
-
+		tcp_eplilog(thread, 0);
 	}
 
-	/* Register next timer checker */
-	if (status != connect_in_progress)
-		thread_add_timer(thread->master, tcp_connect_thread, checker,
-				 checker->vs->delay_loop);
 	return 0;
 }
 

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -88,11 +88,22 @@ ipvs_talk(int cmd)
 	int result;
 	if (result = ipvs_command(cmd, urule))
 		if ((cmd == IP_VS_SO_SET_EDITDEST) &&
-		    (errno == ENOENT))
-			result = ipvs_command(IP_VS_SO_SET_ADDDEST, urule);
-	if (result)
+		    (errno == ENOENT)) {
+			cmd = IP_VS_SO_SET_ADDDEST;
+			result = ipvs_command(cmd, urule);
+		}
+	if (result) {
 		log_message(LOG_INFO, "IPVS : %s", ipvs_strerror(errno));
-	return IPVS_SUCCESS;
+		if (errno == EEXIST &&
+			(cmd == IP_VS_SO_SET_ADD || IP_VS_SO_SET_ADDDEST)
+		)
+			result = 0;
+		else if (errno == ENOENT &&
+			(cmd == IP_VS_SO_SET_DEL || IP_VS_SO_SET_DELDEST)
+		)
+			result = 0;
+	}
+	return result;
 }
 
 int
@@ -122,7 +133,6 @@ static int
 ipvs_group_range_cmd(int cmd, virtual_server_group_entry_t *vsg_entry)
 {
 	uint32_t addr_ip;
-	int err = 0;
 
 	/* Parse the whole range */
 	for (addr_ip = inet_sockaddrip4(&vsg_entry->addr);
@@ -132,10 +142,11 @@ ipvs_group_range_cmd(int cmd, virtual_server_group_entry_t *vsg_entry)
 		urule->vport = inet_sockaddrport(&vsg_entry->addr);
 
 		/* Talk to the IPVS channel */
-		err = ipvs_talk(cmd);
+		if (ipvs_talk(cmd))
+			return -1;
 	}
 
-	return err;
+	return 0;
 }
 
 /* set IPVS group rules */
@@ -146,10 +157,9 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 	virtual_server_group_entry_t *vsg_entry;
 	list l;
 	element e;
-	int err = 1;
 
 	/* return if jointure fails */
-	if (!vsg) return -1;
+	if (!vsg) return 0;
 
 	/* visit addr_ip list */
 	l = vsg->addr_ip;
@@ -160,7 +170,8 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 		/* Talk to the IPVS channel */
 		if (IPVS_ALIVE(cmd, vsg_entry, rs)) {
-			err = ipvs_talk(cmd);
+			if (ipvs_talk(cmd))
+				return -1;
 			IPVS_SET_ALIVE(cmd, vsg_entry);
 		}
 	}
@@ -175,7 +186,8 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 		/* Talk to the IPVS channel */
 		if (IPVS_ALIVE(cmd, vsg_entry, rs)) {
-			err = ipvs_talk(cmd);
+			if (ipvs_talk(cmd))
+				return -1;
 			IPVS_SET_ALIVE(cmd, vsg_entry);
 		}
 	}
@@ -188,12 +200,13 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 		/* Talk to the IPVS channel */
 		if (IPVS_ALIVE(cmd, vsg_entry, rs)) {
-			err = ipvs_group_range_cmd(cmd, vsg_entry);
+			if (ipvs_group_range_cmd(cmd, vsg_entry))
+				return -1;
 			IPVS_SET_ALIVE(cmd, vsg_entry);
 		}
 	}
 
-	return err;
+	return 0;
 }
 
 /* Fill IPVS rule with root vs infos */
@@ -407,7 +420,7 @@ ipvs_stop(void)
 }
 
 /* Send user rules to IPVS module */
-static void
+static int
 ipvs_talk(int cmd)
 {
 	int result = -1;
@@ -439,13 +452,25 @@ ipvs_talk(int cmd)
 			break;
 		case IP_VS_SO_SET_EDITDEST:
 			if ((result = ipvs_update_dest(srule, drule)) &&
-			    (errno == ENOENT))
+			    (errno == ENOENT)) {
+				cmd = IP_VS_SO_SET_ADDDEST;
 				result = ipvs_add_dest(srule, drule);
+			}
 			break;
 	}
 
-	if (result)
+	if (result) {
 		log_message(LOG_INFO, "IPVS: %s", ipvs_strerror(errno));
+		if (errno == EEXIST &&
+			(cmd == IP_VS_SO_SET_ADD || IP_VS_SO_SET_ADDDEST)
+		)
+			result = 0;
+		else if (errno == ENOENT &&
+			(cmd == IP_VS_SO_SET_DEL || IP_VS_SO_SET_DELDEST)
+		)
+			result = 0;
+	}
+	return result;
 }
 
 int
@@ -465,7 +490,7 @@ ipvs_syncd_cmd(int cmd, char *ifname, int state, int syncid)
 }
 
 /* IPVS group range rule */
-static void
+static int
 ipvs_group_range_cmd(int cmd, virtual_server_group_entry_t *vsg_entry)
 {
 	uint32_t addr_ip, ip;
@@ -494,12 +519,15 @@ ipvs_group_range_cmd(int cmd, virtual_server_group_entry_t *vsg_entry)
 		srule->port = inet_sockaddrport(&vsg_entry->addr);
 
 		/* Talk to the IPVS channel */
-		ipvs_talk(cmd);
+		if (ipvs_talk(cmd))
+			return -1;
 	}
+
+	return 0;
 }
 
 /* set IPVS group rules */
-static void
+static int
 ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 {
 	virtual_server_group_t *vsg = vs->vsg;
@@ -508,7 +536,7 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 	element e;
 
 	/* return if jointure fails */
-	if (!vsg) return;
+	if (!vsg) return 0;
 
 	/* visit addr_ip list */
 	l = vsg->addr_ip;
@@ -525,7 +553,8 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 		/* Talk to the IPVS channel */
 		if (IPVS_ALIVE(cmd, vsg_entry, rs)) {
-			ipvs_talk(cmd);
+			if (ipvs_talk(cmd))
+				return -1;
 			IPVS_SET_ALIVE(cmd, vsg_entry);
 		}
 	}
@@ -548,7 +577,8 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 		/* Talk to the IPVS channel */
 		if (IPVS_ALIVE(cmd, vsg_entry, rs)) {
-			ipvs_talk(cmd);
+			if (ipvs_talk(cmd))
+				return -1;
 			IPVS_SET_ALIVE(cmd, vsg_entry);
 		}
 	}
@@ -561,10 +591,12 @@ ipvs_group_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 		/* Talk to the IPVS channel */
 		if (IPVS_ALIVE(cmd, vsg_entry, rs)) {
-			ipvs_group_range_cmd(cmd, vsg_entry);
+			if (ipvs_group_range_cmd(cmd, vsg_entry))
+				return -1;
 			IPVS_SET_ALIVE(cmd, vsg_entry);
 		}
 	}
+	return 0;
 }
 
 /* Fill IPVS rule with root vs infos */
@@ -618,6 +650,8 @@ ipvs_set_rule(int cmd, virtual_server_t * vs, real_server_t * rs)
 int
 ipvs_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 {
+	int err = 0;
+
 	/* Allocate the room */
 	memset(srule, 0, sizeof(ipvs_service_t));
 	ipvs_set_rule(cmd, vs, rs);
@@ -638,7 +672,7 @@ ipvs_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 	/* Set vs rule and send to kernel */
 	if (vs->vsgname) {
-		ipvs_group_cmd(cmd, vs, rs);
+		err = ipvs_group_cmd(cmd, vs, rs);
 	} else {
 		if (vs->vfwmark) {
 			srule->af = AF_INET;
@@ -659,10 +693,10 @@ ipvs_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 		}
 
 		/* Talk to the IPVS channel */
-		ipvs_talk(cmd);
+		err = ipvs_talk(cmd);
 	}
 
-	return IPVS_SUCCESS;
+	return err;
 }
 
 /* add alive destinations to the newly created vsge */

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -106,7 +106,7 @@ ipvs_talk(int cmd)
 	return result;
 }
 
-int
+void
 ipvs_syncd_cmd(int cmd, char *ifname, int state, int syncid)
 {
 #ifdef _HAVE_IPVS_SYNCD_
@@ -120,11 +120,10 @@ ipvs_syncd_cmd(int cmd, char *ifname, int state, int syncid)
 		strncpy(urule->mcast_ifn, ifname, IP_VS_IFNAME_MAXLEN);
 
 	/* Talk to the IPVS channel */
-	return ipvs_talk(cmd);
+	ipvs_talk(cmd);
 
 #else
 	log_message(LOG_INFO, "IPVS : Sync daemon not supported");
-	return IPVS_ERROR;
 #endif
 }
 
@@ -288,11 +287,10 @@ ipvs_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 
 
 /* add alive destinations to the newly created vsge */
-int
+void
 ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 {
 	real_server_t *rs;
-	int err = 0;
 	element e;
 	list l = vs->rs;
 
@@ -323,20 +321,17 @@ ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 				urule->vport = inet_sockaddrport(&vsge->addr);
 
 				/* Talk to the IPVS channel */
-				err = ipvs_talk(IP_VS_SO_SET_ADDDEST);
+				ipvs_talk(IP_VS_SO_SET_ADDDEST);
 			}
 		}
 	}
-
-	return IPVS_SUCCESS;
 }
 
 /* Remove a specific vs group entry */
-int
+void
 ipvs_group_remove_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 {
 	real_server_t *rs;
-	int err = 0;
 	element e;
 	list l = vs->rs;
 
@@ -367,18 +362,17 @@ ipvs_group_remove_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge
 				urule->vport = inet_sockaddrport(&vsge->addr);
 
 				/* Talk to the IPVS channel */
-				err = ipvs_talk(IP_VS_SO_SET_DELDEST);
+				ipvs_talk(IP_VS_SO_SET_DELDEST);
 			}
 		}
 	}
 
 	/* Remove VS entry */
 	if (vsge->range)
-		err = ipvs_group_range_cmd(IP_VS_SO_SET_DEL, vsge);
+		ipvs_group_range_cmd(IP_VS_SO_SET_DEL, vsge);
 	else
-		err = ipvs_talk(IP_VS_SO_SET_DEL);
+		ipvs_talk(IP_VS_SO_SET_DEL);
 	UNSET_ALIVE(vsge);
-	return err;
 }
 
 #else					/* KERNEL 2.6 IPVS handling */
@@ -473,7 +467,7 @@ ipvs_talk(int cmd)
 	return result;
 }
 
-int
+void
 ipvs_syncd_cmd(int cmd, char *ifname, int state, int syncid)
 {
 	memset(daemonrule, 0, sizeof(ipvs_daemon_t));
@@ -486,7 +480,6 @@ ipvs_syncd_cmd(int cmd, char *ifname, int state, int syncid)
 
 	/* Talk to the IPVS channel */
 	ipvs_talk(cmd);
-	return IPVS_SUCCESS;
 }
 
 /* IPVS group range rule */
@@ -700,7 +693,7 @@ ipvs_cmd(int cmd, virtual_server_t * vs, real_server_t * rs)
 }
 
 /* add alive destinations to the newly created vsge */
-int
+void
 ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 {
 	real_server_t *rs;
@@ -749,12 +742,10 @@ ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 			}
 		}
 	}
-
-	return IPVS_SUCCESS;
 }
 
 /* Remove a specific vs group entry */
-int
+void
 ipvs_group_remove_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 {
 	real_server_t *rs;
@@ -810,8 +801,6 @@ ipvs_group_remove_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge
 	else
 		ipvs_talk(IP_VS_SO_SET_DEL);
 	UNSET_ALIVE(vsge);
-
-	return IPVS_SUCCESS;
 }
 
 #ifdef _WITH_SNMP_

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -551,8 +551,7 @@ clear_diff_vsge(list old, list new, virtual_server_t * old_vs)
 					    , vsge->vfwmark
 					    , old_vs->vsgname);
 
-			if (!ipvs_group_remove_entry(old_vs, vsge))
-				return 0;
+			ipvs_group_remove_entry(old_vs, vsge);
 		}
 	}
 

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -118,6 +118,7 @@ typedef struct _virtual_server {
 	struct sockaddr_storage		addr;
 	real_server_t			*s_svr;
 	uint32_t			vfwmark;
+	uint16_t			af;
 	uint16_t			service_type;
 	long				delay_loop;
 	int				ha_suspend;
@@ -219,6 +220,7 @@ static inline int inaddr_equal(sa_family_t family, void *addr1, void *addr2)
 
 #define VS_ISEQ(X,Y)	(sockstorage_equal(&(X)->addr,&(Y)->addr)			&&\
 			 (X)->vfwmark                 == (Y)->vfwmark			&&\
+			 (X)->af                      == (Y)->af                        &&\
 			 (X)->service_type            == (Y)->service_type		&&\
 			 (X)->loadbalancing_kind      == (Y)->loadbalancing_kind	&&\
 			 (X)->nat_mask                == (Y)->nat_mask			&&\

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -71,6 +71,8 @@ typedef struct _real_server {
 	struct sockaddr_storage		addr;
 	int				weight;
 	int				iweight;	/* Initial weight */
+	int 				pweight;	/* previous weight
+							 * used for reloading */
 #ifdef _KRNL_2_6_
 	uint32_t			u_threshold;   /* Upper connection limit. */
 	uint32_t			l_threshold;   /* Lower connection limit. */
@@ -234,8 +236,7 @@ static inline int inaddr_equal(sa_family_t family, void *addr1, void *addr2)
 			 (X)->range     == (Y)->range &&		\
 			 (X)->vfwmark   == (Y)->vfwmark)
 
-#define RS_ISEQ(X,Y)	(sockstorage_equal(&(X)->addr,&(Y)->addr) &&	\
-			 (X)->iweight   == (Y)->iweight)
+#define RS_ISEQ(X,Y)	(sockstorage_equal(&(X)->addr,&(Y)->addr))
 
 /* Global vars exported */
 extern check_data_t *check_data;

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -94,7 +94,7 @@ typedef struct _http_checker {
 /* Define prototypes */
 extern void install_http_check_keyword(void);
 extern int epilog(thread_t *, int, int, int);
-extern int timeout_epilog(thread_t *, char *, char *);
+extern int timeout_epilog(thread_t *, char *);
 extern url_t *fetch_next_url(http_checker_t *);
 extern int http_process_response(request_t *, int);
 extern int http_handle_response(thread_t *, unsigned char digest[16]

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -96,7 +96,7 @@ extern void install_http_check_keyword(void);
 extern int epilog(thread_t *, int, int, int);
 extern int timeout_epilog(thread_t *, char *);
 extern url_t *fetch_next_url(http_checker_t *);
-extern int http_process_response(request_t *, int);
+extern int http_process_response(request_t *, int, int);
 extern int http_handle_response(thread_t *, unsigned char digest[16]
 				, int);
 #endif

--- a/keepalived/include/check_tcp.h
+++ b/keepalived/include/check_tcp.h
@@ -31,6 +31,12 @@
 /* local includes */
 #include "scheduler.h"
 
+typedef struct _tcp_check {
+	int n_retry;
+	long delay_before_retry;
+	int retry_it;
+} tcp_check_t;
+
 /* macro utility */
 #define FMT_TCP_RS(C) FMT_CHK(C)
 

--- a/keepalived/include/ipvswrapper.h
+++ b/keepalived/include/ipvswrapper.h
@@ -92,10 +92,10 @@ do {						\
 extern int ipvs_start(void);
 extern void ipvs_stop(void);
 extern virtual_server_group_t *ipvs_get_group_by_name(char *, list);
-extern int ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge);
-extern int ipvs_group_remove_entry(virtual_server_t *, virtual_server_group_entry_t *);
+extern void ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge);
+extern void ipvs_group_remove_entry(virtual_server_t *, virtual_server_group_entry_t *);
 extern int ipvs_cmd(int, virtual_server_t *, real_server_t *);
-extern int ipvs_syncd_cmd(int, char *, int, int);
+extern void ipvs_syncd_cmd(int, char *, int, int);
 extern void ipvs_syncd_master(char *, int);
 extern void ipvs_syncd_backup(char *, int);
 

--- a/keepalived/include/ipwrapper.h
+++ b/keepalived/include/ipwrapper.h
@@ -49,7 +49,7 @@
 #define LVS_CMD_EDIT_DEST	IP_VS_SO_SET_EDITDEST
 
 /* prototypes */
-extern void perform_svr_state(int, virtual_server_t *, real_server_t *);
+extern int perform_svr_state(int, virtual_server_t *, real_server_t *);
 extern void update_svr_wgt(int, virtual_server_t *, real_server_t *);
 extern int svr_checker_up(checker_id_t, real_server_t *);
 extern void update_svr_checker_state(int, checker_id_t, virtual_server_t *, real_server_t *);

--- a/keepalived/include/ipwrapper.h
+++ b/keepalived/include/ipwrapper.h
@@ -50,7 +50,7 @@
 
 /* prototypes */
 extern int perform_svr_state(int, virtual_server_t *, real_server_t *);
-extern void update_svr_wgt(int, virtual_server_t *, real_server_t *);
+extern void update_svr_wgt(int, virtual_server_t *, real_server_t *, int);
 extern int svr_checker_up(checker_id_t, real_server_t *);
 extern void update_svr_checker_state(int, checker_id_t, virtual_server_t *, real_server_t *);
 extern int init_services(void);

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -618,7 +618,8 @@ retry:	/* When thread can't fetch try to find next thread again. */
 			thread_list_delete(&m->child, t);
 			thread_list_add(&m->ready, t);
 			t->type = THREAD_CHILD_TIMEOUT;
-		}
+		} else
+			break;
 	}
 
 	/* Read thead. */
@@ -683,7 +684,8 @@ retry:	/* When thread can't fetch try to find next thread again. */
 			thread_list_delete(&m->timer, t);
 			thread_list_add(&m->ready, t);
 			t->type = THREAD_READY;
-		}
+		} else
+			break;
 	}
 
 	/* Return one event. */

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -34,7 +34,7 @@ timer_dup(timeval_t b)
 {
 	timeval_t a;
 
-	timer_reset(a);
+	timer_reset_lazy(a);
 	a.tv_sec = b.tv_sec;
 	a.tv_usec = b.tv_usec;
 	return a;
@@ -44,15 +44,10 @@ timer_dup(timeval_t b)
 int
 timer_cmp(timeval_t a, timeval_t b)
 {
-	if (a.tv_sec > b.tv_sec)
-		return 1;
-	if (a.tv_sec < b.tv_sec)
-		return -1;
-	if (a.tv_usec > b.tv_usec)
-		return 1;
-	if (a.tv_usec < b.tv_usec)
-		return -1;
-	return 0;
+	int ret = a.tv_sec - b.tv_sec;
+	if (! ret)
+		return a.tv_usec - b.tv_usec;
+	return ret;
 }
 
 /* timer sub */
@@ -61,7 +56,7 @@ timer_sub(timeval_t a, timeval_t b)
 {
 	timeval_t ret;
 
-	timer_reset(ret);
+	timer_reset_lazy(ret);
 	ret.tv_usec = a.tv_usec - b.tv_usec;
 	ret.tv_sec = a.tv_sec - b.tv_sec;
 
@@ -79,7 +74,7 @@ timer_add(timeval_t a, timeval_t b)
 {
 	timeval_t ret;
 
-	timer_reset(ret);
+	timer_reset_lazy(ret);
 	ret.tv_usec = a.tv_usec + b.tv_usec;
 	ret.tv_sec = a.tv_sec + b.tv_sec;
 
@@ -96,7 +91,7 @@ timer_add_long(timeval_t a, long b)
 {
 	timeval_t ret;
 
-	timer_reset(ret);
+	timer_reset_lazy(ret);
 	ret.tv_usec = a.tv_usec + b % TIMER_HZ;
 	ret.tv_sec = a.tv_sec + b / TIMER_HZ;
 
@@ -128,43 +123,30 @@ int monotonic_gettimeofday(timeval_t *now)
 		return -1;
 	}
 
+	timer_reset_lazy(*now);
+
 	gettimeofday(&sys_date, NULL);
 
 	/* on first call, we set mono_date to system date */
 	if (mono_date.tv_sec == 0) {
 		mono_date = sys_date;
-		drift.tv_sec = drift.tv_usec = 0;
+		timer_reset(drift);
 		*now = mono_date;
 		return 0;
 	}
 
 	/* compute new adjusted time by adding the drift offset */
-	adjusted.tv_sec  = sys_date.tv_sec  + drift.tv_sec;
-	adjusted.tv_usec = sys_date.tv_usec + drift.tv_usec;
-	if (adjusted.tv_usec >= TIMER_HZ) {
-		adjusted.tv_usec -= TIMER_HZ;
-		adjusted.tv_sec++;
-	}
+	adjusted = timer_add(sys_date, drift);
 
 	/* check for jumps in the past, and bound to last date */
-	if (adjusted.tv_sec  <  mono_date.tv_sec ||
-	    (adjusted.tv_sec  == mono_date.tv_sec &&
-	     adjusted.tv_usec <  mono_date.tv_usec))
+	if (timer_cmp(adjusted, mono_date) < 0)
 		goto fixup;
 
 	/* check for jumps too far in the future, and bound them to
 	 * TIME_MAX_FORWARD_US microseconds.
 	 */
-	deadline.tv_sec  = mono_date.tv_sec  + TIME_MAX_FORWARD_US / TIMER_HZ;
-	deadline.tv_usec = mono_date.tv_usec + TIME_MAX_FORWARD_US % TIMER_HZ;
-	if (deadline.tv_usec >= TIMER_HZ) {
-		deadline.tv_usec -= TIMER_HZ;
-		deadline.tv_sec++;
-	}
-
-	if (adjusted.tv_sec  >  deadline.tv_sec ||
-	    (adjusted.tv_sec  == deadline.tv_sec &&
-	     adjusted.tv_usec >= deadline.tv_usec)) {
+	deadline = timer_add_long(mono_date, TIME_MAX_FORWARD_US);
+	if (timer_cmp (adjusted, deadline) >= 0) {
 		mono_date = deadline;
 		goto fixup;
 	}
@@ -180,12 +162,7 @@ int monotonic_gettimeofday(timeval_t *now)
 	 * play with negative carries in all computations, we take
 	 * care of always having the microseconds positive.
 	 */
-	drift.tv_sec  = mono_date.tv_sec  - sys_date.tv_sec;
-	drift.tv_usec = mono_date.tv_usec - sys_date.tv_usec;
-	if (drift.tv_usec < 0) {
-		drift.tv_usec += TIMER_HZ;
-		drift.tv_sec--;
-	}
+	drift = timer_sub(mono_date, sys_date);
 	*now = mono_date;
 	return 0;
 }
@@ -198,9 +175,10 @@ timer_now(void)
 	int old_errno = errno;
 
 	/* init timer */
-	timer_reset(curr_time);
-	monotonic_gettimeofday(&curr_time);
-	errno = old_errno;
+	if (monotonic_gettimeofday(&curr_time)) {
+		timer_reset(curr_time);
+		errno = old_errno;
+	}
 
 	return curr_time;
 }
@@ -212,9 +190,10 @@ set_time_now(void)
 	int old_errno = errno;
 
 	/* init timer */
-	timer_reset(time_now);
-	monotonic_gettimeofday(&time_now);
-	errno = old_errno;
+	if (monotonic_gettimeofday(&time_now)) {
+		timer_reset(time_now);
+		errno = old_errno;
+	}
 
 	return time_now;
 }

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -33,7 +33,7 @@ extern timeval_t time_now;
 /* Some defines */
 #define TIME_MAX_FORWARD_US	2000000
 #define TIMER_HZ		1000000
-#define TIMER_CENTI_HZ          10000
+#define TIMER_CENTI_HZ		10000
 #define TIMER_MAX_SEC		1000
 
 /* Some usefull macros */
@@ -41,6 +41,12 @@ extern timeval_t time_now;
 #define timer_long(T) ((T).tv_sec * TIMER_HZ + (T).tv_usec)
 #define timer_isnull(T) ((T).tv_sec == 0 && (T).tv_usec == 0)
 #define timer_reset(T) (memset(&(T), 0, sizeof(timeval_t)))
+/* call this instead of timer_reset() when you intend to set
+ * all the fields of timeval manually afterwards. */
+#define timer_reset_lazy(T) do { \
+	if ( sizeof((T)) != sizeof((T).tv_sec) + sizeof((T).tv_usec) ) \
+		timer_reset((T)); \
+	} while (0)
 
 /* prototypes */
 extern timeval_t timer_now(void);


### PR DESCRIPTION
Hi, Alexandre.

Please consider these changes:
1. Http retry logic refined, tcp retry feature added
2. ipvs reflector respects kernel result code
3. fix re-adding RS caused by rs weight change on reload
4. ip family config option for a fwmak service
5. Some minor optimizations around scheduler