### PR TITLE
Added vrrp 'timeout' to synopsis

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -89,6 +89,7 @@ This block is divided in 3 sub-block :
 vrrp_script <STRING> {          # VRRP script declaration
     script <QUOTED_STRING>      # script to run periodically
     interval <INTEGER>          # run the script this every seconds
+    timeout <INTEGER>           # script considered failed after 'timeout' seconds
     weight <INTEGER:-254..254>  # adjust priority by this weight
     fall <INTEGER>              # required number of failures for KO switch
     rise <INTEGER>              # required number of successes for OK switch


### PR DESCRIPTION
A new vrrp 'timeout' parameter was added in version 1.2.6 (Git
commit: 019ad5b3a3e4a21a36ca570d370bbaaa34536283 ) but not documented
in the big keepalived.conf.SYNOPSIS example file.