### PR TITLE
SNMP fixes/cleanup

### DIFF
--- a/doc/KEEPALIVED-MIB
+++ b/doc/KEEPALIVED-MIB
@@ -12,7 +12,7 @@ IMPORTS
     Gauge32, enterprises, NOTIFICATION-TYPE
         FROM SNMPv2-SMI
     OBJECT-GROUP, MODULE-COMPLIANCE, NOTIFICATION-GROUP
-    	FROM SNMPv2-CONF
+        FROM SNMPv2-CONF
     InetAddressType, InetAddress, InetPortNumber,
     InetAddressPrefixLength, InetScopeType
         FROM INET-ADDRESS-MIB
@@ -22,13 +22,13 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201208240000Z"
+     LAST-UPDATED "201510270000Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
-     REVISION "201208240000Z"
+     REVISION "201510270000Z"
      DESCRIPTION "routerId added to traps variables"
      REVISION "200904080000Z"
      DESCRIPTION "Initial revision"
@@ -36,25 +36,25 @@ keepalived MODULE-IDENTITY
      ::= { project 5 }
 
 -- We are hosted under Debian OID. See http://dsa.debian.org/iana/
-debian			OBJECT IDENTIFIER ::= { enterprises 9586 }
-project			OBJECT IDENTIFIER ::= { debian 100 }
+debian          OBJECT IDENTIFIER ::= { enterprises 9586 }
+project         OBJECT IDENTIFIER ::= { debian 100 }
 
 VrrpState ::= TEXTUAL-CONVENTION
     STATUS       current
     DESCRIPTION
-	"Represents a VRRP state."
+    "Represents a VRRP state."
     SYNTAX INTEGER {
-    	init(0),
-	backup(1),
-	master(2),
-	fault(3),
-	unknown(4)
-	}
+        init(0),
+    backup(1),
+    master(2),
+    fault(3),
+    unknown(4)
+    }
 
-global			OBJECT IDENTIFIER ::= { keepalived 1 }
-vrrp                    OBJECT IDENTIFIER ::= { keepalived 2 }
-check                   OBJECT IDENTIFIER ::= { keepalived 3 }
-conformance		OBJECT IDENTIFIER ::= { keepalived 4 }
+global          OBJECT IDENTIFIER ::= { keepalived 1 }
+vrrp            OBJECT IDENTIFIER ::= { keepalived 2 }
+check           OBJECT IDENTIFIER ::= { keepalived 3 }
+conformance     OBJECT IDENTIFIER ::= { keepalived 4 }
 
 -- ----------------------------------------------------------------------
 -- Global part
@@ -65,7 +65,7 @@ version OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-    	"Version of keepalived"
+        "Version of keepalived"
     ::= { global 1 }
 
 routerId OBJECT-TYPE
@@ -73,17 +73,17 @@ routerId OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-    	"Router ID"
+        "Router ID"
     ::= { global 2 }
 
-mail	OBJECT IDENTIFIER ::= { global 3 }
+mail    OBJECT IDENTIFIER ::= { global 3 }
 
 smtpServerAddressType OBJECT-TYPE
     SYNTAX InetAddressType
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-    	"Address type for SMTP server."
+        "Address type for SMTP server."
     ::= { mail 1 }
 
 smtpServerAddress OBJECT-TYPE
@@ -91,7 +91,7 @@ smtpServerAddress OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-    	"Address of SMTP server."
+        "Address of SMTP server."
     ::= { mail 2 }
 
 smtpServerTimeout OBJECT-TYPE
@@ -100,7 +100,7 @@ smtpServerTimeout OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-    	"SMTP server connection timeout."
+        "SMTP server connection timeout."
     ::= { mail 3 }
 
 emailFrom OBJECT-TYPE
@@ -108,7 +108,7 @@ emailFrom OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-    	"Email address for the From field."
+        "Email address for the From field."
     ::= { mail 4 }
 
 emailTable OBJECT-TYPE
@@ -116,7 +116,7 @@ emailTable OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Table of email notification addresses."
+        "Table of email notification addresses."
     ::= { mail 5 }
 
 emailEntry OBJECT-TYPE
@@ -124,13 +124,13 @@ emailEntry OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Email address to be notified with an alert."
+        "Email address to be notified with an alert."
     INDEX { emailIndex }
     ::= { emailTable 1 }
 
 EmailEntry ::= SEQUENCE {
-	emailIndex Integer32,
-	emailAddress DisplayString
+    emailIndex Integer32,
+    emailAddress DisplayString
 }
 
 emailIndex OBJECT-TYPE
@@ -138,7 +138,7 @@ emailIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index for the email address."
+        "Index for the email address."
     ::= { emailEntry 1 }
 
 emailAddress OBJECT-TYPE
@@ -146,7 +146,7 @@ emailAddress OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Email address to be notified when an alert is raised."
+        "Email address to be notified when an alert is raised."
     ::= { emailEntry 2 }
 
 trapEnable OBJECT-TYPE
@@ -154,7 +154,7 @@ trapEnable OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Indicate whether traps should be sent for various events."
+        "Indicate whether traps should be sent for various events."
     ::= { global 4 }
 
 linkBeat OBJECT-TYPE
@@ -162,10 +162,10 @@ linkBeat OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Indicate which method is used to check if a link is up or
-	down. netlink(1) means that the kernel will push a link state
-	change while polling(2) means that the status of the link is
-	checked periodically."
+        "Indicate which method is used to check if a link is up or
+        down. netlink(1) means that the kernel will push a link state
+        change while polling(2) means that the status of the link is
+        checked periodically."
     ::= { global 5 }
 
 -- ----------------------------------------------------------------------
@@ -193,15 +193,15 @@ vrrpSyncGroupEntry OBJECT-TYPE
     ::= { vrrpSyncGroupTable 1 }
 
 VrrpSyncGroupEntry ::= SEQUENCE {
-	vrrpSyncGroupIndex Integer32,
-	vrrpSyncGroupName DisplayString,
-	vrrpSyncGroupState VrrpState,
-	vrrpSyncGroupSmtpAlert INTEGER,
-	vrrpSyncGroupNotifyExec INTEGER,
-	vrrpSyncGroupScriptMaster DisplayString,
-	vrrpSyncGroupScriptBackup DisplayString,
-	vrrpSyncGroupScriptFault DisplayString,
-	vrrpSyncGroupScript DisplayString
+    vrrpSyncGroupIndex Integer32,
+    vrrpSyncGroupName DisplayString,
+    vrrpSyncGroupState VrrpState,
+    vrrpSyncGroupSmtpAlert INTEGER,
+    vrrpSyncGroupNotifyExec INTEGER,
+    vrrpSyncGroupScriptMaster DisplayString,
+    vrrpSyncGroupScriptBackup DisplayString,
+    vrrpSyncGroupScriptFault DisplayString,
+    vrrpSyncGroupScript DisplayString
 }
 
 vrrpSyncGroupIndex OBJECT-TYPE
@@ -209,7 +209,7 @@ vrrpSyncGroupIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of the synchronisation group."
+        "Index of the synchronisation group."
     ::= { vrrpSyncGroupEntry 1 }
 
 vrrpSyncGroupName OBJECT-TYPE
@@ -217,7 +217,7 @@ vrrpSyncGroupName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the synchronisation group."
+        "Name of the synchronisation group."
     ::= {vrrpSyncGroupEntry 2 }
 
 vrrpSyncGroupState OBJECT-TYPE
@@ -225,7 +225,7 @@ vrrpSyncGroupState OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current state of the synchronisation group."
+        "Current state of the synchronisation group."
     ::= {vrrpSyncGroupEntry 3 }
 
 vrrpSyncGroupSmtpAlert OBJECT-TYPE
@@ -233,7 +233,7 @@ vrrpSyncGroupSmtpAlert OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Will SMTP alert be sent for this synchronisation group?"
+        "Will SMTP alert be sent for this synchronisation group?"
     ::= {vrrpSyncGroupEntry 4 }
 
 vrrpSyncGroupNotifyExec OBJECT-TYPE
@@ -241,7 +241,7 @@ vrrpSyncGroupNotifyExec OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Will we execute notification script for this group?"
+        "Will we execute notification script for this group?"
     ::= {vrrpSyncGroupEntry 5 }
 
 vrrpSyncGroupScriptMaster OBJECT-TYPE
@@ -249,7 +249,7 @@ vrrpSyncGroupScriptMaster OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute when the group becomes master."
+        "Script to execute when the group becomes master."
     ::= {vrrpSyncGroupEntry 6 }
 
 vrrpSyncGroupScriptBackup OBJECT-TYPE
@@ -257,7 +257,7 @@ vrrpSyncGroupScriptBackup OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute when the group becomes backup."
+        "Script to execute when the group becomes backup."
     ::= {vrrpSyncGroupEntry 7 }
 
 vrrpSyncGroupScriptFault OBJECT-TYPE
@@ -265,7 +265,7 @@ vrrpSyncGroupScriptFault OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute when the group is in fault state."
+        "Script to execute when the group is in fault state."
     ::= {vrrpSyncGroupEntry 8 }
 
 vrrpSyncGroupScript OBJECT-TYPE
@@ -273,7 +273,7 @@ vrrpSyncGroupScript OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute whenever a state change occurs."
+        "Script to execute whenever a state change occurs."
     ::= {vrrpSyncGroupEntry 9 }
 
 vrrpSyncGroupMemberTable OBJECT-TYPE
@@ -294,8 +294,8 @@ vrrpSyncGroupMemberEntry OBJECT-TYPE
     ::= { vrrpSyncGroupMemberTable 1 }
 
 VrrpSyncGroupMemberEntry ::= SEQUENCE {
-	vrrpSyncGroupMemberInstanceIndex Integer32,
-	vrrpSyncGroupMemberName DisplayString
+    vrrpSyncGroupMemberInstanceIndex Integer32,
+    vrrpSyncGroupMemberName DisplayString
 }
 
 vrrpSyncGroupMemberInstanceIndex OBJECT-TYPE
@@ -303,10 +303,10 @@ vrrpSyncGroupMemberInstanceIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of an instance in a synchronisation group.
-	 There is no relation with this index and the index of the
-	 corresponding instance in vrrpInstanceTable. Use the name
-	 to find out the corresponding instance."
+        "Index of an instance in a synchronisation group.
+         There is no relation with this index and the index of the
+         corresponding instance in vrrpInstanceTable. Use the name
+         to find out the corresponding instance."
     ::= { vrrpSyncGroupMemberEntry 1 }
 
 vrrpSyncGroupMemberName OBJECT-TYPE
@@ -314,7 +314,7 @@ vrrpSyncGroupMemberName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the instance contained in the synchronisation group."
+        "Name of the instance contained in the synchronisation group."
     ::= { vrrpSyncGroupMemberEntry 2 }
 
 -- VRRP instances
@@ -338,45 +338,44 @@ vrrpInstanceEntry OBJECT-TYPE
     ::= { vrrpInstanceTable 1 }
 
 VrrpInstanceEntry ::= SEQUENCE {
-	vrrpInstanceIndex INTEGER,
-	vrrpInstanceName DisplayString,
-	vrrpInstanceVirtualRouterId Unsigned32,
-	vrrpInstanceState VrrpState,
-	vrrpInstanceInitialState VrrpState,
-	vrrpInstanceWantedState VrrpState,
-	vrrpInstanceBasePriority Integer32,
-	vrrpInstanceEffectivePriority Integer32,
-	vrrpInstanceVipsStatus INTEGER,
-	vrrpInstancePrimaryInterface DisplayString,
-	vrrpInstanceTrackPrimaryIf INTEGER,
-	vrrpInstanceAdvertisementsInt Unsigned32,
-	vrrpInstancePreempt INTEGER,
-	vrrpInstancePreemptDelay Unsigned32,
-	vrrpInstanceAuthType INTEGER,
-	vrrpInstanceLvsSyncDaemon INTEGER,
-	vrrpInstanceLvsSyncInterface DisplayString,
-	vrrpInstanceSyncGroup DisplayString,
-	vrrpInstanceGarpDelay Unsigned32,
-	vrrpInstanceSmtpAlert INTEGER,
-	vrrpInstanceNotifyExec INTEGER,
-	vrrpInstanceScriptMaster DisplayString,
-	vrrpInstanceScriptBackup DisplayString,
-	vrrpInstanceScriptFault DisplayString,
-	vrrpInstanceScriptStop DisplayString,
-	vrrpInstanceScript DisplayString,
-	vrrpInstanceAccept INTEGER
+    vrrpInstanceIndex INTEGER,
+    vrrpInstanceName DisplayString,
+    vrrpInstanceVirtualRouterId Unsigned32,
+    vrrpInstanceState VrrpState,
+    vrrpInstanceInitialState VrrpState,
+    vrrpInstanceWantedState VrrpState,
+    vrrpInstanceBasePriority Integer32,
+    vrrpInstanceEffectivePriority Integer32,
+    vrrpInstanceVipsStatus INTEGER,
+    vrrpInstancePrimaryInterface DisplayString,
+    vrrpInstanceTrackPrimaryIf INTEGER,
+    vrrpInstanceAdvertisementsInt Unsigned32,
+    vrrpInstancePreempt INTEGER,
+    vrrpInstancePreemptDelay Unsigned32,
+    vrrpInstanceAuthType INTEGER,
+    vrrpInstanceLvsSyncDaemon INTEGER,
+    vrrpInstanceLvsSyncInterface DisplayString,
+    vrrpInstanceSyncGroup DisplayString,
+    vrrpInstanceGarpDelay Unsigned32,
+    vrrpInstanceSmtpAlert INTEGER,
+    vrrpInstanceNotifyExec INTEGER,
+    vrrpInstanceScriptMaster DisplayString,
+    vrrpInstanceScriptBackup DisplayString,
+    vrrpInstanceScriptFault DisplayString,
+    vrrpInstanceScriptStop DisplayString,
+    vrrpInstanceScript DisplayString,
+    vrrpInstanceAccept INTEGER
 }
 
 vrrpInstanceIndex OBJECT-TYPE
     SYNTAX INTEGER {
-    	static(0)
-	}
+        static(0)
+    }
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of the VRRP instance.
-
-	 Instance 0 is for static IP and static routes."
+        "Index of the VRRP instance.
+         Instance 0 is for static IP and static routes."
     ::= { vrrpInstanceEntry 1 }
 
 vrrpInstanceName OBJECT-TYPE
@@ -384,7 +383,7 @@ vrrpInstanceName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the VRRP instance."
+        "Name of the VRRP instance."
     ::= { vrrpInstanceEntry 2 }
 
 vrrpInstanceVirtualRouterId OBJECT-TYPE
@@ -392,7 +391,7 @@ vrrpInstanceVirtualRouterId OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Virtual Router ID (VRID) for this VRRP instance."
+        "Virtual Router ID (VRID) for this VRRP instance."
     ::= { vrrpInstanceEntry 3 }
 
 vrrpInstanceState OBJECT-TYPE
@@ -400,7 +399,7 @@ vrrpInstanceState OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current state of this VRRP instance."
+        "Current state of this VRRP instance."
     ::= { vrrpInstanceEntry 4 }
 
 vrrpInstanceInitialState OBJECT-TYPE
@@ -408,7 +407,7 @@ vrrpInstanceInitialState OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Initial state of this VRRP instance."
+        "Initial state of this VRRP instance."
     ::= { vrrpInstanceEntry 5 }
 
 vrrpInstanceWantedState OBJECT-TYPE
@@ -416,7 +415,7 @@ vrrpInstanceWantedState OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"State wanted by the operator for this VRRP instance."
+        "State wanted by the operator for this VRRP instance."
     ::= { vrrpInstanceEntry 6 }
 
 vrrpInstanceBasePriority OBJECT-TYPE
@@ -424,12 +423,10 @@ vrrpInstanceBasePriority OBJECT-TYPE
     MAX-ACCESS read-write
     STATUS current
     DESCRIPTION
-	"Base priority (as defined in the configuration file) for this
-	 VRRP instance.
-
-	 This value can be modified to force the virtual router
-	 instance to become backup or master.
-	 "
+        "Base priority (as defined in the configuration file) for this
+         VRRP instance.
+         This value can be modified to force the virtual router
+         instance to become backup or master."
     ::= { vrrpInstanceEntry 7 }
 
 vrrpInstanceEffectivePriority OBJECT-TYPE
@@ -437,9 +434,9 @@ vrrpInstanceEffectivePriority OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Effective priority for this VRRP instance. Status of
-	 interfaces and script results are used to compute this value
-	 from the base priority."
+        "Effective priority for this VRRP instance. Status of
+         interfaces and script results are used to compute this value
+         from the base priority."
     ::= { vrrpInstanceEntry 8 }
 
 vrrpInstanceVipsStatus OBJECT-TYPE
@@ -447,7 +444,7 @@ vrrpInstanceVipsStatus OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Are all VIP of this VRRP instance enabled?"
+        "Are all VIP of this VRRP instance enabled?"
     ::= { vrrpInstanceEntry 9 }
 
 vrrpInstancePrimaryInterface OBJECT-TYPE
@@ -455,7 +452,7 @@ vrrpInstancePrimaryInterface OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Primary interface of this VRRP instance."
+        "Primary interface of this VRRP instance."
     ::= { vrrpInstanceEntry 10 }
 
 vrrpInstanceTrackPrimaryIf OBJECT-TYPE
@@ -463,7 +460,7 @@ vrrpInstanceTrackPrimaryIf OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Do we track the status of the primary interface?"
+        "Do we track the status of the primary interface?"
     ::= { vrrpInstanceEntry 11 }
 
 vrrpInstanceAdvertisementsInt OBJECT-TYPE
@@ -472,7 +469,7 @@ vrrpInstanceAdvertisementsInt OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Delay in seconds between two VRRP advertisements and it is in centiseconds between two VRRPV3 advertisements"
+        "Delay in seconds between two VRRP advertisements and it is in centiseconds between two VRRPV3 advertisements"
     ::= { vrrpInstanceEntry 12 }
 
 vrrpInstancePreempt OBJECT-TYPE
@@ -480,7 +477,7 @@ vrrpInstancePreempt OBJECT-TYPE
     MAX-ACCESS read-write
     STATUS current
     DESCRIPTION
-	"Will a higher priority advertisement preempt a lower instance?"
+        "Will a higher priority advertisement preempt a lower instance?"
     ::= { vrrpInstanceEntry 13 }
 
 vrrpInstancePreemptDelay OBJECT-TYPE
@@ -489,20 +486,19 @@ vrrpInstancePreemptDelay OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Delay after startup until preemption can happen. 0 means that
-	 there is no delay."
+        "Delay after startup until preemption can happen. 0 means that there is no delay."
     ::= { vrrpInstanceEntry 14 }
 
 vrrpInstanceAuthType OBJECT-TYPE
     SYNTAX INTEGER {
-    		none(0),
-		password(1),
-		ah(2)
-		}
+            none(0),
+        password(1),
+        ah(2)
+        }
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"VRRPv2 supports authentication method to authenticate other peers. VRRPv3 does not support authentication"
+        "VRRPv2 supports authentication method to authenticate other peers. VRRPv3 does not support authentication"
     ::= { vrrpInstanceEntry 15 }
 
 vrrpInstanceLvsSyncDaemon OBJECT-TYPE
@@ -510,7 +506,7 @@ vrrpInstanceLvsSyncDaemon OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Is LVS sync daemon enabled for this VRRP instance?"
+        "Is LVS sync daemon enabled for this VRRP instance?"
     ::= { vrrpInstanceEntry 16 }
 
 vrrpInstanceLvsSyncInterface OBJECT-TYPE
@@ -518,7 +514,7 @@ vrrpInstanceLvsSyncInterface OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If LVS sync daemon is enabled, which interface to use for syncing?"
+        "If LVS sync daemon is enabled, which interface to use for syncing?"
     ::= { vrrpInstanceEntry 17 }
 
 vrrpInstanceSyncGroup OBJECT-TYPE
@@ -526,7 +522,7 @@ vrrpInstanceSyncGroup OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the synchronisation group this VRRP instance belongs, if any."
+        "Name of the synchronisation group this VRRP instance belongs, if any."
     ::= { vrrpInstanceEntry 18 }
 
 vrrpInstanceGarpDelay OBJECT-TYPE
@@ -535,7 +531,7 @@ vrrpInstanceGarpDelay OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Delay to launch gratuitous ARP (GARP)."
+        "Delay to launch gratuitous ARP (GARP)."
     ::= { vrrpInstanceEntry 19 }
 
 vrrpInstanceSmtpAlert OBJECT-TYPE
@@ -543,7 +539,7 @@ vrrpInstanceSmtpAlert OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Will SMTP alert be sent for this VRRP instance?"
+        "Will SMTP alert be sent for this VRRP instance?"
     ::= { vrrpInstanceEntry 20 }
 
 vrrpInstanceNotifyExec OBJECT-TYPE
@@ -551,7 +547,7 @@ vrrpInstanceNotifyExec OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Will we execute notification script for this instance?"
+        "Will we execute notification script for this instance?"
     ::= { vrrpInstanceEntry 21 }
 
 vrrpInstanceScriptMaster OBJECT-TYPE
@@ -559,7 +555,7 @@ vrrpInstanceScriptMaster OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute when the instance becomes master."
+        "Script to execute when the instance becomes master."
     ::= { vrrpInstanceEntry 22 }
 
 vrrpInstanceScriptBackup OBJECT-TYPE
@@ -567,7 +563,7 @@ vrrpInstanceScriptBackup OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute when the instance becomes backup."
+        "Script to execute when the instance becomes backup."
     ::= { vrrpInstanceEntry 23 }
 
 vrrpInstanceScriptFault OBJECT-TYPE
@@ -575,7 +571,7 @@ vrrpInstanceScriptFault OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute when the instance is in fault state."
+        "Script to execute when the instance is in fault state."
     ::= { vrrpInstanceEntry 24 }
 
 vrrpInstanceScriptStop OBJECT-TYPE
@@ -583,7 +579,7 @@ vrrpInstanceScriptStop OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute when the instance is stopped."
+        "Script to execute when the instance is stopped."
     ::= { vrrpInstanceEntry 25 }
 
 vrrpInstanceScript OBJECT-TYPE
@@ -591,7 +587,7 @@ vrrpInstanceScript OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Script to execute whenever a state change occurs."
+        "Script to execute whenever a state change occurs."
     ::= { vrrpInstanceEntry 26 }
 
 vrrpInstanceAccept OBJECT-TYPE
@@ -599,7 +595,7 @@ vrrpInstanceAccept OBJECT-TYPE
     MAX-ACCESS read-write
     STATUS current
     DESCRIPTION
-	"Accept allow the non-master owner to process the packets destined to VIP and it is supported for only VRRPv3."
+        "Accept allow the non-master owner to process the packets destined to VIP and it is supported for only VRRPv3."
     ::= { vrrpInstanceEntry 27 }
 
 vrrpTrackedInterfaceTable OBJECT-TYPE
@@ -620,8 +616,8 @@ vrrpTrackedInterfaceEntry OBJECT-TYPE
     ::= { vrrpTrackedInterfaceTable 1 }
 
 VrrpTrackedInterfaceEntry ::= SEQUENCE {
-	vrrpTrackedInterfaceName DisplayString,
-	vrrpTrackedInterfaceWeight Integer32
+    vrrpTrackedInterfaceName DisplayString,
+    vrrpTrackedInterfaceWeight Integer32
 }
 
 vrrpTrackedInterfaceName OBJECT-TYPE
@@ -629,7 +625,7 @@ vrrpTrackedInterfaceName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the tracked interface."
+        "Name of the tracked interface."
     ::= { vrrpTrackedInterfaceEntry 1 }
 
 vrrpTrackedInterfaceWeight OBJECT-TYPE
@@ -658,9 +654,9 @@ vrrpTrackedScriptEntry OBJECT-TYPE
     ::= { vrrpTrackedScriptTable 1 }
 
 VrrpTrackedScriptEntry ::= SEQUENCE {
-	vrrpTrackedScriptIndex Integer32,
-	vrrpTrackedScriptName DisplayString,
-	vrrpTrackedScriptWeight Integer32
+    vrrpTrackedScriptIndex Integer32,
+    vrrpTrackedScriptName DisplayString,
+    vrrpTrackedScriptWeight Integer32
 }
 
 vrrpTrackedScriptIndex OBJECT-TYPE
@@ -668,9 +664,9 @@ vrrpTrackedScriptIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of the tracked script in the set of tracked scripts for
-	 the given VRRP instance. This index has no relation with the
-	 index of vrrpScriptTable."
+        "Index of the tracked script in the set of tracked scripts for
+         the given VRRP instance. This index has no relation with the
+         index of vrrpScriptTable."
     ::= { vrrpTrackedScriptEntry 1 }
 
 vrrpTrackedScriptName OBJECT-TYPE
@@ -678,7 +674,7 @@ vrrpTrackedScriptName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the tracked interface."
+        "Name of the tracked interface."
     ::= { vrrpTrackedScriptEntry 2 }
 
 vrrpTrackedScriptWeight OBJECT-TYPE
@@ -712,17 +708,17 @@ vrrpAddressEntry OBJECT-TYPE
     ::= { vrrpAddressTable 1 }
 
 VrrpAddressEntry ::= SEQUENCE {
-	vrrpAddressIndex Integer32,
-        vrrpAddressType InetAddressType,
-	vrrpAddressValue InetAddress,
-	vrrpAddressBroadcast InetAddress,
-	vrrpAddressMask InetAddressPrefixLength,
-	vrrpAddressScope InetScopeType,
-	vrrpAddressIfIndex InterfaceIndex,
-	vrrpAddressIfName DisplayString,
-	vrrpAddressIfAlias DisplayString,
-	vrrpAddressStatus INTEGER,
-	vrrpAddressAdvertising INTEGER
+    vrrpAddressIndex Integer32,
+    vrrpAddressType InetAddressType,
+    vrrpAddressValue InetAddress,
+    vrrpAddressBroadcast InetAddress,
+    vrrpAddressMask InetAddressPrefixLength,
+    vrrpAddressScope InetScopeType,
+    vrrpAddressIfIndex InterfaceIndex,
+    vrrpAddressIfName DisplayString,
+    vrrpAddressIfAlias DisplayString,
+    vrrpAddressStatus INTEGER,
+    vrrpAddressAdvertising INTEGER
 }
 
 vrrpAddressIndex OBJECT-TYPE
@@ -730,7 +726,7 @@ vrrpAddressIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Address index."
+        "Address index."
     ::= { vrrpAddressEntry 1 }
 
 vrrpAddressType OBJECT-TYPE
@@ -738,7 +734,7 @@ vrrpAddressType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"A value that represents a type of Internet address."
+        "A value that represents a type of Internet address."
     ::= { vrrpAddressEntry 2 }
 
 vrrpAddressValue OBJECT-TYPE
@@ -746,7 +742,7 @@ vrrpAddressValue OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Actual IP address."
+        "Actual IP address."
     ::= { vrrpAddressEntry 3 }
 
 vrrpAddressBroadcast OBJECT-TYPE
@@ -754,7 +750,7 @@ vrrpAddressBroadcast OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Broadcast address associated with the IP address."
+        "Broadcast address associated with the IP address."
     ::= { vrrpAddressEntry 4 }
 
 vrrpAddressMask OBJECT-TYPE
@@ -762,7 +758,7 @@ vrrpAddressMask OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Address mask."
+        "Address mask."
     ::= { vrrpAddressEntry 5 }
 
 vrrpAddressScope OBJECT-TYPE
@@ -770,7 +766,7 @@ vrrpAddressScope OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Address scope."
+        "Address scope."
     ::= { vrrpAddressEntry 6 }
 
 vrrpAddressIfIndex OBJECT-TYPE
@@ -778,7 +774,7 @@ vrrpAddressIfIndex OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Index of the interface to which the IP address is linked to."
+        "Index of the interface to which the IP address is linked to."
     ::= { vrrpAddressEntry 7 }
 
 vrrpAddressIfName OBJECT-TYPE
@@ -786,7 +782,7 @@ vrrpAddressIfName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the interface to which the IP address is linked to."
+        "Name of the interface to which the IP address is linked to."
     ::= { vrrpAddressEntry 8 }
 
 vrrpAddressIfAlias OBJECT-TYPE
@@ -794,7 +790,7 @@ vrrpAddressIfAlias OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Alias name of the interface."
+        "Alias name of the interface."
     ::= { vrrpAddressEntry 9 }
 
 vrrpAddressStatus OBJECT-TYPE
@@ -802,7 +798,7 @@ vrrpAddressStatus OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Is the IP address set?"
+        "Is the IP address set?"
     ::= { vrrpAddressEntry 10 }
 
 vrrpAddressAdvertising OBJECT-TYPE
@@ -810,7 +806,7 @@ vrrpAddressAdvertising OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Status of VRRP advertising for this IP address."
+        "Status of VRRP advertising for this IP address."
     ::= { vrrpAddressEntry 11 }
 
 -- Routes
@@ -835,20 +831,20 @@ vrrpRouteEntry OBJECT-TYPE
     ::= { vrrpRouteTable 1 }
 
 VrrpRouteEntry ::= SEQUENCE {
-	vrrpRouteIndex Integer32,
-        vrrpRouteAddressType InetAddressType,
-	vrrpRouteDestination InetAddress,
-	vrrpRouteDestinationMask InetAddressPrefixLength,
-	vrrpRouteGateway InetAddress,
-	vrrpRouteSecondaryGateway InetAddress,
-	vrrpRouteSource InetAddress,
-	vrrpRouteMetric Unsigned32,
-	vrrpRouteScope InetScopeType,
-	vrrpRouteType INTEGER,
-	vrrpRouteIfIndex InterfaceIndex,
-	vrrpRouteIfName DisplayString,
-	vrrpRouteRoutingTable Unsigned32,
-	vrrpRouteStatus INTEGER
+    vrrpRouteIndex Integer32,
+    vrrpRouteAddressType InetAddressType,
+    vrrpRouteDestination InetAddress,
+    vrrpRouteDestinationMask InetAddressPrefixLength,
+    vrrpRouteGateway InetAddress,
+    vrrpRouteSecondaryGateway InetAddress,
+    vrrpRouteSource InetAddress,
+    vrrpRouteMetric Unsigned32,
+    vrrpRouteScope InetScopeType,
+    vrrpRouteType INTEGER,
+    vrrpRouteIfIndex InterfaceIndex,
+    vrrpRouteIfName DisplayString,
+    vrrpRouteRoutingTable Unsigned32,
+    vrrpRouteStatus INTEGER
 }
 
 vrrpRouteIndex OBJECT-TYPE
@@ -856,7 +852,7 @@ vrrpRouteIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Route index."
+        "Route index."
     ::= { vrrpRouteEntry 1 }
 
 vrrpRouteAddressType OBJECT-TYPE
@@ -864,7 +860,7 @@ vrrpRouteAddressType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Route type of internet address."
+        "Route type of internet address."
     ::= { vrrpRouteEntry 2 }
 
 vrrpRouteDestination OBJECT-TYPE
@@ -872,7 +868,7 @@ vrrpRouteDestination OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Route destination."
+        "Route destination."
     ::= { vrrpRouteEntry 3 }
 
 vrrpRouteDestinationMask OBJECT-TYPE
@@ -880,7 +876,7 @@ vrrpRouteDestinationMask OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Route destination mask."
+        "Route destination mask."
     ::= { vrrpRouteEntry 4 }
 
 vrrpRouteGateway OBJECT-TYPE
@@ -888,7 +884,7 @@ vrrpRouteGateway OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Gateway for the given destination."
+        "Gateway for the given destination."
     ::= { vrrpRouteEntry 5 }
 
 vrrpRouteSecondaryGateway OBJECT-TYPE
@@ -896,7 +892,7 @@ vrrpRouteSecondaryGateway OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"An optional second gateway for the given destination."
+        "An optional second gateway for the given destination."
     ::= { vrrpRouteEntry 6 }
 
 vrrpRouteSource OBJECT-TYPE
@@ -904,7 +900,7 @@ vrrpRouteSource OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Which source IP address to use with this route."
+        "Which source IP address to use with this route."
     ::= { vrrpRouteEntry 7 }
 
 vrrpRouteMetric OBJECT-TYPE
@@ -912,7 +908,7 @@ vrrpRouteMetric OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Metric of this route."
+        "Metric of this route."
     ::= { vrrpRouteEntry 8 }
 
 vrrpRouteScope OBJECT-TYPE
@@ -920,7 +916,7 @@ vrrpRouteScope OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Scope of this route."
+        "Scope of this route."
     ::= { vrrpRouteEntry 9 }
 
 vrrpRouteType OBJECT-TYPE
@@ -928,7 +924,7 @@ vrrpRouteType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Kind of route."
+        "Kind of route."
     ::= { vrrpRouteEntry 10 }
 
 vrrpRouteIfIndex OBJECT-TYPE
@@ -936,7 +932,7 @@ vrrpRouteIfIndex OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Interface attached to this route."
+        "Interface attached to this route."
     ::= { vrrpRouteEntry 11 }
 
 vrrpRouteIfName OBJECT-TYPE
@@ -944,7 +940,7 @@ vrrpRouteIfName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the interface of attached to this route."
+        "Name of the interface of attached to this route."
     ::= { vrrpRouteEntry 12 }
 
 vrrpRouteRoutingTable OBJECT-TYPE
@@ -952,7 +948,7 @@ vrrpRouteRoutingTable OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Routing table where to route should be inserted."
+        "Routing table where the route should be inserted."
     ::= { vrrpRouteEntry 13 }
 
 vrrpRouteStatus OBJECT-TYPE
@@ -960,7 +956,7 @@ vrrpRouteStatus OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Is this route set in the kernel?"
+        "Is this route set in the kernel?"
     ::= { vrrpRouteEntry 14 }
 
 -- VRRP scripts
@@ -984,14 +980,14 @@ vrrpScriptEntry OBJECT-TYPE
     ::= { vrrpScriptTable 1 }
 
 VrrpScriptEntry ::= SEQUENCE {
-	vrrpScriptIndex Integer32,
-        vrrpScriptName DisplayString,
-        vrrpScriptCommand DisplayString,
-        vrrpScriptInterval Integer32,
-        vrrpScriptWeight Integer32,
-        vrrpScriptResult INTEGER,
-        vrrpScriptRise Unsigned32,
-        vrrpScriptFall Unsigned32
+    vrrpScriptIndex Integer32,
+    vrrpScriptName DisplayString,
+    vrrpScriptCommand DisplayString,
+    vrrpScriptInterval Integer32,
+    vrrpScriptWeight Integer32,
+    vrrpScriptResult INTEGER,
+    vrrpScriptRise Unsigned32,
+    vrrpScriptFall Unsigned32
 }
 
 vrrpScriptIndex OBJECT-TYPE
@@ -999,7 +995,7 @@ vrrpScriptIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Script index."
+        "Script index."
     ::= { vrrpScriptEntry 1 }
 
 vrrpScriptName OBJECT-TYPE
@@ -1073,26 +1069,26 @@ vrrpTrapControl OBJECT IDENTIFIER ::= { vrrpTrap 1 }
 
 vrrpSyncGroupStateChange NOTIFICATION-TYPE
     OBJECTS {
-    	vrrpSyncGroupName,
-	vrrpSyncGroupState,
-	routerId
+        vrrpSyncGroupName,
+    vrrpSyncGroupState,
+    routerId
     }
     STATUS current
     DESCRIPTION
-	"This trap signifies that the state of the whole vrrp sync
-	group changed."
+        "This trap signifies that the state of the whole vrrp sync
+        group changed."
     ::= { vrrpTraps 1 }
 
 vrrpInstanceStateChange NOTIFICATION-TYPE
     OBJECTS {
-    	vrrpInstanceName,
-	vrrpInstanceState,
-	vrrpInstanceInitialState,
-	routerId
+        vrrpInstanceName,
+    vrrpInstanceState,
+    vrrpInstanceInitialState,
+    routerId
     }
     STATUS current
     DESCRIPTION
-	"This trap signifies that the state of a vrrp instance changed."
+        "This trap signifies that the state of a vrrp instance changed."
     ::= { vrrpTraps 2 }
 
 -- ----------------------------------------------------------------------
@@ -1106,7 +1102,7 @@ virtualServerGroupTable OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Table of virtual server groups."
+        "Table of virtual server groups."
     ::= { check 1 }
 
 virtualServerGroupEntry OBJECT-TYPE
@@ -1114,13 +1110,13 @@ virtualServerGroupEntry OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Information describing a virtual server group."
+        "Information describing a virtual server group."
     INDEX { virtualServerGroupIndex }
     ::= { virtualServerGroupTable 1 }
 
 VirtualServerGroupEntry ::= SEQUENCE {
-	virtualServerGroupIndex Integer32,
-	virtualServerGroupName DisplayString
+    virtualServerGroupIndex Integer32,
+    virtualServerGroupName DisplayString
 }
 
 virtualServerGroupIndex OBJECT-TYPE
@@ -1128,7 +1124,7 @@ virtualServerGroupIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of the virtual server group."
+        "Index of the virtual server group."
     ::= { virtualServerGroupEntry 1 }
 
 virtualServerGroupName OBJECT-TYPE
@@ -1136,7 +1132,7 @@ virtualServerGroupName OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Name of the virtual server group."
+        "Name of the virtual server group."
     ::= { virtualServerGroupEntry 2 }
 
 virtualServerGroupMemberTable OBJECT-TYPE
@@ -1144,7 +1140,7 @@ virtualServerGroupMemberTable OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Table of members of a virtual server group."
+        "Table of members of a virtual server group."
     ::= { check 2 }
 
 virtualServerGroupMemberEntry OBJECT-TYPE
@@ -1152,19 +1148,19 @@ virtualServerGroupMemberEntry OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Description of a member of a virtual server group."
+        "Description of a member of a virtual server group."
     INDEX { virtualServerGroupIndex, virtualServerGroupMemberIndex }
     ::= { virtualServerGroupMemberTable 1 }
 
 VirtualServerGroupMemberEntry ::= SEQUENCE {
-	virtualServerGroupMemberIndex Integer32,
-	virtualServerGroupMemberType INTEGER,
-	virtualServerGroupMemberFwMark Unsigned32,
-	virtualServerGroupMemberAddrType InetAddressType,
-	virtualServerGroupMemberAddress InetAddress,
-	virtualServerGroupMemberAddr1 InetAddress,
-	virtualServerGroupMemberAddr2 InetAddress,
-	virtualServerGroupMemberPort InetPortNumber
+    virtualServerGroupMemberIndex Integer32,
+    virtualServerGroupMemberType INTEGER,
+    virtualServerGroupMemberFwMark Unsigned32,
+    virtualServerGroupMemberAddrType InetAddressType,
+    virtualServerGroupMemberAddress InetAddress,
+    virtualServerGroupMemberAddr1 InetAddress,
+    virtualServerGroupMemberAddr2 InetAddress,
+    virtualServerGroupMemberPort InetPortNumber
 }
 
 virtualServerGroupMemberIndex OBJECT-TYPE
@@ -1172,7 +1168,7 @@ virtualServerGroupMemberIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of the member into virtual server group."
+        "Index of the member into virtual server group."
     ::= { virtualServerGroupMemberEntry 1 }
 
 virtualServerGroupMemberType OBJECT-TYPE
@@ -1180,8 +1176,8 @@ virtualServerGroupMemberType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Kind of entry: firewall mark, address with port or range of
-	 addresses with port."
+        "Kind of entry: firewall mark, address with port or range of
+         addresses with port."
     ::= { virtualServerGroupMemberEntry 2 }
 
 virtualServerGroupMemberFwMark OBJECT-TYPE
@@ -1189,10 +1185,10 @@ virtualServerGroupMemberFwMark OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Firewall mark for this member.
+        "Firewall mark for this member.
 
-	 If the kind of this member is not fwmark(1), then this entry
-	 should not exist for the current row."
+         If the kind of this member is not fwmark(1), then this entry
+         should not exist for the current row."
     ::= { virtualServerGroupMemberEntry 3 }
 
 virtualServerGroupMemberAddrType OBJECT-TYPE
@@ -1200,10 +1196,10 @@ virtualServerGroupMemberAddrType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Type of IP address for this member.
+        "Type of IP address for this member.
 
-	 If the kind of this member is neither address(2) or range(3),
-	 then this entry should not exist for the current row."
+         If the kind of this member is neither address(2) or range(3),
+         then this entry should not exist for the current row."
     ::= { virtualServerGroupMemberEntry 4 }
 
 virtualServerGroupMemberAddress OBJECT-TYPE
@@ -1211,10 +1207,10 @@ virtualServerGroupMemberAddress OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"IP address of this member.
+        "IP address of this member.
 
-	If the kind of this member is not address(2), then this entry
-	should not exist for the current row."
+        If the kind of this member is not address(2), then this entry
+        should not exist for the current row."
     ::= { virtualServerGroupMemberEntry 5 }
 
 virtualServerGroupMemberAddr1 OBJECT-TYPE
@@ -1222,10 +1218,10 @@ virtualServerGroupMemberAddr1 OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"First IP address of the range for this member.
+        "First IP address of the range for this member.
 
-	If the kind of this member is not range(3), then this entry
-	should not exist for the current row."
+        If the kind of this member is not range(3), then this entry
+        should not exist for the current row."
     ::= { virtualServerGroupMemberEntry 6 }
 
 virtualServerGroupMemberAddr2 OBJECT-TYPE
@@ -1233,10 +1229,10 @@ virtualServerGroupMemberAddr2 OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Second IP address of the range for this member.
+        "Second IP address of the range for this member.
 
-	If the kind of this member is not range(3), then this entry
-	should not exist for the current row."
+        If the kind of this member is not range(3), then this entry
+        should not exist for the current row."
     ::= { virtualServerGroupMemberEntry 7 }
 
 virtualServerGroupMemberPort OBJECT-TYPE
@@ -1244,10 +1240,10 @@ virtualServerGroupMemberPort OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"V port for this member.
+        "V port for this member.
 
-	If the kind of this member is neither address(2) nor range(3),
-	then this entry should not exist for the current row."
+        If the kind of this member is neither address(2) nor range(3),
+        then this entry should not exist for the current row."
     ::= { virtualServerGroupMemberEntry 8 }
 
 -- virtual server
@@ -1257,7 +1253,7 @@ virtualServerTable OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Table of virtual servers."
+        "Table of virtual servers."
     ::= { check 3 }
 
 virtualServerEntry OBJECT-TYPE
@@ -1265,48 +1261,48 @@ virtualServerEntry OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Information describing a virtual server."
+        "Information describing a virtual server."
     INDEX { virtualServerIndex }
     ::= { virtualServerTable 1 }
 
 VirtualServerEntry ::= SEQUENCE {
-	virtualServerIndex Integer32,
-	virtualServerType INTEGER,
-	virtualServerNameOfGroup DisplayString,
-	virtualServerFwMark Unsigned32,
-	virtualServerAddrType InetAddressType,
-	virtualServerAddress InetAddress,
-	virtualServerPort InetPortNumber,
-	virtualServerProtocol INTEGER,
-	virtualServerLoadBalancingAlgo INTEGER,
-	virtualServerLoadBalancingKind INTEGER,
-	virtualServerOPS TruthValue,
-	virtualServerStatus INTEGER,
-	virtualServerVirtualHost DisplayString,
-	virtualServerPersist INTEGER,
-	virtualServerPersistTimeout Unsigned32,
-	virtualServerPersistGranularity InetAddress,
-	virtualServerDelayLoop Unsigned32,
-	virtualServerHaSuspend TruthValue,
-	virtualServerAlpha INTEGER,
-	virtualServerOmega INTEGER,
-	virtualServerRealServersTotal Unsigned32,
-	virtualServerRealServersUp Unsigned32,
-	virtualServerQuorum Unsigned32,
-	virtualServerQuorumStatus INTEGER,
-	virtualServerQuorumUp DisplayString,
-	virtualServerQuorumDown DisplayString,
-	virtualServerHysteresis Unsigned32,
-	virtualServerStatsConns Gauge32,
-	virtualServerStatsInPkts Counter32,
-	virtualServerStatsOutPkts Counter32,
-	virtualServerStatsInBytes Counter64,
-	virtualServerStatsOutBytes Counter64,
-	virtualServerRateCps Gauge32,
-	virtualServerRateInPPS Gauge32,
-	virtualServerRateOutPPS Gauge32,
-	virtualServerRateInBPS Gauge32,
-	virtualServerRateOutBPS Gauge32
+    virtualServerIndex Integer32,
+    virtualServerType INTEGER,
+    virtualServerNameOfGroup DisplayString,
+    virtualServerFwMark Unsigned32,
+    virtualServerAddrType InetAddressType,
+    virtualServerAddress InetAddress,
+    virtualServerPort InetPortNumber,
+    virtualServerProtocol INTEGER,
+    virtualServerLoadBalancingAlgo INTEGER,
+    virtualServerLoadBalancingKind INTEGER,
+    virtualServerStatus INTEGER,
+    virtualServerVirtualHost DisplayString,
+    virtualServerPersist INTEGER,
+    virtualServerPersistTimeout Unsigned32,
+    virtualServerPersistGranularity InetAddress,
+    virtualServerDelayLoop Unsigned32,
+    virtualServerHaSuspend TruthValue,
+    virtualServerAlpha INTEGER,
+    virtualServerOmega INTEGER,
+    virtualServerRealServersTotal Unsigned32,
+    virtualServerRealServersUp Unsigned32,
+    virtualServerQuorum Unsigned32,
+    virtualServerQuorumStatus INTEGER,
+    virtualServerQuorumUp DisplayString,
+    virtualServerQuorumDown DisplayString,
+    virtualServerHysteresis Unsigned32,
+    virtualServerStatsConns Gauge32,
+    virtualServerStatsInPkts Counter32,
+    virtualServerStatsOutPkts Counter32,
+    virtualServerStatsInBytes Counter64,
+    virtualServerStatsOutBytes Counter64,
+    virtualServerRateCps Gauge32,
+    virtualServerRateInPPS Gauge32,
+    virtualServerRateOutPPS Gauge32,
+    virtualServerRateInBPS Gauge32,
+    virtualServerRateOutBPS Gauge32,
+    virtualServerOPS TruthValue
 }
 
 virtualServerIndex OBJECT-TYPE
@@ -1314,7 +1310,7 @@ virtualServerIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of the virtual server."
+        "Index of the virtual server."
     ::= { virtualServerEntry 1 }
 
 virtualServerType OBJECT-TYPE
@@ -1322,9 +1318,9 @@ virtualServerType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Type of virtual server. A virtual server can either be
-	defined from a firewall mark, an IP and a port
-	or from a virtual server group."
+        "Type of virtual server. A virtual server can either be
+        defined from a firewall mark, an IP and a port
+        or from a virtual server group."
     ::= { virtualServerEntry 2 }
 
 virtualServerNameOfGroup OBJECT-TYPE
@@ -1332,7 +1328,7 @@ virtualServerNameOfGroup OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If the virtual is defined from a group, this is the name of the group."
+        "If the virtual is defined from a group, this is the name of the group."
     ::= { virtualServerEntry 3 }
 
 virtualServerFwMark OBJECT-TYPE
@@ -1340,9 +1336,9 @@ virtualServerFwMark OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If the virtual server is defined from a firewall mark, this
-	is the value of the mark. Otherwise, this column should not
-	exist in the current row."
+        "If the virtual server is defined from a firewall mark, this
+        is the value of the mark. Otherwise, this column should not
+        exist in the current row."
     ::= { virtualServerEntry 4 }
 
 virtualServerAddrType OBJECT-TYPE
@@ -1350,9 +1346,9 @@ virtualServerAddrType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If the virtual server is defined from an IP, this
-	is the address family. Otherwise, this column should not
-	exist in the current row."
+        "If the virtual server is defined from an IP, this
+        is the address family. Otherwise, this column should not
+        exist in the current row."
     ::= { virtualServerEntry 5 }
 
 virtualServerAddress OBJECT-TYPE
@@ -1360,9 +1356,9 @@ virtualServerAddress OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If the virtual server is defined from an IP address, this
-	is the value of the IP. Otherwise, this column should not
-	exist in the current row."
+        "If the virtual server is defined from an IP address, this
+        is the value of the IP. Otherwise, this column should not
+        exist in the current row."
     ::= { virtualServerEntry 6 }
 
 virtualServerPort OBJECT-TYPE
@@ -1370,9 +1366,9 @@ virtualServerPort OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If the virtual server is defined from an IP, this is
-	the value of the port to listen for requests. Otherwise, this column
-	should not exist in the current row."
+        "If the virtual server is defined from an IP, this is
+        the value of the port to listen for requests. Otherwise, this column
+        should not exist in the current row."
     ::= { virtualServerEntry 7 }
 
 virtualServerProtocol OBJECT-TYPE
@@ -1380,28 +1376,28 @@ virtualServerProtocol OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Which transport protocol should be used for this virtual server."
+        "Which transport protocol should be used for this virtual server."
     ::= { virtualServerEntry 8 }
 
 virtualServerLoadBalancingAlgo OBJECT-TYPE
     SYNTAX INTEGER {
-    	rr(1),
-	wrr(2),
-	lc(3),
-	wlc(4),
-	lblc(5),
-	lblcr(6),
-	dh(7),
-	sh(8),
-	sed(9),
-	nq(10),
-	unknown(99)
+        rr(1),
+    wrr(2),
+    lc(3),
+    wlc(4),
+    lblc(5),
+    lblcr(6),
+    dh(7),
+    sh(8),
+    sed(9),
+    nq(10),
+    unknown(99)
     }
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Which load balancing algorithm (or scheduler) should be used
-	for this virtual server."
+        "Which load balancing algorithm (or scheduler) should be used
+        for this virtual server."
     ::= { virtualServerEntry 9 }
 
 virtualServerLoadBalancingKind OBJECT-TYPE
@@ -1409,7 +1405,7 @@ virtualServerLoadBalancingKind OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Forwarding method to use for this virtual server."
+        "Forwarding method to use for this virtual server."
     ::= { virtualServerEntry 10 }
 
 virtualServerStatus OBJECT-TYPE
@@ -1417,7 +1413,7 @@ virtualServerStatus OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current status of this virtual server."
+        "Current status of this virtual server."
     ::= { virtualServerEntry 11 }
 
 virtualServerVirtualHost OBJECT-TYPE
@@ -1425,7 +1421,7 @@ virtualServerVirtualHost OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Virtualhost of this server for HTTP like requests."
+        "Virtualhost of this server for HTTP like requests."
     ::= { virtualServerEntry 12 }
 
 virtualServerPersist OBJECT-TYPE
@@ -1433,7 +1429,7 @@ virtualServerPersist OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Is the virtual service persistence enabled?"
+        "Is the virtual service persistence enabled?"
     ::= { virtualServerEntry 13 }
 
 virtualServerPersistTimeout OBJECT-TYPE
@@ -1442,7 +1438,7 @@ virtualServerPersistTimeout OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If this virtual service is persistence, what is the timeout."
+        "If this virtual service is persistence, what is the timeout."
     ::= { virtualServerEntry 14 }
 
 virtualServerPersistGranularity OBJECT-TYPE
@@ -1450,7 +1446,7 @@ virtualServerPersistGranularity OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Netmask specifying the granularity of the persistence mechanism."
+        "Netmask specifying the granularity of the persistence mechanism."
     ::= { virtualServerEntry 15 }
 
 virtualServerDelayLoop OBJECT-TYPE
@@ -1459,7 +1455,7 @@ virtualServerDelayLoop OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Delay in seconds between two checks."
+        "Delay in seconds between two checks."
     ::= { virtualServerEntry 16 }
 
 virtualServerHaSuspend OBJECT-TYPE
@@ -1467,8 +1463,8 @@ virtualServerHaSuspend OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If set to true(1), checks will be suspended if the IP of the
-	virtual server is currently not set."
+        "If set to true(1), checks will be suspended if the IP of the
+        virtual server is currently not set."
     ::= { virtualServerEntry 17 }
 
 virtualServerAlpha OBJECT-TYPE
@@ -1476,7 +1472,7 @@ virtualServerAlpha OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Is alpha mode enabled?"
+        "Is alpha mode enabled?"
     ::= { virtualServerEntry 18 }
 
 virtualServerOmega OBJECT-TYPE
@@ -1484,7 +1480,7 @@ virtualServerOmega OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Is omega mode enabled?"
+        "Is omega mode enabled?"
     ::= { virtualServerEntry 19 }
 
 virtualServerRealServersTotal OBJECT-TYPE
@@ -1492,7 +1488,7 @@ virtualServerRealServersTotal OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of real servers for this virtual server."
+        "Total number of real servers for this virtual server."
     ::= { virtualServerEntry 20 }
 
 virtualServerRealServersUp OBJECT-TYPE
@@ -1500,7 +1496,7 @@ virtualServerRealServersUp OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Real servers actually up for this virtual server."
+        "Real servers actually up for this virtual server."
     ::= { virtualServerEntry 21 }
 
 virtualServerQuorum OBJECT-TYPE
@@ -1508,7 +1504,7 @@ virtualServerQuorum OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Quorum to get amond real servers to consider this virtual server up."
+        "Quorum to get amond real servers to consider this virtual server up."
     ::= { virtualServerEntry 22 }
 
 virtualServerQuorumStatus OBJECT-TYPE
@@ -1516,7 +1512,7 @@ virtualServerQuorumStatus OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current status of the quorum for this virtual server."
+        "Current status of the quorum for this virtual server."
     ::= { virtualServerEntry 23 }
 
 virtualServerQuorumUp OBJECT-TYPE
@@ -1524,7 +1520,7 @@ virtualServerQuorumUp OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Command to execute when the quorum is met."
+        "Command to execute when the quorum is met."
     ::= { virtualServerEntry 24 }
 
 virtualServerQuorumDown OBJECT-TYPE
@@ -1532,7 +1528,7 @@ virtualServerQuorumDown OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Command to execute when the quorum is not met."
+        "Command to execute when the quorum is not met."
     ::= { virtualServerEntry 25 }
 
 virtualServerHysteresis OBJECT-TYPE
@@ -1540,7 +1536,7 @@ virtualServerHysteresis OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Hysteresis with respect to quorum count."
+        "Hysteresis with respect to quorum count."
     ::= { virtualServerEntry 26 }
 
 virtualServerStatsConns OBJECT-TYPE
@@ -1549,7 +1545,7 @@ virtualServerStatsConns OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of connections scheduled for this virtual server."
+        "Total number of connections scheduled for this virtual server."
     ::= { virtualServerEntry 27 }
 
 virtualServerStatsInPkts OBJECT-TYPE
@@ -1558,7 +1554,7 @@ virtualServerStatsInPkts OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of incoming packets for this virtual server."
+        "Total number of incoming packets for this virtual server."
     ::= { virtualServerEntry 28 }
 
 virtualServerStatsOutPkts OBJECT-TYPE
@@ -1567,7 +1563,7 @@ virtualServerStatsOutPkts OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of outgoing packets for this virtual server."
+        "Total number of outgoing packets for this virtual server."
     ::= { virtualServerEntry 29 }
 
 virtualServerStatsInBytes OBJECT-TYPE
@@ -1576,7 +1572,7 @@ virtualServerStatsInBytes OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of incoming bytes for this virtual server."
+        "Total number of incoming bytes for this virtual server."
     ::= { virtualServerEntry 30 }
 
 virtualServerStatsOutBytes OBJECT-TYPE
@@ -1585,7 +1581,7 @@ virtualServerStatsOutBytes OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of outgoing bytes for this virtual server."
+        "Total number of outgoing bytes for this virtual server."
     ::= { virtualServerEntry 31 }
 
 virtualServerRateCps OBJECT-TYPE
@@ -1594,7 +1590,7 @@ virtualServerRateCps OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current connection rate for this virtual server."
+        "Current connection rate for this virtual server."
     ::= { virtualServerEntry 32 }
 
 virtualServerRateInPPS OBJECT-TYPE
@@ -1603,7 +1599,7 @@ virtualServerRateInPPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current in packet rate for this virtual server."
+        "Current in packet rate for this virtual server."
     ::= { virtualServerEntry 33 }
 
 virtualServerRateOutPPS OBJECT-TYPE
@@ -1612,7 +1608,7 @@ virtualServerRateOutPPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current out packet rate for this virtual server."
+        "Current out packet rate for this virtual server."
     ::= { virtualServerEntry 34 }
 
 virtualServerRateInBPS OBJECT-TYPE
@@ -1621,7 +1617,7 @@ virtualServerRateInBPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current incoming rate for this virtual server."
+        "Current incoming rate for this virtual server."
     ::= { virtualServerEntry 35 }
 
 virtualServerRateOutBPS OBJECT-TYPE
@@ -1630,7 +1626,7 @@ virtualServerRateOutBPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current outgoing rate for this virtual server."
+        "Current outgoing rate for this virtual server."
     ::= { virtualServerEntry 36 }
 
 virtualServerOPS OBJECT-TYPE
@@ -1638,7 +1634,7 @@ virtualServerOPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"If set to true(1), One-Packet-Scheduling will be applied."
+        "If set to true(1), One-Packet-Scheduling will be applied."
     ::= { virtualServerEntry 37 }
 
 -- real servers
@@ -1648,7 +1644,7 @@ realServerTable OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Table of real servers. This includes regular real servers and sorry servers."
+        "Table of real servers. This includes regular real servers and sorry servers."
     ::= { check 4 }
 
 realServerEntry OBJECT-TYPE
@@ -1656,37 +1652,37 @@ realServerEntry OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Information describing a real server."
+        "Information describing a real server."
     INDEX { virtualServerIndex, realServerIndex }
     ::= { realServerTable 1 }
 
 RealServerEntry ::= SEQUENCE {
-	realServerIndex Integer32,
-	realServerType INTEGER,
-	realServerAddrType InetAddressType,
-	realServerAddress InetAddress,
-	realServerPort InetPortNumber,
-	realServerStatus INTEGER,
-	realServerWeight Integer32,
-	realServerUpperConnectionLimit Unsigned32,
-	realServerLowerConnectionLimit Unsigned32,
-	realServerActionWhenDown INTEGER,
-	realServerNotifyUp DisplayString,
-	realServerNotifyDown DisplayString,
-	realServerFailedChecks Unsigned32,
-	realServerStatsConns Gauge32,
-	realServerStatsActiveConns Gauge32,
-	realServerStatsInactiveConns Gauge32,
-	realServerStatsPersistentConns Gauge32,
-	realServerStatsInPkts Counter32,
-	realServerStatsOutPkts Counter32,
-	realServerStatsInBytes Counter64,
-	realServerStatsOutBytes Counter64,
-	realServerRateCps Gauge32,
-	realServerRateInPPS Gauge32,
-	realServerRateOutPPS Gauge32,
-	realServerRateInBPS Gauge32,
-	realServerRateOutBPS Gauge32
+    realServerIndex Integer32,
+    realServerType INTEGER,
+    realServerAddrType InetAddressType,
+    realServerAddress InetAddress,
+    realServerPort InetPortNumber,
+    realServerStatus INTEGER,
+    realServerWeight Integer32,
+    realServerUpperConnectionLimit Unsigned32,
+    realServerLowerConnectionLimit Unsigned32,
+    realServerActionWhenDown INTEGER,
+    realServerNotifyUp DisplayString,
+    realServerNotifyDown DisplayString,
+    realServerFailedChecks Unsigned32,
+    realServerStatsConns Gauge32,
+    realServerStatsActiveConns Gauge32,
+    realServerStatsInactiveConns Gauge32,
+    realServerStatsPersistentConns Gauge32,
+    realServerStatsInPkts Counter32,
+    realServerStatsOutPkts Counter32,
+    realServerStatsInBytes Counter64,
+    realServerStatsOutBytes Counter64,
+    realServerRateCps Gauge32,
+    realServerRateInPPS Gauge32,
+    realServerRateOutPPS Gauge32,
+    realServerRateInBPS Gauge32,
+    realServerRateOutBPS Gauge32
 }
 
 realServerIndex OBJECT-TYPE
@@ -1694,7 +1690,7 @@ realServerIndex OBJECT-TYPE
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION
-	"Index of the real server."
+        "Index of the real server."
     ::= { realServerEntry 1 }
 
 realServerType OBJECT-TYPE
@@ -1702,7 +1698,7 @@ realServerType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Type of real server: either a regular real server or a sorry server."
+        "Type of real server: either a regular real server or a sorry server."
     ::= { realServerEntry 2 }
 
 realServerAddrType OBJECT-TYPE
@@ -1710,7 +1706,7 @@ realServerAddrType OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Address family for this real server."
+        "Address family for this real server."
     ::= { realServerEntry 3 }
 
 realServerAddress OBJECT-TYPE
@@ -1718,7 +1714,7 @@ realServerAddress OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"IP address of this real server."
+        "IP address of this real server."
     ::= { realServerEntry 4 }
 
 realServerPort OBJECT-TYPE
@@ -1726,7 +1722,7 @@ realServerPort OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Port of the service."
+        "Port of the service."
     ::= { realServerEntry 5 }
 
 realServerStatus OBJECT-TYPE
@@ -1734,7 +1730,7 @@ realServerStatus OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Status of this real server."
+        "Status of this real server."
     ::= { realServerEntry 6 }
 
 realServerWeight OBJECT-TYPE
@@ -1742,9 +1738,9 @@ realServerWeight OBJECT-TYPE
     MAX-ACCESS read-write
     STATUS current
     DESCRIPTION
-	"Weight of this real server.
+        "Weight of this real server.
 
-	This value can be set to 0 to disable the real server."
+        This value can be set to 0 to disable the real server."
     ::= { realServerEntry 7 }
 
 realServerUpperConnectionLimit OBJECT-TYPE
@@ -1752,7 +1748,7 @@ realServerUpperConnectionLimit OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Maximum number of connections for this real server."
+        "Maximum number of connections for this real server."
     ::= { realServerEntry 8 }
 
 realServerLowerConnectionLimit OBJECT-TYPE
@@ -1760,7 +1756,7 @@ realServerLowerConnectionLimit OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Minimum number of connections for this real server."
+        "Minimum number of connections for this real server."
     ::= { realServerEntry 9 }
 
 realServerActionWhenDown OBJECT-TYPE
@@ -1768,8 +1764,8 @@ realServerActionWhenDown OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"What action is performed when this server is down. Its weight
-	can be set to 0 (inhibit) or it can be removed from the pool."
+        "What action is performed when this server is down. Its weight
+        can be set to 0 (inhibit) or it can be removed from the pool."
     ::= { realServerEntry 10 }
 
 realServerNotifyUp OBJECT-TYPE
@@ -1777,7 +1773,7 @@ realServerNotifyUp OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Command to execute when this server becomes alive."
+        "Command to execute when this server becomes alive."
     ::= { realServerEntry 11 }
 
 realServerNotifyDown OBJECT-TYPE
@@ -1785,7 +1781,7 @@ realServerNotifyDown OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Command to execute when this server becomes dead."
+        "Command to execute when this server becomes dead."
     ::= { realServerEntry 12 }
 
 realServerFailedChecks OBJECT-TYPE
@@ -1793,7 +1789,7 @@ realServerFailedChecks OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"How many failed checks for this real server."
+        "How many failed checks for this real server."
     ::= { realServerEntry 13 }
 
 realServerStatsConns OBJECT-TYPE
@@ -1802,7 +1798,7 @@ realServerStatsConns OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of connections scheduled for this real server."
+        "Total number of connections scheduled for this real server."
     ::= { realServerEntry 14 }
 
 realServerStatsActiveConns OBJECT-TYPE
@@ -1811,7 +1807,7 @@ realServerStatsActiveConns OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current active connections for this real server."
+        "Current active connections for this real server."
     ::= { realServerEntry 15 }
 
 realServerStatsInactiveConns OBJECT-TYPE
@@ -1820,7 +1816,7 @@ realServerStatsInactiveConns OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current inactive connections for this real server."
+        "Current inactive connections for this real server."
     ::= { realServerEntry 16 }
 
 realServerStatsPersistentConns OBJECT-TYPE
@@ -1829,7 +1825,7 @@ realServerStatsPersistentConns OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current persistent connections for this real server."
+        "Current persistent connections for this real server."
     ::= { realServerEntry 17 }
 
 realServerStatsInPkts OBJECT-TYPE
@@ -1838,7 +1834,7 @@ realServerStatsInPkts OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of incoming packets for this real server."
+        "Total number of incoming packets for this real server."
     ::= { realServerEntry 18 }
 
 realServerStatsOutPkts OBJECT-TYPE
@@ -1847,7 +1843,7 @@ realServerStatsOutPkts OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of outgoing packets for this real server."
+        "Total number of outgoing packets for this real server."
     ::= { realServerEntry 19 }
 
 realServerStatsInBytes OBJECT-TYPE
@@ -1856,7 +1852,7 @@ realServerStatsInBytes OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of incoming bytes for this real server."
+        "Total number of incoming bytes for this real server."
     ::= { realServerEntry 20 }
 
 realServerStatsOutBytes OBJECT-TYPE
@@ -1865,7 +1861,7 @@ realServerStatsOutBytes OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Total number of outgoing bytes for this real server."
+        "Total number of outgoing bytes for this real server."
     ::= { realServerEntry 21 }
 
 realServerRateCps OBJECT-TYPE
@@ -1874,7 +1870,7 @@ realServerRateCps OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current connection rate for this real server."
+        "Current connection rate for this real server."
     ::= { realServerEntry 22 }
 
 realServerRateInPPS OBJECT-TYPE
@@ -1883,7 +1879,7 @@ realServerRateInPPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current in packet rate for this real server."
+        "Current in packet rate for this real server."
     ::= { realServerEntry 23 }
 
 realServerRateOutPPS OBJECT-TYPE
@@ -1892,7 +1888,7 @@ realServerRateOutPPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current out packet rate for this real server."
+        "Current out packet rate for this real server."
     ::= { realServerEntry 24 }
 
 realServerRateInBPS OBJECT-TYPE
@@ -1901,7 +1897,7 @@ realServerRateInBPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current incoming rate for this real server."
+        "Current incoming rate for this real server."
     ::= { realServerEntry 25 }
 
 realServerRateOutBPS OBJECT-TYPE
@@ -1910,7 +1906,7 @@ realServerRateOutBPS OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-	"Current outgoing rate for this real server."
+        "Current outgoing rate for this real server."
     ::= { realServerEntry 26 }
 
 -- Traps
@@ -1921,42 +1917,42 @@ checkTrapControl OBJECT IDENTIFIER ::= { checkTrap 1 }
 
 realServerStateChange NOTIFICATION-TYPE
     OBJECTS {
-    	realServerAddrType,
-	realServerAddress,
-	realServerPort,
-	realServerStatus,
-	virtualServerType,
-	virtualServerProtocol,
-	virtualServerRealServersUp,
-	virtualServerRealServersTotal,
-	routerId
+        realServerAddrType,
+    realServerAddress,
+    realServerPort,
+    realServerStatus,
+    virtualServerType,
+    virtualServerProtocol,
+    virtualServerRealServersUp,
+    virtualServerRealServersTotal,
+    routerId
     }
     STATUS current
     DESCRIPTION
-	"This trap signifies that the state of a real server has
-	changed. Additional varbinds will be added depending on the
-	value of virtualServerType: virtualServerNameOfGroup,
-	virtualServerFwMark, virtualServerAddrType,
-	virtualServerAddress, virtualServerPort."
+        "This trap signifies that the state of a real server has
+        changed. Additional varbinds will be added depending on the
+        value of virtualServerType: virtualServerNameOfGroup,
+        virtualServerFwMark, virtualServerAddrType,
+        virtualServerAddress, virtualServerPort."
     ::= { checkTraps 1 }
 
 virtualServerQuorumStateChange NOTIFICATION-TYPE
     OBJECTS {
-	virtualServerType,
-	virtualServerProtocol,
-	virtualServerQuorumStatus,
-	virtualServerQuorum,
-	virtualServerRealServersUp,
-	virtualServerRealServersTotal,
-	routerId
+    virtualServerType,
+    virtualServerProtocol,
+    virtualServerQuorumStatus,
+    virtualServerQuorum,
+    virtualServerRealServersUp,
+    virtualServerRealServersTotal,
+    routerId
     }
     STATUS current
     DESCRIPTION
-	"This trap signifies that the quorum of a virtual server has
-	changed. Additional varbinds will be added depending on the
-	value of virtualServerType: virtualServerNameOfGroup,
-	virtualServerFwMark, virtualServerAddrType,
-	virtualServerAddress, virtualServerPort."
+        "This trap signifies that the quorum of a virtual server has
+        changed. Additional varbinds will be added depending on the
+        value of virtualServerType: virtualServerNameOfGroup,
+        virtualServerFwMark, virtualServerAddrType,
+        virtualServerAddress, virtualServerPort."
     ::= { checkTraps 2 }
 
 -- ----------------------------------------------------------------------
@@ -1964,268 +1960,269 @@ virtualServerQuorumStateChange NOTIFICATION-TYPE
 -- ----------------------------------------------------------------------
 
 compliances  OBJECT IDENTIFIER ::= { conformance 1 }
-groups	     OBJECT IDENTIFIER ::= { conformance 2 }
+groups       OBJECT IDENTIFIER ::= { conformance 2 }
 
 globalCompliances MODULE-COMPLIANCE
     STATUS current
     DESCRIPTION
-	"Compliance statement for global data"
+        "Compliance statement for global data"
     MODULE -- this module
     MANDATORY-GROUPS {
-    	globalGroup
+        globalGroup
     }
     ::= { compliances 1 }
 
 vrrpCompliances MODULE-COMPLIANCE
     STATUS current
     DESCRIPTION
-	"The VRRP compliance statement"
+        "The VRRP compliance statement"
     MODULE -- this module
     MANDATORY-GROUPS {
-	vrrpScriptGroup,
-	vrrpSyncGroup,
-	vrrpInstanceGroup,
-	vrrpTrapsGroup
+    vrrpScriptGroup,
+    vrrpSyncGroup,
+    vrrpInstanceGroup,
+    vrrpTrapsGroup
     }
     ::= { compliances 2 }
 
 checkCompliances MODULE-COMPLIANCE
     STATUS current
     DESCRIPTION
-	"The check compliance statement"
+        "The check compliance statement"
     MODULE -- this module
     MANDATORY-GROUPS {
-	virtualServerGroupGroup,
-	virtualServerGroup,
-	realServerGroup,
-	checkTrapsGroup
+    virtualServerGroupGroup,
+    virtualServerGroup,
+    realServerGroup,
+    checkTrapsGroup
     }
     ::= { compliances 3 }
 
 globalGroup OBJECT-GROUP
     OBJECTS {
-    	version,
-	routerId,
-	smtpServerAddressType,
-	smtpServerAddress,
-	smtpServerTimeout,
-	emailFrom,
-	emailAddress,
-	trapEnable,
-	linkBeat
+        version,
+    routerId,
+    smtpServerAddressType,
+    smtpServerAddress,
+    smtpServerTimeout,
+    emailFrom,
+    emailAddress,
+    trapEnable,
+    linkBeat
     }
     STATUS current
     DESCRIPTION
-	"Conformance group for global data."
+        "Conformance group for global data."
     ::= { groups 1 }
 
 vrrpGroups OBJECT IDENTIFIER ::= { groups 2 }
 
 vrrpSyncGroup OBJECT-GROUP
     OBJECTS {
-	vrrpSyncGroupName,
-	vrrpSyncGroupState,
-	vrrpSyncGroupSmtpAlert,
-	vrrpSyncGroupNotifyExec,
-	vrrpSyncGroupScriptMaster,
-	vrrpSyncGroupScriptBackup,
-	vrrpSyncGroupScriptFault,
-	vrrpSyncGroupScript,
-	vrrpSyncGroupMemberName
-	}
+    vrrpSyncGroupName,
+    vrrpSyncGroupState,
+    vrrpSyncGroupSmtpAlert,
+    vrrpSyncGroupNotifyExec,
+    vrrpSyncGroupScriptMaster,
+    vrrpSyncGroupScriptBackup,
+    vrrpSyncGroupScriptFault,
+    vrrpSyncGroupScript,
+    vrrpSyncGroupMemberName
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for synchronisation groups."
+        "Conformance group for synchronisation groups."
     ::= { vrrpGroups 1 }
 
 vrrpInstanceGroup OBJECT-GROUP
     OBJECTS {
-	vrrpInstanceName,
-	vrrpInstanceVirtualRouterId,
-	vrrpInstanceState,
-	vrrpInstanceInitialState,
-	vrrpInstanceWantedState,
-	vrrpInstanceBasePriority,
-	vrrpInstanceEffectivePriority,
-	vrrpInstanceVipsStatus,
-	vrrpInstancePrimaryInterface,
-	vrrpInstanceTrackPrimaryIf,
-	vrrpInstanceAdvertisementsInt,
-	vrrpInstancePreempt,
-	vrrpInstancePreemptDelay,
-	vrrpInstanceAuthType,
-	vrrpInstanceLvsSyncDaemon,
-	vrrpInstanceLvsSyncInterface,
-	vrrpInstanceSyncGroup,
-	vrrpInstanceGarpDelay,
-	vrrpInstanceSmtpAlert,
-	vrrpInstanceNotifyExec,
-	vrrpInstanceScriptMaster,
-	vrrpInstanceScriptBackup,
-	vrrpInstanceScriptFault,
-	vrrpInstanceScriptStop,
-	vrrpInstanceScript,
-        vrrpInstanceAccept,
-	vrrpTrackedInterfaceName,
-	vrrpTrackedInterfaceWeight,
-	vrrpTrackedScriptName,
-	vrrpTrackedScriptWeight,
-        vrrpAddressType,
-	vrrpAddressValue,
-	vrrpAddressBroadcast,
-	vrrpAddressMask,
-	vrrpAddressScope,
-	vrrpAddressIfIndex,
-	vrrpAddressIfName,
-	vrrpAddressIfAlias,
-	vrrpAddressStatus,
-	vrrpAddressAdvertising,
-        vrrpRouteAddressType,
-	vrrpRouteDestination,
-	vrrpRouteDestinationMask,
-	vrrpRouteGateway,
-	vrrpRouteSecondaryGateway,
-	vrrpRouteSource,
-	vrrpRouteMetric,
-	vrrpRouteScope,
-	vrrpRouteType,
-	vrrpRouteIfIndex,
-	vrrpRouteIfName,
-	vrrpRouteRoutingTable,
-	vrrpRouteStatus
-	}
+    vrrpInstanceName,
+    vrrpInstanceVirtualRouterId,
+    vrrpInstanceState,
+    vrrpInstanceInitialState,
+    vrrpInstanceWantedState,
+    vrrpInstanceBasePriority,
+    vrrpInstanceEffectivePriority,
+    vrrpInstanceVipsStatus,
+    vrrpInstancePrimaryInterface,
+    vrrpInstanceTrackPrimaryIf,
+    vrrpInstanceAdvertisementsInt,
+    vrrpInstancePreempt,
+    vrrpInstancePreemptDelay,
+    vrrpInstanceAuthType,
+    vrrpInstanceLvsSyncDaemon,
+    vrrpInstanceLvsSyncInterface,
+    vrrpInstanceSyncGroup,
+    vrrpInstanceGarpDelay,
+    vrrpInstanceSmtpAlert,
+    vrrpInstanceNotifyExec,
+    vrrpInstanceScriptMaster,
+    vrrpInstanceScriptBackup,
+    vrrpInstanceScriptFault,
+    vrrpInstanceScriptStop,
+    vrrpInstanceScript,
+    vrrpInstanceAccept,
+    vrrpTrackedInterfaceName,
+    vrrpTrackedInterfaceWeight,
+    vrrpTrackedScriptName,
+    vrrpTrackedScriptWeight,
+    vrrpAddressType,
+    vrrpAddressValue,
+    vrrpAddressBroadcast,
+    vrrpAddressMask,
+    vrrpAddressScope,
+    vrrpAddressIfIndex,
+    vrrpAddressIfName,
+    vrrpAddressIfAlias,
+    vrrpAddressStatus,
+    vrrpAddressAdvertising,
+    vrrpRouteAddressType,
+    vrrpRouteDestination,
+    vrrpRouteDestinationMask,
+    vrrpRouteGateway,
+    vrrpRouteSecondaryGateway,
+    vrrpRouteSource,
+    vrrpRouteMetric,
+    vrrpRouteScope,
+    vrrpRouteType,
+    vrrpRouteIfIndex,
+    vrrpRouteIfName,
+    vrrpRouteRoutingTable,
+    vrrpRouteStatus
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for VRRP instances."
+        "Conformance group for VRRP instances."
     ::= { vrrpGroups 2 }
 
 vrrpScriptGroup OBJECT-GROUP
     OBJECTS {
-    	vrrpScriptName,
-	vrrpScriptCommand,
-	vrrpScriptInterval,
-	vrrpScriptWeight,
-	vrrpScriptResult,
-	vrrpScriptRise,
-	vrrpScriptFall
-	}
+    vrrpScriptName,
+    vrrpScriptCommand,
+    vrrpScriptInterval,
+    vrrpScriptWeight,
+    vrrpScriptResult,
+    vrrpScriptRise,
+    vrrpScriptFall
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for VRRP scripts."
+        "Conformance group for VRRP scripts."
     ::= { vrrpGroups 3 }
 
 vrrpTrapsGroup NOTIFICATION-GROUP
     NOTIFICATIONS {
-    	vrrpSyncGroupStateChange,
-    	vrrpInstanceStateChange
-	}
+        vrrpSyncGroupStateChange,
+        vrrpInstanceStateChange
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for VRRP traps."
+        "Conformance group for VRRP traps."
     ::= { vrrpGroups 4 }
 
 checkGroups OBJECT IDENTIFIER ::= { groups 3 }
 
 virtualServerGroupGroup OBJECT-GROUP
     OBJECTS {
-	virtualServerGroupName,
-	virtualServerGroupMemberType,
-	virtualServerGroupMemberFwMark,
-	virtualServerGroupMemberAddrType,
-	virtualServerGroupMemberAddress,
-	virtualServerGroupMemberAddr1,
-	virtualServerGroupMemberAddr2,
-	virtualServerGroupMemberPort
-	}
+    virtualServerGroupName,
+    virtualServerGroupMemberType,
+    virtualServerGroupMemberFwMark,
+    virtualServerGroupMemberAddrType,
+    virtualServerGroupMemberAddress,
+    virtualServerGroupMemberAddr1,
+    virtualServerGroupMemberAddr2,
+    virtualServerGroupMemberPort
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for virtual server groups."
+        "Conformance group for virtual server groups."
     ::= { checkGroups 1 }
 
 virtualServerGroup OBJECT-GROUP
     OBJECTS {
-	virtualServerType,
-	virtualServerNameOfGroup,
-	virtualServerFwMark,
-	virtualServerAddrType,
-	virtualServerAddress,
-	virtualServerPort,
-	virtualServerProtocol,
-	virtualServerLoadBalancingAlgo,
-	virtualServerLoadBalancingKind,
-	virtualServerStatus,
-	virtualServerVirtualHost,
-	virtualServerPersist,
-	virtualServerPersistTimeout,
-	virtualServerPersistGranularity,
-	virtualServerDelayLoop,
-	virtualServerHaSuspend,
-	virtualServerAlpha,
-	virtualServerOmega,
-	virtualServerRealServersTotal,
-	virtualServerRealServersUp,
-	virtualServerQuorum,
-	virtualServerQuorumStatus,
-	virtualServerQuorumUp,
-	virtualServerQuorumDown,
-	virtualServerHysteresis,
-	virtualServerStatsConns,
-	virtualServerStatsInPkts,
-	virtualServerStatsOutPkts,
-	virtualServerStatsInBytes,
-	virtualServerStatsOutBytes,
-	virtualServerRateCps,
-	virtualServerRateInPPS,
-	virtualServerRateOutPPS,
-	virtualServerRateInBPS,
-	virtualServerRateOutBPS
-	}
+    virtualServerType,
+    virtualServerNameOfGroup,
+    virtualServerFwMark,
+    virtualServerAddrType,
+    virtualServerAddress,
+    virtualServerPort,
+    virtualServerProtocol,
+    virtualServerLoadBalancingAlgo,
+    virtualServerLoadBalancingKind,
+    virtualServerStatus,
+    virtualServerVirtualHost,
+    virtualServerPersist,
+    virtualServerPersistTimeout,
+    virtualServerPersistGranularity,
+    virtualServerDelayLoop,
+    virtualServerHaSuspend,
+    virtualServerAlpha,
+    virtualServerOmega,
+    virtualServerRealServersTotal,
+    virtualServerRealServersUp,
+    virtualServerQuorum,
+    virtualServerQuorumStatus,
+    virtualServerQuorumUp,
+    virtualServerQuorumDown,
+    virtualServerHysteresis,
+    virtualServerStatsConns,
+    virtualServerStatsInPkts,
+    virtualServerStatsOutPkts,
+    virtualServerStatsInBytes,
+    virtualServerStatsOutBytes,
+    virtualServerRateCps,
+    virtualServerRateInPPS,
+    virtualServerRateOutPPS,
+    virtualServerRateInBPS,
+    virtualServerRateOutBPS,
+    virtualServerOPS
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for virtual servers."
+        "Conformance group for virtual servers."
     ::= { checkGroups 2 }
 
 realServerGroup OBJECT-GROUP
     OBJECTS {
-	realServerType,
-	realServerAddrType,
-	realServerAddress,
-	realServerPort,
-	realServerStatus,
-	realServerWeight,
-	realServerUpperConnectionLimit,
-	realServerLowerConnectionLimit,
-	realServerActionWhenDown,
-	realServerNotifyUp,
-	realServerNotifyDown,
-	realServerFailedChecks,
-	realServerStatsConns,
-	realServerStatsActiveConns,
-	realServerStatsInactiveConns,
-	realServerStatsPersistentConns,
-	realServerStatsInPkts,
-	realServerStatsOutPkts,
-	realServerStatsInBytes,
-	realServerStatsOutBytes,
-	realServerRateCps,
-	realServerRateInPPS,
-	realServerRateOutPPS,
-	realServerRateInBPS,
-	realServerRateOutBPS
-	}
+    realServerType,
+    realServerAddrType,
+    realServerAddress,
+    realServerPort,
+    realServerStatus,
+    realServerWeight,
+    realServerUpperConnectionLimit,
+    realServerLowerConnectionLimit,
+    realServerActionWhenDown,
+    realServerNotifyUp,
+    realServerNotifyDown,
+    realServerFailedChecks,
+    realServerStatsConns,
+    realServerStatsActiveConns,
+    realServerStatsInactiveConns,
+    realServerStatsPersistentConns,
+    realServerStatsInPkts,
+    realServerStatsOutPkts,
+    realServerStatsInBytes,
+    realServerStatsOutBytes,
+    realServerRateCps,
+    realServerRateInPPS,
+    realServerRateOutPPS,
+    realServerRateInBPS,
+    realServerRateOutBPS
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for real servers."
+        "Conformance group for real servers."
     ::= { checkGroups 3 }
 
 checkTrapsGroup NOTIFICATION-GROUP
     NOTIFICATIONS {
-    	realServerStateChange,
-    	virtualServerQuorumStateChange
-	}
+        realServerStateChange,
+        virtualServerQuorumStateChange
+    }
     STATUS current
     DESCRIPTION
-	"Conformance group for check traps."
+        "Conformance group for check traps."
     ::= { checkGroups 4 }
 
 END

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -348,23 +348,52 @@ vrrp_snmp_route(struct variable *vp, oid *name, size_t *length,
 		long_ret = 1;	/* IPv4 only */
 		return (u_char *)&long_ret;
 	case VRRP_SNMP_ROUTE_DESTINATION:
-		*var_len = 4;
-		return (u_char *)&route->dst;
+		if (route->dst) {
+			if (route->dst->ifa.ifa_family == AF_INET6) {
+				*var_len = 16;
+				return (u_char *)&route->dst->u.sin6_addr;
+			} else {
+				*var_len = 4;
+				return (u_char *)&route->dst->u.sin.sin_addr;
+			}
+		}
+		break;
 	case VRRP_SNMP_ROUTE_DESTINATIONMASK:
 		long_ret = route->dmask;
 		return (u_char *)&long_ret;
 	case VRRP_SNMP_ROUTE_GATEWAY:
-		*var_len = 4;
-		return (u_char *)&route->gw;
+		if (route->gw) {
+			if (route->gw->ifa.ifa_family == AF_INET6) {
+				*var_len = 16;
+				return (u_char *)&route->gw->u.sin6_addr;
+			} else {
+				*var_len = 4;
+				return (u_char *)&route->gw->u.sin.sin_addr;
+			}
+		}
+		break;
 	case VRRP_SNMP_ROUTE_SECONDARYGATEWAY:
 		if (route->gw2) {
-			*var_len = 4;
-			return (u_char *)&route->gw2;
+			if (route->gw2->ifa.ifa_family == AF_INET6) {
+				*var_len = 16;
+				return (u_char *)&route->gw2->u.sin6_addr;
+			} else {
+				*var_len = 4;
+				return (u_char *)&route->gw2->u.sin.sin_addr;
+			}
 		}
 		break;
 	case VRRP_SNMP_ROUTE_SOURCE:
-		*var_len = 4;
-		return (u_char *)&route->src;
+		if (route->src) {
+			if (route->src->ifa.ifa_family == AF_INET6) {
+				*var_len = 16;
+				return (u_char *)&route->src->u.sin6_addr;
+			} else {
+				*var_len = 4;
+				return (u_char *)&route->src->u.sin.sin_addr;
+			}
+		}
+		break;
 	case VRRP_SNMP_ROUTE_METRIC:
 		long_ret = route->metric;
 		return (u_char *)&long_ret;


### PR DESCRIPTION
Hi Alexandre,

This pull requests cleans up KEEPALIVED-MIB so that it passes smilint and makes some changes to vrrp_snmp_route() in vrrp_snmp.c. vrrp_snmp_route() was returning the address of the pointer instead of the IP address / network address for dst, gw, gw2, and src. 

Best Regards,
Chris Riley