### PR TITLE
Fix socket and interface setup and closedown code for IPv4 multicast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ lib/config.h
 *~
 *.swp
 .dir-locals.el
-
+autom4te.cache

--- a/configure
+++ b/configure
@@ -4124,7 +4124,7 @@ else
     #elif defined(LINUX_VERSION_CODE)
       fprintf (fp, "%d.%d.%d\n", LINUX_VERSION_CODE >> 16, (LINUX_VERSION_CODE >> 8) & 0xFF, LINUX_VERSION_CODE & 0xFF);
     #else
-      fprintf (fp, "0.0.0\n"); /* Let's fail gently */
+      fprintf (fp, "0.0.0\n"); /* Let''s fail gently */
     #endif
       fclose (fp);
       return 0;

--- a/configure
+++ b/configure
@@ -634,6 +634,7 @@ NETSNMP_CONFIG
 VRRP_VMAC
 IPVS_SYNCD
 KERN
+USE_NL3
 EGREP
 GREP
 CPP
@@ -3905,6 +3906,7 @@ else
 fi
 
 
+USE_NL3="_WITHOUT_LIBNL_"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_alloc in -lnl-3" >&5
 $as_echo_n "checking for nl_socket_alloc in -lnl-3... " >&6; }
 if ${ac_cv_lib_nl_3_nl_socket_alloc+:} false; then :
@@ -3991,6 +3993,50 @@ else
 
 fi
 
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_rtgen_request in -lnl-route-3" >&5
+$as_echo_n "checking for nl_rtgen_request in -lnl-route-3... " >&6; }
+if ${ac_cv_lib_nl_route_3_nl_rtgen_request+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lnl-route-3  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char nl_rtgen_request ();
+int
+main ()
+{
+return nl_rtgen_request ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_nl_route_3_nl_rtgen_request=yes
+else
+  ac_cv_lib_nl_route_3_nl_rtgen_request=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nl_route_3_nl_rtgen_request" >&5
+$as_echo "$ac_cv_lib_nl_route_3_nl_rtgen_request" >&6; }
+if test "x$ac_cv_lib_nl_route_3_nl_rtgen_request" = xyes; then :
+
+        USE_NL3="_HAVE_LIBNL3_"
+        CFLAGS="$CFLAGS $(pkg-config --cflags libnl-route-3.0)"
+        LIBS="$LIBS $(pkg-config --libs libnl-route-3.0)"
+
+fi
+
 
 else
 
@@ -4033,6 +4079,7 @@ $as_echo "$ac_cv_lib_nl_nl_socket_modify_cb" >&6; }
 if test "x$ac_cv_lib_nl_nl_socket_modify_cb" = xyes; then :
 
         USE_NL="LIBIPVS_USE_NL"
+        USE_NL3="_HAVE_LIBNL1_"
         CFLAGS="$CFLAGS -DFALLBACK_LIBNL1"
         LIBS="$LIBS $(pkg-config --libs libnl-1)"
 
@@ -4046,6 +4093,8 @@ fi
 
 
 fi
+
+
 
 
 CPPFLAGS="$CPPFLAGS -I$kernelinc"
@@ -6022,4 +6071,11 @@ if test "${DFLAGS}" = "-D_DEBUG_"; then
   echo "Use Debug flags          : Yes"
 else
   echo "Use Debug flags          : No"
+fi
+if test "${USE_NL3}" = "_HAVE_LIBNL3_"; then
+  echo "libnl version            : 3"
+elif test "${USE_NL3}" = "_HAVE_LIBNL1_"; then
+  echo "libnl version            : 1"
+else
+  echo "libnl version            : None"
 fi

--- a/configure.in
+++ b/configure.in
@@ -58,6 +58,7 @@ AC_CHECK_LIB(crypt, crypt,,AC_MSG_ERROR([crypt() function is required]))
 AC_CHECK_LIB(crypto, MD5_Init,,AC_MSG_ERROR([OpenSSL libraries are required]))
 AC_CHECK_LIB(ssl, SSL_CTX_new,,AC_MSG_ERROR([OpenSSL libraries are required]))
 
+USE_NL3="_WITHOUT_LIBNL_"
 AC_CHECK_LIB(nl-3, nl_socket_alloc,
   [
     AC_CHECK_LIB(nl-genl-3, genl_connect,
@@ -69,11 +70,18 @@ AC_CHECK_LIB(nl-3, nl_socket_alloc,
       [
         AC_MSG_ERROR([libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3.])
       ])
+    AC_CHECK_LIB(nl-route-3, nl_rtgen_request,
+      [
+        USE_NL3="_HAVE_LIBNL3_"
+        CFLAGS="$CFLAGS $(pkg-config --cflags libnl-route-3.0)"
+        LIBS="$LIBS $(pkg-config --libs libnl-route-3.0)"
+      ])
   ],
   [
     AC_CHECK_LIB(nl, nl_socket_modify_cb,
       [
         USE_NL="LIBIPVS_USE_NL"
+        USE_NL3="_HAVE_LIBNL1_"
         CFLAGS="$CFLAGS -DFALLBACK_LIBNL1"
         LIBS="$LIBS $(pkg-config --libs libnl-1)"
       ],
@@ -82,6 +90,8 @@ AC_CHECK_LIB(nl-3, nl_socket_alloc,
         AC_MSG_WARN([keepalived will be built without libnl support.])
       ])
   ])
+
+AC_SUBST(USE_NL3)
 
 dnl ----[ Kernel version check ]----
 CPPFLAGS="$CPPFLAGS -I$kernelinc"
@@ -391,5 +401,12 @@ if test "${DFLAGS}" = "-D_DEBUG_"; then
   echo "Use Debug flags          : Yes"
 else
   echo "Use Debug flags          : No"
+fi
+if test "${USE_NL3}" = "_HAVE_LIBNL3_"; then
+  echo "libnl version            : 3"
+elif test "${USE_NL3}" = "_HAVE_LIBNL1_"; then
+  echo "libnl version            : 1"
+else
+  echo "libnl version            : None"
 fi
 dnl ----[ end configure ]---

--- a/configure.in
+++ b/configure.in
@@ -111,7 +111,7 @@ AC_TRY_RUN([
     #elif defined(LINUX_VERSION_CODE)
       fprintf (fp, "%d.%d.%d\n", LINUX_VERSION_CODE >> 16, (LINUX_VERSION_CODE >> 8) & 0xFF, LINUX_VERSION_CODE & 0xFF);
     #else
-      fprintf (fp, "0.0.0\n"); /* Let's fail gently */
+      fprintf (fp, "0.0.0\n"); /* Let''s fail gently */
     #endif
       fclose (fp); 
       return 0;

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -328,8 +328,6 @@ int
 timeout_epilog(thread_t * thread, char *debug_msg)
 {
 	checker_t *checker = THREAD_ARG(thread);
-	http_checker_t *http_get_check = CHECKER_ARG(checker);
-	http_t *http = HTTP_ARG(http_get_check);
 
 	/* check if server is currently alive */
 	if (svr_checker_up(checker->id, checker->rs)) {

--- a/keepalived/include/ipvswrapper.h
+++ b/keepalived/include/ipvswrapper.h
@@ -31,7 +31,7 @@
 #include <arpa/inet.h>
 #include <asm/types.h>
 
-#include <net/if.h>
+#include <linux/if.h>
 #include <netinet/ip_icmp.h>
 #include <netinet/udp.h>
 #include <netinet/tcp.h>

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -209,7 +209,7 @@ typedef struct _vrrp_t {
 	char			*script_stop;
 	char			*script;
 
-	/* rfc2336.6.2 */
+	/* rfc2338.6.2 */
 	uint32_t		ms_down_timer;
 	timeval_t		sands;
 

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -303,6 +303,7 @@ extern void vrrp_state_leave_master(vrrp_t *);
 extern int vrrp_ipsecah_len(void);
 extern int vrrp_complete_init(void);
 extern int vrrp_ipvs_needed(void);
+extern void restore_vrrp_interfaces(void);
 extern void shutdown_vrrp_instances(void);
 extern void clear_diff_vrrp(void);
 extern void clear_diff_script(void);

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -24,7 +24,9 @@
 #define _VRRP_IF_H
 
 /* global includes */
-#include <net/if.h>
+#include <sys/socket.h>
+#include <linux/if.h>
+#include <netinet/in.h>
 
 /* needed to get correct values for SIOC* */
 #include <linux/sockios.h>
@@ -88,6 +90,9 @@ typedef struct _interface {
 	int			linkbeat;		/* LinkBeat from MII BMSR req */
 	int			vmac;			/* Set if interface is a VMAC interface */
 	unsigned int		base_ifindex;		/* Base interface index (if interface is a VMAC interface) */
+	int			reset_arp_config;	/* Count of how many vrrps have changed arp parameters on interface */
+	uint32_t		reset_arp_ignore_value;	/* Original value of arp_ignore to be restored */
+	uint32_t		reset_arp_filter_value;	/* Original value of arp_filter to be restored */
 } interface_t;
 
 /* Tracked interface structure definition */

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -135,6 +135,7 @@ extern int if_leave_vrrp_group(sa_family_t, int, interface_t *);
 extern int if_setsockopt_bindtodevice(int *, interface_t *);
 extern int if_setsockopt_hdrincl(int *);
 extern int if_setsockopt_ipv6_checksum(int *);
+extern int if_setsockopt_mcast_all(sa_family_t, int *);
 extern int if_setsockopt_mcast_loop(sa_family_t, int *);
 extern int if_setsockopt_mcast_hops(sa_family_t, int *);
 extern int if_setsockopt_mcast_if(sa_family_t, int *, interface_t *);

--- a/keepalived/include/vrrp_if_config.h
+++ b/keepalived/include/vrrp_if_config.h
@@ -1,0 +1,32 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        vrrp_if_config.c include file.
+ *
+ * Author:      Alexandre Cassen, <acassen@linux-vs.org>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2001-2015 Alexandre Cassen, <acassen@gmail.com>
+ */
+
+#ifndef _VRRP_IF_CONFIG_H
+#define _VRRP_IF_CONFIG_H 1
+
+#include "vrrp_if.h"
+
+/* prototypes */
+extern void set_interface_parameters(const interface_t*, interface_t*);
+extern void reset_interface_parameters(interface_t*);
+
+#endif

--- a/keepalived/vrrp/Makefile.in
+++ b/keepalived/vrrp/Makefile.in
@@ -2,23 +2,27 @@
 #
 # Keepalived OpenSource project.
 #
-# Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
+# Copyright (C) 2001-2015 Alexandre Cassen, <acassen@gmail.com>
 
 CC	 = @CC@
 SNMP_FLAG = @SNMP_SUPPORT@
+NL3_FLAG = @USE_NL3@
 INCLUDES = -I../include -I../../lib
 CFLAGS	 = $(INCLUDES) @CFLAGS@ @CPPFLAGS@ \
 	   -Wall -Wunused -Wstrict-prototypes
-DEFS	 = -D@KERN@ -D@IPVS_SUPPORT@ -D@IPVS_SYNCD@ -D@VRRP_VMAC@ -D@SNMP_SUPPORT@ @DFLAGS@
+DEFS	 = -D@KERN@ -D@IPVS_SUPPORT@ -D@IPVS_SYNCD@ -D@VRRP_VMAC@ -D@SNMP_SUPPORT@ -D@USE_NL3@ @DFLAGS@
 COMPILE	 = $(CC) $(CFLAGS) $(DEFS)
 
 OBJS = 	vrrp_daemon.o vrrp_print.o vrrp_data.o vrrp_parser.o \
 	vrrp.o vrrp_notify.o vrrp_scheduler.o vrrp_sync.o vrrp_index.o \
 	vrrp_netlink.o vrrp_arp.o vrrp_if.o vrrp_track.o vrrp_ipaddress.o \
-	vrrp_iproute.o vrrp_iprule.o vrrp_ipsecah.o vrrp_ndisc.o vrrp_vmac.o
+	vrrp_iproute.o vrrp_iprule.o vrrp_ipsecah.o vrrp_ndisc.o vrrp_vmac.o \
+	vrrp_if_config.o
+
 ifeq ($(SNMP_FLAG),_WITH_SNMP_)
   OBJS += vrrp_snmp.o
 endif
+
 HEADERS = $(OBJS:.o=.h)
 
 .c.o:
@@ -83,8 +87,9 @@ vrrp_ndisc.o: vrrp_ndisc.c ../include/vrrp_ndisc.h ../include/vrrp_ipaddress.h \
   ../../lib/utils.h ../../lib/memory.h
 vrrp_vmac.o: vrrp_vmac.c ../include/vrrp_vmac.h ../include/vrrp_netlink.h \
   ../include/vrrp_data.h ../../lib/logger.h ../../lib/memory.h ../../lib/utils.h \
-  ../../lib/bitops.h
+  ../../lib/bitops.h ../include/vrrp_if_config.h
 vrrp_snmp.o: vrrp_snmp.c ../include/vrrp_snmp.h ../include/vrrp_track.h \
   ../include/vrrp_data.h ../include/vrrp_ipaddress.h ../include/vrrp_iproute.h \
   ../include/vrrp_iprule.h ../include/vrrp.h ../../lib/vector.h ../../lib/list.h ../include/snmp.h \
   ../include/global_data.h ../../lib/logger.h
+vrrp_if_config.o: vrrp_if_config.c ../include/vrrp_if_config.h ../../lib/logger.h

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1111,10 +1111,10 @@ vrrp_restore_interface(vrrp_t * vrrp, int advF)
 {
         /* if we stop vrrp, warn the other routers to speed up the recovery */
 	if (advF) {
-	        syslog(LOG_INFO, "VRRP_Instance(%s) sending 0 priority",
-		       vrrp->iname);
 		vrrp_send_adv(vrrp, VRRP_PRIO_STOP);
 		++vrrp->stats->pri_zero_sent;
+	        syslog(LOG_INFO, "VRRP_Instance(%s) sent 0 priority",
+		       vrrp->iname);
 	}
 
 	/* remove virtual routes */
@@ -1519,11 +1519,10 @@ open_vrrp_socket(sa_family_t family, int proto, int idx,
 void
 close_vrrp_socket(vrrp_t * vrrp)
 {
-	if (LIST_ISEMPTY(vrrp->unicast_peer)) {
+	if (LIST_ISEMPTY(vrrp->unicast_peer))
 		if_leave_vrrp_group(vrrp->family, vrrp->fd_in, vrrp->ifp);
-	} else {
-		close(vrrp->fd_in);
-	}
+
+	close(vrrp->fd_in);
 	close(vrrp->fd_out);
 }
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1451,6 +1451,7 @@ open_vrrp_send_socket(sa_family_t family, int proto, int idx, int unicast)
 
 	if (family == AF_INET) {
 		/* Set v4 related */
+		if_setsockopt_mcast_all(family, &fd);
 		if_setsockopt_hdrincl(&fd);
 		if (unicast)
 			if_setsockopt_bindtodevice(&fd, ifp);
@@ -1467,7 +1468,6 @@ open_vrrp_send_socket(sa_family_t family, int proto, int idx, int unicast)
 	}
 
 	if_setsockopt_priority(&fd);
-
 	if (fd < 0)
 		return -1;
 
@@ -1492,6 +1492,10 @@ open_vrrp_socket(sa_family_t family, int proto, int idx,
 		log_message(LOG_INFO, "cant open raw socket. errno=%d", err);
 		return -1;
 	}
+
+	/* Ensure no unwanted multicast packets are queued to this interface */
+	if (family == AF_INET)
+		if_setsockopt_mcast_all(family, &fd);
 
 	/* Join the VRRP MCAST group */
 	if (!unicast) {

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -321,7 +321,7 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer)
 		 */
 		if ((ntohs(ip->tot_len) - ihl) <= sizeof(vrrphdr_t)) {
 			log_message(LOG_INFO,
-			       "ip payload too short. %d and expect at least %lu",
+			       "ip payload too short. %d and expect at least %zu",
 			       ntohs(ip->tot_len) - ihl, sizeof(vrrphdr_t));
 			++vrrp->stats->packet_len_err;
 			return VRRP_PACKET_KO;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -948,7 +948,7 @@ vrrp_send_adv(vrrp_t * vrrp, int prio)
 	}
 
 	++vrrp->stats->advert_sent;
-	/* send it */
+	/* sent it */
 	return 0;
 }
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1552,6 +1552,25 @@ new_vrrp_socket(vrrp_t * vrrp)
 	return vrrp->fd_in;
 }
 
+/* handle terminate state phase 1 */
+void
+restore_vrrp_interfaces(void)
+{
+	list l = vrrp_data->vrrp;
+	element e;
+	vrrp_t *vrrp;
+
+	/* Ensure any interfaces are in backup mode,
+	 * sending a priority 0 vrrp message
+	 */
+	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
+		vrrp = ELEMENT_DATA(e);
+		/* Remove VIPs/VROUTEs/VRULEs */
+		if (vrrp->state == VRRP_STATE_MAST)
+			vrrp_restore_interface(vrrp, 1);
+	}
+}
+
 /* handle terminate state */
 void
 shutdown_vrrp_instances(void)
@@ -1562,10 +1581,6 @@ shutdown_vrrp_instances(void)
 
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		vrrp = ELEMENT_DATA(e);
-
-		/* Remove VIPs/VROUTEs/VRULEs */
-		if (vrrp->state == VRRP_STATE_MAST)
-			vrrp_restore_interface(vrrp, 1);
 
 		/* Remove VMAC */
 		if (__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags))

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -85,6 +85,12 @@ stop_vrrp(void)
 	free_global_data(global_data);
 	vrrp_dispatcher_release(vrrp_data);
 
+	/* This is not nice, but it significantly increases the chances
+	 * of an IGMP leave group being sent for some reason.
+	 * Since we are about to exit, it doesn't affect anything else
+	 * running. */
+	sleep ( 1 );
+
 	if (!__test_bit(DONT_RELEASE_VRRP_BIT, &debug))
 		shutdown_vrrp_instances();
 

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -56,8 +56,10 @@ extern char *vrrp_pidfile;
 static void
 stop_vrrp(void)
 {
-	if (!__test_bit(DONT_RELEASE_VRRP_BIT, &debug))
-		shutdown_vrrp_instances();
+	/* Ensure any interfaces are in backup mode,
+	 * sending a priority 0 vrrp message
+	 */
+	restore_vrrp_interfaces();
 
 	/* Clear static entries */
 	netlink_rtlist(vrrp_data->static_routes, IPROUTE_DEL);
@@ -82,6 +84,10 @@ stop_vrrp(void)
 	/* Clean data */
 	free_global_data(global_data);
 	vrrp_dispatcher_release(vrrp_data);
+
+	if (!__test_bit(DONT_RELEASE_VRRP_BIT, &debug))
+		shutdown_vrrp_instances();
+
 	free_vrrp_data(vrrp_data);
 	free_vrrp_buffer();
 	free_interface_queue();

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -243,14 +243,14 @@ dump_vrrp(void *data)
 		log_message(LOG_INFO, "   Want State = BACKUP");
 	else
 		log_message(LOG_INFO, "   Want State = MASTER");
-	log_message(LOG_INFO, "   Runing on device = %s", IF_NAME(vrrp->ifp));
+	log_message(LOG_INFO, "   Running on device = %s", IF_NAME(vrrp->ifp));
 	if (vrrp->dont_track_primary)
 		log_message(LOG_INFO, "   VRRP interface tracking disabled");
 	if (vrrp->saddr.ss_family)
 		log_message(LOG_INFO, "   Using src_ip = %s"
 				    , inet_sockaddrtos(&vrrp->saddr));
 	if (vrrp->lvs_syncd_if)
-		log_message(LOG_INFO, "   Runing LVS sync daemon on interface = %s",
+		log_message(LOG_INFO, "   Running LVS sync daemon on interface = %s",
 		       vrrp->lvs_syncd_if);
 	if (vrrp->garp_delay)
 		log_message(LOG_INFO, "   Gratuitous ARP delay = %d",

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -326,9 +326,10 @@ dump_vrrp(void *data)
 	if (vrrp->smtp_alert)
 		log_message(LOG_INFO, "   Using smtp notification");
 	if (__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags))
-		log_message(LOG_INFO, "   Using VRRP VMAC (flags:%s|%s)"
+		log_message(LOG_INFO, "   Using VRRP VMAC (flags:%s|%s), vmac ifindex %d"
 				    , (__test_bit(VRRP_VMAC_UP_BIT, &vrrp->vmac_flags)) ? "UP" : "DOWN"
-				    , (__test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->vmac_flags)) ? "xmit_base" : "xmit");
+				    , (__test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->vmac_flags)) ? "xmit_base" : "xmit"
+				    , vrrp->ifp->base_ifindex);
 }
 
 void

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -150,20 +150,13 @@ static void
 free_sock(void *sock_data)
 {
 	sock_t *sock = sock_data;
-	interface_t *ifp;
 
 	/* First of all cancel pending thread */
 	thread_cancel(sock->thread);
 
 	/* Close related socket */
-	if (sock->fd_in > 0) {
-		ifp = if_get_by_ifindex(sock->ifindex);
-		if (sock->unicast) {
-			close(sock->fd_in);
-		} else {
-			if_leave_vrrp_group(sock->family, sock->fd_in, ifp);
-		}
-	}
+	if (sock->fd_in > 0)
+		close(sock->fd_in);
 	if (sock->fd_out > 0)
 		close(sock->fd_out);
 	FREE(sock_data);

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -459,7 +459,6 @@ if_join_vrrp_group(sa_family_t family, int *sd, interface_t *ifp, int proto)
 	if (family == AF_INET) {
 		memset(&imr, 0, sizeof(imr));
 		imr.imr_multiaddr = ((struct sockaddr_in *) &global_data->vrrp_mcast_group4)->sin_addr;
-		imr.imr_address.s_addr = IF_ADDR(ifp);
 		imr.imr_ifindex = IF_INDEX(ifp);
 
 		/* -> Need to handle multicast convergance after takeover.

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -488,7 +488,7 @@ if_join_vrrp_group(sa_family_t family, int *sd, interface_t *ifp, int proto)
 int
 if_leave_vrrp_group(sa_family_t family, int sd, interface_t *ifp)
 {
-	struct ip_mreq imr;
+	struct ip_mreqn imr;
 	struct ipv6_mreq imr6;
 	int ret = 0;
 
@@ -500,9 +500,9 @@ if_leave_vrrp_group(sa_family_t family, int sd, interface_t *ifp)
 	if (family == AF_INET) {
 		memset(&imr, 0, sizeof(imr));
 		imr.imr_multiaddr = ((struct sockaddr_in *) &global_data->vrrp_mcast_group4)->sin_addr;
-		imr.imr_interface.s_addr = IF_ADDR(ifp);
+		imr.imr_ifindex = IF_INDEX(ifp);
 		ret = setsockopt(sd, IPPROTO_IP, IP_DROP_MEMBERSHIP,
-				 (char *) &imr, sizeof(struct ip_mreq));
+				 (char *) &imr, sizeof(imr));
 	} else {
 		memset(&imr6, 0, sizeof(imr6));
 		imr6.ipv6mr_multiaddr = ((struct sockaddr_in6 *) &global_data->vrrp_mcast_group6)->sin6_addr;

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -513,12 +513,9 @@ if_leave_vrrp_group(sa_family_t family, int sd, interface_t *ifp)
 	if (ret < 0) {
 		log_message(LOG_INFO, "cant do IP%s_DROP_MEMBERSHIP errno=%s (%d)",
 			    (family == AF_INET) ? "" : "V6", strerror(errno), errno);
-		close(sd);
 		return -1;
 	}
 
-	/* Finally close the desc */
-	close(sd);
 	return 0;
 }
 

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -592,6 +592,31 @@ if_setsockopt_ipv6_checksum(int *sd)
 
 
 int
+if_setsockopt_mcast_all(sa_family_t family, int *sd)
+{
+	int ret;
+	unsigned char no = 0;
+
+	if (*sd < 0)
+		return -1;
+
+	if (family == AF_INET6)
+		return *sd;
+
+	/* Don't accept multicast packets we haven't requested */
+	ret = setsockopt(*sd, IPPROTO_IP, IP_MULTICAST_ALL, &no, sizeof(no));
+
+	if (ret < 0) {
+		log_message(LOG_INFO, "cant set IP_MULTICAST_ALL IP option. errno=%d (%m)",
+			    errno);
+		close(*sd);
+		*sd = -1;
+	}
+
+	return *sd;
+}
+
+int
 if_setsockopt_mcast_loop(sa_family_t family, int *sd)
 {
 	int ret;

--- a/keepalived/vrrp/vrrp_if_config.c
+++ b/keepalived/vrrp/vrrp_if_config.c
@@ -1,0 +1,302 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        vrrp_if_config interface
+ *
+ * Author:      Alexandre Cassen, <acassen@linux-vs.org>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2001-2015 Alexandre Cassen, <acassen@gmail.com>
+ */
+
+/* The following parameters need to be set on the vmac interface and its parent:
+ *
+ *   vmac interface:
+ *     accept_local=1	// We need to be able to hear another instance multicasting it's presence
+ *     arp_ignore=1	// We mustn't reply to ARP requests on this interface for IP address on parent interface
+ *			// and we mustn't only reply to addresses on the same subnet.
+ *     rp_filter=0	// Allows us to receive on VMAC interface when it has no IP address.
+ *
+ *   parent interface:
+ *     arp_ignore=1	// We mustn't reply to ARP requests on this interface for vrrp IP address
+ *     arp_filter=1	// We mustn't reply to ARP requests for our own IP address
+ */
+
+#include <string.h>
+#include "vrrp_if_config.h"
+#include "memory.h"
+
+#ifdef _HAVE_LIBNL3_
+#include <netlink/netlink.h>
+#include <netlink/route/link.h>
+#include <netlink/route/link/inet.h>
+#include <linux/ip.h>
+#include <syslog.h>
+
+#include "vrrp_if.h"
+#include "logger.h"
+
+#else
+#include <limits.h>
+#include <unistd.h>
+#endif
+
+#ifdef _HAVE_LIBNL3_
+static int
+netlink3_set_interface_parameters(const interface_t *ifp, interface_t *base_ifp)
+{
+	struct nl_sock *sk;
+	struct nl_cache *cache;
+	struct rtnl_link *link = NULL;
+	struct rtnl_link *new_state = NULL;
+	int res = 0;
+
+	if (!(sk = nl_socket_alloc())) {
+		log_message(LOG_INFO, "Unable to open netlink socket");
+		return -1;
+	}
+
+	if (nl_connect(sk, NETLINK_ROUTE) < 0)
+		goto err;
+	if (rtnl_link_alloc_cache(sk, AF_UNSPEC, &cache))
+		goto err;
+	if (!(link = rtnl_link_get(cache, ifp->ifindex)))
+		goto err;
+
+	// Allocate a new link
+	if (!(new_state = rtnl_link_alloc()))
+		goto err;
+
+	if (rtnl_link_inet_set_conf(new_state, IPV4_DEVCONF_ARP_IGNORE, 1) ||
+	    rtnl_link_inet_set_conf(new_state, IPV4_DEVCONF_ACCEPT_LOCAL, 1) ||
+	    rtnl_link_inet_set_conf(new_state, IPV4_DEVCONF_RP_FILTER, 0) ||
+	    rtnl_link_change (sk, link, new_state, 0))
+		goto err;
+
+	rtnl_link_put(new_state);
+	new_state = NULL;
+
+	rtnl_link_put(link);
+	link = NULL;
+
+	/* Set arp_ignore and arp_filter on base interface if needed */
+	if (base_ifp->reset_arp_config)
+		(base_ifp->reset_arp_config)++;
+	else {
+		if (!(link = rtnl_link_get(cache, base_ifp->ifindex)))
+			goto err;
+		if (rtnl_link_inet_get_conf(link, IPV4_DEVCONF_ARP_IGNORE, &base_ifp->reset_arp_ignore_value) < 0)
+			goto err;
+		if (rtnl_link_inet_get_conf(link, IPV4_DEVCONF_ARPFILTER, &base_ifp->reset_arp_filter_value) < 0)
+			goto err;
+
+		if (base_ifp->reset_arp_ignore_value != 1 ||
+		    base_ifp->reset_arp_filter_value != 1 ) {
+			/* The underlying interface mustn't reply for our address(es) */
+			if (!(new_state = rtnl_link_alloc()))
+				goto err;
+
+			if (rtnl_link_inet_set_conf(new_state, IPV4_DEVCONF_ARP_IGNORE, 1) ||
+			    rtnl_link_inet_set_conf(new_state, IPV4_DEVCONF_ARPFILTER, 1) ||
+			    rtnl_link_change(sk, link, new_state, 0))
+				goto err;
+
+			rtnl_link_put(new_state);
+			new_state = NULL;
+
+			rtnl_link_put(link);
+			link = NULL;
+
+			base_ifp->reset_arp_config = 1;
+		}
+	}
+
+	goto exit;
+err:
+	res = -1;
+
+	if (link)
+		rtnl_link_put(link);
+	if (new_state)
+		rtnl_link_put(new_state);
+
+exit:
+	nl_close ( sk ) ;
+
+	return res;
+}
+
+static int
+netlink3_reset_interface_parameters(const interface_t* ifp)
+{
+	struct nl_sock *sk;
+	struct nl_cache *cache;
+	struct rtnl_link *link = NULL;
+	struct rtnl_link *new_state = NULL;
+	int res = 0;
+
+	if (!(sk = nl_socket_alloc())) {
+		log_message(LOG_INFO, "Unable to open netlink socket");
+		return -1;
+	}
+
+	if (nl_connect(sk, NETLINK_ROUTE) < 0)
+		goto err;
+	if (rtnl_link_alloc_cache(sk, AF_UNSPEC, &cache))
+		goto err;
+	if (!(link = rtnl_link_get(cache, ifp->ifindex)))
+		goto err;
+	if (!(new_state = rtnl_link_alloc()))
+		goto err;
+	if (rtnl_link_inet_set_conf(new_state, IPV4_DEVCONF_ARP_IGNORE, ifp->reset_arp_ignore_value) ||
+	    rtnl_link_inet_set_conf(new_state, IPV4_DEVCONF_ARPFILTER, ifp->reset_arp_filter_value) ||
+	    rtnl_link_change(sk, link, new_state, 0))
+		goto err;
+
+	rtnl_link_put(link);
+	link = NULL;
+
+	rtnl_link_put(new_state);
+	new_state = NULL;
+
+	goto exit;
+err:
+	res = -1;
+
+	if (link)
+		rtnl_link_put(link);
+	if (new_state)
+		rtnl_link_put(new_state);
+
+exit:
+	nl_close(sk);
+
+	return res;
+}
+
+void
+set_interface_parameters(const interface_t *ifp, interface_t *base_ifp)
+{
+	if (netlink3_set_interface_parameters(ifp, base_ifp))
+		log_message(LOG_INFO, "Unable to set parameters for %s", ifp->ifname);
+}
+
+void
+reset_interface_parameters(interface_t *base_ifp)
+{
+	if (base_ifp->reset_arp_config && --base_ifp->reset_arp_config == 0) {
+		if (netlink3_reset_interface_parameters(base_ifp))
+			log_message(LOG_INFO, "Unable to reset parameters for %s", base_ifp->ifname);
+	}
+}
+
+#else
+
+/* Sysctl get and set functions */
+static void
+make_sysctl_filename(char *dest, const char* prefix, const char* iface, const char* parameter)
+{
+	strcpy(dest, "/proc/sys/");
+	strcat(dest, prefix);
+	strcat(dest, "/");
+	strcat(dest, iface);
+	strcat(dest, "/");
+	strcat(dest, parameter);
+}
+
+static int
+get_sysctl(const char* prefix, const char* iface, const char* parameter)
+{
+	char *filename;
+	char buf[1];
+	int fd;
+	int len;
+
+	/* Make the filename */
+	filename = MALLOC(PATH_MAX);
+	make_sysctl_filename(filename, prefix, iface, parameter);
+
+	fd = open(filename, O_RDONLY);
+	FREE(filename);
+	if (fd<0)
+		return -1;
+
+	len = read(fd, &buf, 1);
+	close(fd);
+
+	/* We only read integers 0-9 */
+	if (len <= 0)
+		return -1;
+
+	/* Return the value of the string read */
+	return buf[0] - '0';
+}
+
+static int
+set_sysctl(const char* prefix, const char* iface, const char* parameter, int value)
+{
+	char* filename;
+	char buf[1];
+	int fd;
+	int len;
+
+	/* Make the filename */
+	filename = MALLOC(PATH_MAX);
+	make_sysctl_filename(filename, prefix, iface, parameter);
+
+	fd = open(filename, O_WRONLY);
+	FREE(filename);
+	if (fd <0)
+		return -1;
+
+	/* We only write integers 0-9 */
+	buf[0] = '0' + value;
+	len = write(fd, &buf, 1);
+	close(fd);
+
+	if (len != 1)
+		return -1;
+
+	/* Success */
+	return 0;
+}
+
+void
+set_interface_parameters(const interface_t *ifp, interface_t *base_ifp)
+{
+	set_sysctl("net/ipv4/conf", ifp->ifname, "arp_ignore", 1);
+	set_sysctl("net/ipv4/conf", ifp->ifname, "accept_local", 1);
+	set_sysctl("net/ipv4/conf", ifp->ifname, "rp_filter", 0);
+
+	if (base_ifp->reset_arp_config)
+		base_ifp->reset_arp_config++;
+	else {
+		if ((base_ifp->reset_arp_ignore_value = get_sysctl("net/ipv4/conf", base_ifp->ifname, "arp_ignore")) != 1)
+			set_sysctl("net/ipv4/conf", base_ifp->ifname, "arp_ignore", 1);
+
+		if ((base_ifp->reset_arp_filter_value = get_sysctl("net/ipv4/conf", base_ifp->ifname, "arp_filter")) != 1)
+			set_sysctl("net/ipv4/conf", base_ifp->ifname, "arp_filter", 1);
+
+		base_ifp->reset_arp_config = 1;
+	}
+}
+
+void reset_interface_parameters(interface_t *base_ifp)
+{
+	if (base_ifp->reset_arp_config && --base_ifp->reset_arp_config == 0) {
+		set_sysctl("net/ipv4/conf", base_ifp->ifname, "arp_ignore", base_ifp->reset_arp_ignore_value);
+		set_sysctl("net/ipv4/conf", base_ifp->ifname, "arp_filter", base_ifp->reset_arp_filter_value);
+	}
+}
+#endif

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -477,6 +477,7 @@ netlink_if_link_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 	ifp->ifindex = ifi->ifi_index;
 	ifp->mtu = *(int *) RTA_DATA(tb[IFLA_MTU]);
 	ifp->hw_type = ifi->ifi_type;
+	ifp->reset_arp_config = 0;
 
 	if (!ifp->vmac) {
 		if_vmac_reflect_flags(ifi->ifi_index, ifi->ifi_flags);

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -308,7 +308,7 @@ vrrp_debug_handler(vector_t *strvec)
 	vrrp->debug = atoi(vector_slot(strvec, 1));
 
 	if (VRRP_IS_BAD_DEBUG_INT(vrrp->debug)) {
-		log_message(LOG_INFO, "VRRP Error : Debug interval not valid !");
+		log_message(LOG_INFO, "VRRP Error : Debug value not valid !");
 		log_message(LOG_INFO, "             must be between 0-4");
 		vrrp->debug = 0;
 	}

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -20,15 +20,16 @@
  * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
  */
 
+/* global include */
+//#include <limits.h>
+
 /* local include */
 #include "vrrp_vmac.h"
 #include "vrrp_netlink.h"
 #include "vrrp_data.h"
 #include "logger.h"
-#include "memory.h"
-#include "utils.h"
-#include "parser.h"
 #include "bitops.h"
+#include "vrrp_if_config.h"
 
 #ifdef _HAVE_VRRP_VMAC_
 /* private matter */
@@ -69,6 +70,7 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 	struct rtattr *data;
 	unsigned int base_ifindex;
 	interface_t *ifp;
+	interface_t *base_ifp;
 	char ifname[IFNAMSIZ];
 	u_char ll_addr[ETH_ALEN] = {0x00, 0x00, 0x5e, 0x00, 0x01, vrrp->vrid};
 	struct {
@@ -175,6 +177,7 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 	ifp = if_get_by_ifname(ifname);
 	if (!ifp)
 		return -1;
+	base_ifp = vrrp->ifp;
 	base_ifindex = vrrp->ifp->ifindex;
 	ifp->flags = vrrp->ifp->flags; /* Copy base interface flags */
 	vrrp->ifp = ifp;
@@ -183,6 +186,11 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 	vrrp->vmac_ifindex = IF_INDEX(vrrp->ifp); /* For use on delete */
 	__set_bit(VRRP_VMAC_UP_BIT, &vrrp->vmac_flags);
 	netlink_link_up(vrrp);
+
+	if (vrrp->family == AF_INET) {
+		/* Set the necessary kernel parameters to make macvlans work for us */
+		set_interface_parameters(ifp, base_ifp);
+	}
 #endif
 	return 1;
 }
@@ -193,6 +201,7 @@ netlink_link_del_vmac(vrrp_t *vrrp)
 	int status = 1;
 
 #ifdef _HAVE_VRRP_VMAC_
+	interface_t *base_ifp ;
 	struct {
 		struct nlmsghdr n;
 		struct ifinfomsg ifi;
@@ -201,6 +210,10 @@ netlink_link_del_vmac(vrrp_t *vrrp)
 
 	if (!vrrp->ifp)
 		return -1;
+
+	/* Reset arp_ignore and arp_filter on the base interface if necessary */
+	base_ifp = if_get_by_ifindex(vrrp->ifp->base_ifindex);
+	reset_interface_parameters(base_ifp);
 
 	memset(&req, 0, sizeof (req));
 

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -226,7 +226,7 @@ netlink_link_del_vmac(vrrp_t *vrrp)
 	if (netlink_talk(&nl_cmd, &req.n) < 0) {
 		log_message(LOG_INFO, "vmac: Error removing VMAC interface %s for vrrp_instance %s!!!"
 				    , vrrp->vmac_ifname, vrrp->iname);
-		status = -1;
+		return -1;
 	}
 
 	log_message(LOG_INFO, "vmac: Success removing VMAC interface %s for vrrp_instance %s"


### PR DESCRIPTION
The following series of patches resolve a number of issues regarding
the use of macvlans with vrrp. Some of the other patches fix typos
that were noticed during investigating the other fixes.

Principally, the patches change some of the ioctls that are called,
and some of the parameters that are passed, set the necessary options
in /proc/sys/net/ipv4/conf automatically, and restore them on exit,
and re-order the closedown sequence.

The end result of the patches is that keepalived starts up and
closes down without any error messages, and there is no need for
external intervention to set the configuration on the vmac or
physical interfaces.

The explicit call of IGMP_DROP_MEMBERSHIP at closedown is also removed, since the kernel handles that when the interface is deleted.