### PR TITLE
Documentation updates, removal of redundant code, global config

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -34,6 +34,16 @@ global_defs {				# Block identification
     router_id <STRING>			   # String identifying router
     vrrp_mcast_group4 <IPv4 ADDRESS>	   # optional, default 224.0.0.18
     vrrp_mcast_group6 <IPv6 ADDRESS>	   # optional, default ff02::12
+    vrrp_garp_master_delay <INTEGER>	   # delay in seconds for second set of gratuitous ARP
+					   #  messages after MASTER state transition, default 5
+    vrrp_garp_master_repeat <INTEGER>	   # how many gratuitous ARP messages after MASTER
+					   #  state transition should be sent, default 5
+    vrrp_garp_master_refresh <INTEGER>	   # Periodic delay in seconds sending
+					   #  gratuitous ARP while in MASTER state
+					   #  Default: 0 (no refreshing)
+    vrrp_garp_master_refresh_repeat <INTEGER> # how many gratuitous ARP messages shoule be sent
+					   #  at each periodic repeat
+					   #  Default: once (per period)
 }
 
 linkbeat_use_polling	# Use media link failure detection polling fashion
@@ -175,15 +185,14 @@ vrrp_instance <STRING> {		# VRRP instance declaration
       ...				#  in unicast design fashion
     }
     lvs_sync_daemon_interface <STRING>	# Binding interface for lvs syncd
-    garp_master_delay <INTEGER>		# delay for gratuitous ARP after MASTER
-					#  state transition
-    garp_master_repeat <INTEGER>        # how often the gratuitous ARP after MASTER
-                                        #  state transition should be repeated?
-    garp_master_refresh <INTEGER>	# Periodic delay in seconds sending
-					#  gratuitous ARP while in MASTER state
-    garp_master_refresh_repeat <INTEGER># how often the periodically repeated gratuitous ARP
-                                        #  should be repeated?
-                                        #  Default: once (per period)
+
+    # The following garp parameters take their defaults from the global config for vrrp_garp_master_...
+    # See their descriptions for the meaning of the parameters.
+    garp_master_delay <INTEGER>
+    garp_master_repeat <INTEGER>
+    garp_master_refresh <INTEGER>
+    garp_master_refresh_repeat <INTEGER>
+
     virtual_router_id <INTEGER-0..255>	# VRRP VRID
     priority <INTEGER-0..255>		# VRRP PRIO
     advert_int <INTEGER>		# VRRP Advert interval (use default)

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -44,6 +44,7 @@ global_defs {				# Block identification
     vrrp_garp_master_refresh_repeat <INTEGER> # how many gratuitous ARP messages shoule be sent
 					   #  at each periodic repeat
 					   #  Default: once (per period)
+    vrrp_version <INTEGER:2..3>            # Default VRRP version (default 2)
 }
 
 linkbeat_use_polling	# Use media link failure detection polling fashion
@@ -159,6 +160,7 @@ Important: for a SYNC group to run reliably, it is vital that all instances in
 
 vrrp_instance <STRING> {		# VRRP instance declaration
     use_vmac				# Use VRRP Virtual MAC
+    version <INTEGER:2..3>              # VRRP version to use
     vmac_xmit_base			# Send/Recv VRRP messages from base
 					#  interface instead of VMAC interface
     native_ipv6				# Force instance to use IPv6

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -56,6 +56,9 @@ and
  # number of gratuitous ARP messages to send at a time while MASTER
  vrrp_garp_master_refresh_repeat 2 # default 1
 
+ # Set the default VRRP version to use
+ vrrp_version <2 or 3>        # default version 2
+
  enable_traps                 # enable SNMP traps
  }
 
@@ -192,7 +195,8 @@ which will transition together on any state change.
     mcast_src_ip <IPADDR>
     unicast_src_ip <IPADDR>
 
-    version <2 or 3>		# VRRP version to run on interface (default 2)
+    version <2 or 3>		# VRRP version to run on interface
+                                #  default is global parameter vrrp_version.
 
     # Do not send VRRP adverts over VRRP multicast group.
     # Instead it sends adverts to the following list of

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -57,8 +57,10 @@ and
  vrrp_garp_master_refresh_repeat 2 # default 1
 
  enable_traps                 # enable SNMP traps
+ plugin_dir                   # UNIMPLEMENTED
  }
 
+ linkbeat_use_polling         # Poll to detect media link failure otherwise attempt to use ETHTOOL or MII interface
 
 .SH Static routes/addresses/rules
 .PP
@@ -132,6 +134,8 @@ and
     # Send email notification during state transition,
     # using addresses in global_defs above.
     smtp_alert
+
+    global_tracking	# All VRRP share same tracking conf
  }
 
 .SH VRRP instance(s)
@@ -160,6 +164,8 @@ which will transition together on any state change.
     # VMAC interface
     vmac_xmit_base
 
+    native_ipv6		# force instance to use IPv6 (when mixed IPv4 and IPv6 config).
+
     # Ignore VRRP interface faults (default unset)
     dont_track_primary
 
@@ -168,7 +174,14 @@ which will transition together on any state change.
     track_interface {
       eth0
       eth1
+      eth2 weight <-254..254>
       ...
+    }
+
+    # add a tracking script to the interface
+    track_script {
+        <SCRIPT_PATH>
+        <SCRIPT_PATH> weight <-254..254>
     }
 
     # default IP for binding vrrpd is the primary IP
@@ -179,6 +192,8 @@ which will transition together on any state change.
     # optional
     mcast_src_ip <IPADDR>
     unicast_src_ip <IPADDR>
+
+    version <2 or 3>		# VRRP version to run on interface (default 2)
 
     # Do not send VRRP adverts over VRRP multicast group.
     # Instead it sends adverts to the following list of
@@ -250,10 +265,19 @@ which will transition together on any state change.
         192.168.110.0/24 via 192.168.200.254 dev eth1
         192.168.111.0/24 dev eth2
         192.168.112.0/24 via 192.168.100.254
-	    192.168.113.0/24 via 192.168.200.254 or 192.168.100.254 dev eth1
-	    blackhole 192.168.114.0/24
+        192.168.113.0/24 via 192.168.200.254 or 192.168.100.254 dev eth1
+        blackhole 192.168.114.0/24
         0.0.0.0/0 gw 192.168.0.1 table 100  # To set a default gateway into table 100.
     }
+
+    # rules add|del when changing to MASTER, to BACKUP
+    virtual_rules {
+        from 192.168.2.0/24 table 1
+        to 192.168.2.0/24 table 1
+    }
+
+    accept	# Allow the non-master owner to process the packets destined to VIP
+
     # rules add|del when changing to MASTER, to BACKUP
     static_rules {
         from 192.168.2.0/24 table 1
@@ -268,6 +292,7 @@ which will transition together on any state change.
     # NOTE: For this to work, the initial state of this
     # entry must be BACKUP.
     nopreempt
+    preempt		# for backwards compatibility
 
     # Seconds after startup until preemption
     # (if not disabled by "nopreempt").
@@ -283,9 +308,31 @@ which will transition together on any state change.
     notify_master <STRING>|<QUOTED-STRING>
     notify_backup <STRING>|<QUOTED-STRING>
     notify_fault <STRING>|<QUOTED-STRING>
+    notify_stop <STRING>|<QUOTED_STRING>	# run when stopping vrrp
     notify <STRING>|<QUOTED-STRING>
     smtp_alert
  }
+
+# Adds a script to be executed periodically. Its exit code will be
+# recorded for all VRRP instances which are monitoring it with
+# non-zero weight.
+vrrp_script <SCRIPT_NAME> {
+	script <QUOTED_STRING>	# path of script to execute
+	interval <INTEGER>	# seconds between script invocations, default 1 second
+	timeout	<INTEGER>	# seconds after which script is considered to have failed
+	weight<INTEGER:-254..254> # adjust priority by this weight, default 2
+	rise <INTEGER>		# required number of successes for OK transition
+	fall <INTEGER>		# required number of successes for KO transition
+}
+
+# Parameters used for SSL GET check.
+# If none of the parameters are specified, the SSL context will be auto generated
+SSL {
+	password <STRING>	# password
+	ca <STRING>		# ca file
+	certificate <STRING>	# certificate file
+	key <STRING>		# key file
+}
 
 .SH LVS CONFIGURATION
 contains subblocks of
@@ -357,6 +404,9 @@ A virtual_server can be a declaration of one of
     # suspend healthchecker's activity
     ha_suspend
 
+    lvs_sched	# synonym for lb_algo
+    lvs_method	# synonym for lb_kind
+
     # VirtualHost string for HTTP_GET or SSL_GET
     # eg virtualhost www.firewall.loc
     virtualhost <STRING>
@@ -415,6 +465,9 @@ A virtual_server can be a declaration of one of
            # Script to launch when healthchecker
            # considers service as down.
            notify_down <STRING>|<QUOTED-STRING>
+
+	   uthreshold <INTEGER>	# maximum number of connections to server
+	   lthreshold <INTEGER>	# minimum number of connections to server
 
            # pick one healthchecker
            # HTTP_GET|SSL_GET|TCP_CHECK|SMTP_CHECK|MISC_CHECK

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -43,6 +43,19 @@ and
                               # (doesn't have to be hostname).
  vrrp_mcast_group4 224.0.0.18 # optional, default 224.0.0.18
  vrrp_mcast_group6 ff02::12   # optional, default ff02::12
+
+ # delay for second set of gratuitous ARPs after transition to MASTER
+ vrrp_garp_master_delay 10    # secs, default 5, 0 for no second set
+
+ # number of gratuitous ARP messages to send at a time after transition to MASTER
+ vrrp_garp_master_repeat 1    # default 5
+
+ # minimum time interval for refreshing gratuitous ARPs while MASTER
+ vrrp_garp_master_refresh 60  # secs, default 0 (no refreshing)
+
+ # number of gratuitous ARP messages to send at a time while MASTER
+ vrrp_garp_master_refresh_repeat 2 # default 1
+
  enable_traps                 # enable SNMP traps
  }
 
@@ -181,8 +194,11 @@ which will transition together on any state change.
     # Binding interface for lvs syncd
     lvs_sync_daemon_interface eth1
 
-    # delay for gratuitous ARP after transition to MASTER
-    garp_master_delay 10 # secs, default 5
+    # interface specific settings, same as global parameters; default to global parameters
+    garp_master_delay 10
+    garp_master_repeat 1
+    garp_master_refresh 60
+    garp_master_refresh_repeat 2
 
     # arbitrary unique number 0..255
     # used to differentiate multiple instances of vrrpd

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -57,7 +57,6 @@ and
  vrrp_garp_master_refresh_repeat 2 # default 1
 
  enable_traps                 # enable SNMP traps
- plugin_dir                   # UNIMPLEMENTED
  }
 
  linkbeat_use_polling         # Poll to detect media link failure otherwise attempt to use ETHTOOL or MII interface

--- a/doc/man/man8/keepalived.8
+++ b/doc/man/man8/keepalived.8
@@ -34,8 +34,8 @@ well\-known and widely used Linux Virtual Server (IPVS) kernel module
 providing Layer4 load\-balancing. Keepalived implements a set of
 checkers to dynamically and adaptively maintain and manage
 load\-balanced server pool according their health. Keepalived also
-implements the VRRPv2 protocol to achieve high\-availability with
-director failover.
+implements the VRRPv2 and VRRPv3 protocols to achieve high\-availability
+with director failover.
 
 .SH "OPTIONS"
 .TP
@@ -60,6 +60,9 @@ Detailed log messages.
 .TP
 \fB -S, --log-facility\fP=[0-7]
 Set syslog facility to LOG_LOCAL[0-7]. The default syslog facility is LOG_DAEMON.
+.TP
+\fB -X, --release-vips\fP
+Drop VIP on transition from signal.
 .TP
 \fB -V, --dont-release-vrrp\fP
 Don't remove VRRP VIPs and VROUTEs on daemon stop. The default
@@ -104,6 +107,44 @@ Display the version and exit.
 .TP
 \fB -h, --help\fP
 Display this help message and exit.
+
+.SH SIGNALS
+.B keepalived
+reacts to a set of signals.  You may easily send a signal to
+the parent
+.B keepalived
+process using the following:
+.IP
+.nf
+kill -SIGNAL $(cat /var/run/keepalived.pid)
+.fi
+.PP
+Note that -SIGNAL must be replaced with the actual signal
+you are trying to send, e.g. with HUP. So it then becomes:
+.IP
+.nf
+kill -HUP $(cat /var/run/keepalived.pid)
+.fi
+.PP
+.TP
+.B HUP
+This causes
+.B keepalived
+to close down all interfaces, reload its configuration, and start up the
+new configuration.
+.TP
+.B TERM, INT
+.B keepalived
+will die.
+.TP
+.B USR1
+Write configuration data to
+.B /tmp/keepalived.data
+.TP
+.B USR2
+Write statistics info to
+.B /tmp/keepalived.stats
+.LP
 
 .SH "SEE ALSO"
 \fBkeepalived.conf\fP(5), \fBipvsadm\fP(8)

--- a/doc/samples/keepalived.conf.misc_check
+++ b/doc/samples/keepalived.conf.misc_check
@@ -14,7 +14,6 @@ virtual_server 10.10.10.2 1358 {
     delay_loop 6
     lb_algo rr 
     lb_kind NAT
-    nat_mask 255.255.255.0
     persistence_timeout 50
     protocol TCP
 

--- a/doc/samples/keepalived.conf.misc_check_arg
+++ b/doc/samples/keepalived.conf.misc_check_arg
@@ -14,7 +14,6 @@ virtual_server 10.10.10.2 1358 {
     delay_loop 6
     lb_algo rr 
     lb_kind NAT
-    nat_mask 255.255.255.0
     persistence_timeout 50
     protocol TCP
 

--- a/doc/samples/keepalived.conf.vrrp.lvs_syncd
+++ b/doc/samples/keepalived.conf.vrrp.lvs_syncd
@@ -51,7 +51,6 @@ virtual_server 192.168.200.19 80 {
     delay_loop 20
     lb_algo rr
     lb_kind NAT
-    nat_mask 255.255.255.0
     persistence_timeout 50
     protocol TCP
 

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -128,12 +128,6 @@ lbkind_handler(vector_t *strvec)
 		log_message(LOG_INFO, "PARSER : unknown [%s] routing method.", str);
 }
 static void
-natmask_handler(vector_t *strvec)
-{
-	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
-	inet_ston(vector_slot(strvec, 1), &vs->nat_mask);
-}
-static void
 pto_handler(vector_t *strvec)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
@@ -323,7 +317,6 @@ check_init_keywords(void)
 	install_keyword("lvs_sched", &lbalgo_handler);
 	install_keyword("lb_kind", &lbkind_handler);
 	install_keyword("lvs_method", &lbkind_handler);
-	install_keyword("nat_mask", &natmask_handler);
 	install_keyword("persistence_timeout", &pto_handler);
 	install_keyword("persistence_granularity", &pgr_handler);
 	install_keyword("protocol", &proto_handler);

--- a/keepalived/check/check_snmp.c
+++ b/keepalived/check/check_snmp.c
@@ -280,17 +280,6 @@ check_snmp_virtualserver(struct variable *vp, oid *name, size_t *length,
 		long_ret = 0;
 		switch (v->loadbalancing_kind) {
 #ifdef _WITH_LVS_
-#ifdef _KRNL_2_2_
-		case 0:
-			long_ret = 1;
-			break;
-		case IP_MASQ_F_VS_DROUTE:
-			long_ret = 2;
-			break;
-		case IP_MASQ_F_VS_TUNNEL:
-			long_ret = 3;
-			break;
-#else
 		case IP_VS_CONN_F_MASQ:
 			long_ret = 1;
 			break;
@@ -300,7 +289,6 @@ check_snmp_virtualserver(struct variable *vp, oid *name, size_t *length,
 		case IP_VS_CONN_F_TUNNEL:
 			long_ret = 3;
 			break;
-#endif
 #endif
 		}
 		if (!long_ret) break;

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -29,6 +29,7 @@
 #include "list.h"
 #include "logger.h"
 #include "utils.h"
+#include "vrrp.h"
 
 /* global vars */
 data_t *global_data = NULL;
@@ -84,6 +85,14 @@ set_default_mcast_group(data_t * data)
 	inet_stosockaddr("ff02::12", 0, &data->vrrp_mcast_group6);
 }
 
+static void
+set_vrrp_defaults(data_t * data)
+{
+	data->vrrp_garp_rep = VRRP_GARP_REP;
+	data->vrrp_garp_refresh_rep = VRRP_GARP_REFRESH_REP;
+	data->vrrp_garp_delay = VRRP_GARP_DELAY;
+}
+
 /* email facility functions */
 static void
 free_email(void *data)
@@ -119,6 +128,7 @@ alloc_global_data(void)
 	new->email = alloc_list(free_email, dump_email);
 
 	set_default_mcast_group(new);
+	set_vrrp_defaults(new);
 
 	return new;
 }
@@ -182,6 +192,14 @@ dump_global_data(data_t * data)
 		log_message(LOG_INFO, " VRRP IPv6 mcast group = %s"
 				    , inet_sockaddrtos(&data->vrrp_mcast_group6));
 	}
+	if (data->vrrp_garp_delay)
+		log_message(LOG_INFO, " Gratuitous ARP delay = %d",
+		       data->vrrp_garp_delay/TIMER_HZ);
+	if (!timer_isnull(data->vrrp_garp_refresh))
+		log_message(LOG_INFO, " Gratuitous ARP refresh timer = %lu",
+		       data->vrrp_garp_refresh.tv_sec);
+	log_message(LOG_INFO, " Gratuitous ARP repeat = %d", data->vrrp_garp_rep);
+	log_message(LOG_INFO, " Gratuitous ARP refresh repeat = %d", data->vrrp_garp_refresh_rep);
 #ifdef _WITH_SNMP_
 	if (data->enable_traps)
 		log_message(LOG_INFO, " SNMP Trap enabled");

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -91,6 +91,7 @@ set_vrrp_defaults(data_t * data)
 	data->vrrp_garp_rep = VRRP_GARP_REP;
 	data->vrrp_garp_refresh_rep = VRRP_GARP_REFRESH_REP;
 	data->vrrp_garp_delay = VRRP_GARP_DELAY;
+	data->vrrp_version = VRRP_VERSION_2;
 }
 
 /* email facility functions */
@@ -197,6 +198,7 @@ dump_global_data(data_t * data)
 		       data->vrrp_garp_refresh.tv_sec);
 	log_message(LOG_INFO, " Gratuitous ARP repeat = %d", data->vrrp_garp_rep);
 	log_message(LOG_INFO, " Gratuitous ARP refresh repeat = %d", data->vrrp_garp_refresh_rep);
+	log_message(LOG_INFO, " VRRP default protocol version = %d", data->vrrp_version);
 #ifdef _WITH_SNMP_
 	if (data->enable_traps)
 		log_message(LOG_INFO, " SNMP Trap enabled");

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -155,7 +155,6 @@ free_global_data(data_t * data)
 {
 	free_list(data->email);
 	FREE_PTR(data->router_id);
-	FREE_PTR(data->plugin_dir);
 	FREE_PTR(data->email_from);
 	FREE(data);
 }
@@ -172,8 +171,6 @@ dump_global_data(data_t * data)
 	}
 	if (data->router_id)
 		log_message(LOG_INFO, " Router ID = %s", data->router_id);
-	if (data->plugin_dir)
-		log_message(LOG_INFO, " Plugin dir = %s", data->plugin_dir);
 	if (data->smtp_server.ss_family)
 		log_message(LOG_INFO, " Smtp server = %s", inet_sockaddrtos(&data->smtp_server));
 	if (data->smtp_connection_to)

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -46,11 +46,6 @@ routerid_handler(vector_t *strvec)
 	global_data->router_id = set_value(strvec);
 }
 static void
-plugin_handler(vector_t *strvec)
-{
-	global_data->plugin_dir = set_value(strvec);
-}
-static void
 emailfrom_handler(vector_t *strvec)
 {
 	FREE_PTR(global_data->email_from);
@@ -147,7 +142,6 @@ global_init_keywords(void)
 	install_keyword_root("linkbeat_use_polling", use_polling_handler);
 	install_keyword_root("global_defs", NULL);
 	install_keyword("router_id", &routerid_handler);
-	install_keyword("plugin_dir", &plugin_handler);
 	install_keyword("notification_email_from", &emailfrom_handler);
 	install_keyword("smtp_server", &smtpserver_handler);
 	install_keyword("smtp_connect_timeout", &smtpto_handler);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -108,6 +108,30 @@ vrrp_mcast_group6_handler(vector_t *strvec)
 				   , FMT_STR_VSLOT(strvec, 1));
 	}
 }
+static void
+vrrp_garp_delay_handler(vector_t *strvec)
+{
+	global_data->vrrp_garp_delay = atoi(vector_slot(strvec, 1)) * TIMER_HZ;
+}
+static void
+vrrp_garp_refresh_handler(vector_t *strvec)
+{
+	global_data->vrrp_garp_refresh.tv_sec = atoi(vector_slot(strvec, 1));
+}
+static void
+vrrp_garp_rep_handler(vector_t *strvec)
+{
+	global_data->vrrp_garp_rep = atoi(vector_slot(strvec, 1));
+	if ( global_data->vrrp_garp_rep < 1 )
+		global_data->vrrp_garp_rep = 1;
+}
+static void
+vrrp_garp_refresh_rep_handler(vector_t *strvec)
+{
+	global_data->vrrp_garp_refresh_rep = atoi(vector_slot(strvec, 1));
+	if ( global_data->vrrp_garp_refresh_rep < 1 )
+		global_data->vrrp_garp_refresh_rep = 1;
+}
 #ifdef _WITH_SNMP_
 static void
 trap_handler(vector_t *strvec)
@@ -130,6 +154,10 @@ global_init_keywords(void)
 	install_keyword("notification_email", &email_handler);
 	install_keyword("vrrp_mcast_group4", &vrrp_mcast_group4_handler);
 	install_keyword("vrrp_mcast_group6", &vrrp_mcast_group6_handler);
+	install_keyword("vrrp_garp_master_delay", &vrrp_garp_delay_handler);
+	install_keyword("vrrp_garp_master_repeat", &vrrp_garp_rep_handler);
+	install_keyword("vrrp_garp_master_refresh", &vrrp_garp_refresh_handler);
+	install_keyword("vrrp_garp_master_refresh_repeat", &vrrp_garp_refresh_rep_handler);
 #ifdef _WITH_SNMP_
 	install_keyword("enable_traps", &trap_handler);
 #endif

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -127,6 +127,17 @@ vrrp_garp_refresh_rep_handler(vector_t *strvec)
 	if ( global_data->vrrp_garp_refresh_rep < 1 )
 		global_data->vrrp_garp_refresh_rep = 1;
 }
+static void
+vrrp_version_handler(vector_t *strvec)
+{
+	uint8_t version = atoi(vector_slot(strvec, 1));
+	if (VRRP_IS_BAD_VERSION(version)) {
+		log_message(LOG_INFO, "VRRP Error : Version not valid !\n");
+		log_message(LOG_INFO, "             must be between either 2 or 3. reconfigure !\n");
+		return;
+	}
+	global_data->vrrp_version = version;
+}
 #ifdef _WITH_SNMP_
 static void
 trap_handler(vector_t *strvec)
@@ -152,6 +163,7 @@ global_init_keywords(void)
 	install_keyword("vrrp_garp_master_repeat", &vrrp_garp_rep_handler);
 	install_keyword("vrrp_garp_master_refresh", &vrrp_garp_refresh_handler);
 	install_keyword("vrrp_garp_master_refresh_repeat", &vrrp_garp_refresh_rep_handler);
+	install_keyword("vrrp_version", &vrrp_version_handler);
 #ifdef _WITH_SNMP_
 	install_keyword("enable_traps", &trap_handler);
 #endif

--- a/keepalived/etc/keepalived/keepalived.conf
+++ b/keepalived/etc/keepalived/keepalived.conf
@@ -33,7 +33,6 @@ virtual_server 192.168.200.100 443 {
     delay_loop 6
     lb_algo rr
     lb_kind NAT
-    nat_mask 255.255.255.0
     persistence_timeout 50
     protocol TCP
 
@@ -107,7 +106,6 @@ virtual_server 10.10.10.3 1358 {
     delay_loop 3
     lb_algo rr 
     lb_kind NAT
-    nat_mask 255.255.255.0
     persistence_timeout 50
     protocol TCP
 

--- a/keepalived/include/check_api.h
+++ b/keepalived/include/check_api.h
@@ -42,7 +42,6 @@ typedef struct _checker {
 	void				(*free_func) (void *);
 	void				(*dump_func) (void *);
 	int				(*launch) (struct _thread *);
-	int				(*plugin_launch) (void *);
 	virtual_server_t		*vs;	/* pointer to the checker thread virtualserver */
 	real_server_t			*rs;	/* pointer to the checker thread realserver */
 	void				*data;

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -126,7 +126,6 @@ typedef struct _virtual_server {
 	char				sched[SCHED_MAX_LENGTH];
 	char				timeout_persistence[MAX_TIMEOUT_LENGTH];
 	unsigned			loadbalancing_kind;
-	uint32_t			nat_mask;
 	uint32_t			granularity_persistence;
 	char				*virtualhost;
 	list				rs;
@@ -223,7 +222,6 @@ static inline int inaddr_equal(sa_family_t family, void *addr1, void *addr2)
 			 (X)->af                      == (Y)->af                        &&\
 			 (X)->service_type            == (Y)->service_type		&&\
 			 (X)->loadbalancing_kind      == (Y)->loadbalancing_kind	&&\
-			 (X)->nat_mask                == (Y)->nat_mask			&&\
 			 (X)->granularity_persistence == (Y)->granularity_persistence	&&\
 			 (  (!(X)->quorum_up && !(Y)->quorum_up) || \
 			    ((X)->quorum_up && (Y)->quorum_up && !strcmp ((X)->quorum_up, (Y)->quorum_up)) \

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <sys/socket.h>
 
 /* local includes */
 #include "list.h"
@@ -53,6 +54,10 @@ typedef struct _data {
 	list				email;
 	struct sockaddr_storage		vrrp_mcast_group4;
 	struct sockaddr_storage		vrrp_mcast_group6;
+	int				vrrp_garp_delay;
+	timeval_t			vrrp_garp_refresh;
+	int				vrrp_garp_rep;
+	int				vrrp_garp_refresh_rep;
 #ifdef _WITH_SNMP_
 	int				enable_traps;
 #endif

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -36,7 +36,6 @@
 /* constants */
 #define DEFAULT_SMTP_SERVER 0x7f000001
 #define DEFAULT_SMTP_CONNECTION_TIMEOUT (30 * TIMER_HZ)
-#define DEFAULT_PLUGIN_DIR "/etc/keepalived/plugins"
 
 /* email link list */
 typedef struct _email {
@@ -47,7 +46,6 @@ typedef struct _email {
 typedef struct _data {
 	int				linkbeat_use_polling;
 	char				*router_id;
-	char				*plugin_dir;
 	char				*email_from;
 	struct sockaddr_storage		smtp_server;
 	long				smtp_connection_to;

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -56,6 +56,7 @@ typedef struct _data {
 	timeval_t			vrrp_garp_refresh;
 	int				vrrp_garp_rep;
 	int				vrrp_garp_refresh_rep;
+	int				vrrp_version;            /* VRRP version (2 or 3) */
 #ifdef _WITH_SNMP_
 	int				enable_traps;
 #endif

--- a/keepalived/include/vrrp_netlink.h
+++ b/keepalived/include/vrrp_netlink.h
@@ -34,6 +34,10 @@
 #include <linux/rtnetlink.h>
 #ifdef _HAVE_LIBNL3_
 #include <netlink/netlink.h>
+#include <libnfnetlink/libnfnetlink.h>
+#endif
+#ifdef _HAVE_LIBNL1_
+#include <libnfnetlink/libnfnetlink.h>
 #endif
 
 /* local includes */
@@ -52,7 +56,12 @@ typedef struct _nl_handle {
 
 /* Define types */
 #define NETLINK_TIMER (30 * TIMER_HZ)
+#ifndef _HAVE_LIBNL3_
+#ifndef _HAVE_LIBNL1_
 #define NLMSG_TAIL(nmsg) ((struct rtattr *) (((void *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
+#define SOL_NETLINK 270
+#endif
+#endif
 
 /* Global vars exported */
 extern nl_handle_t nl_kernel;	/* Kernel reflection channel */
@@ -64,7 +73,7 @@ extern int addattr_l(struct nlmsghdr *, int, int, void *, int);
 extern int rta_addattr_l(struct rtattr *, int, int, const void *, int);
 extern char *netlink_scope_n2a(int);
 extern int netlink_scope_a2n(char *);
-extern int netlink_socket(nl_handle_t *, uint32_t, int flags);
+extern int netlink_socket(nl_handle_t *, int, int, ...);
 extern int netlink_close(nl_handle_t *);
 extern int netlink_talk(nl_handle_t *, struct nlmsghdr *);
 extern int netlink_interface_lookup(void);

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -272,7 +272,9 @@ vrrp_in_chk_vips(vrrp_t * vrrp, ip_address_t *ipaddress, unsigned char *buffer)
 
 /*
  * VRRP incoming packet check.
- * return 0 if the pkt is valid, != 0 otherwise.
+ * return VRRP_PACKET_OK if the pkt is valid, or
+ * 	  VRRP_PACKET_KO if packet invalid or
+ * 	  VRRP_PACKET_DROP if packet not relevant to us
  */
 static int
 vrrp_in_chk(vrrp_t * vrrp, char *buffer)
@@ -984,11 +986,11 @@ vrrp_send_update(vrrp_t * vrrp, ip_address_t * ipaddress, int idx)
 
 	if (!IP_IS6(ipaddress)) {
 		msg = "gratuitous ARPs";
-		inet_ntop(AF_INET, &ipaddress->u.sin.sin_addr, addr_str, 41);
+		inet_ntop(AF_INET, &ipaddress->u.sin.sin_addr, addr_str, sizeof(addr_str));
 		send_gratuitous_arp(ipaddress);
 	} else {
 		msg = "Unsolicited Neighbour Adverts";
-		inet_ntop(AF_INET6, &ipaddress->u.sin6_addr, addr_str, 41);
+		inet_ntop(AF_INET6, &ipaddress->u.sin6_addr, addr_str, sizeof(addr_str));
 		ndisc_send_unsolicited_na(ipaddress);
 	}
 
@@ -1308,8 +1310,8 @@ vrrp_saddr_cmp(struct sockaddr_storage *addr, vrrp_t *vrrp)
 int
 vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 {
-	vrrphdr_t *hd = NULL;
-	int ret = 0, proto = 0;
+	vrrphdr_t *hd;
+	int ret, proto = 0;
 	ipsec_ah_t *ah;
 
 	/* return on link failure */

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -20,6 +20,7 @@
  * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
  */
 
+#include "global_data.h"
 #include "vrrp_data.h"
 #include "vrrp_index.h"
 #include "vrrp_sync.h"
@@ -367,8 +368,9 @@ alloc_vrrp(char *iname)
 	new->stats = alloc_vrrp_stats();
 	memcpy(new->iname, iname, size);
 	new->quick_sync = 0;
-	new->garp_rep = VRRP_GARP_REP;
-	new->garp_refresh_rep = VRRP_GARP_REFRESH_REP;
+	new->garp_rep = global_data->vrrp_garp_rep;
+	new->garp_refresh_rep = global_data->vrrp_garp_refresh_rep;
+	new->garp_delay = global_data->vrrp_garp_delay;
 
 	list_add(vrrp_data->vrrp, new);
 }

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -360,7 +360,7 @@ alloc_vrrp(char *iname)
 	new->family = AF_INET;
 	new->wantstate = VRRP_STATE_BACK;
 	new->init_state = VRRP_STATE_BACK;
-	new->version = VRRP_VERSION_2;
+	new->version = global_data->vrrp_version;
 	new->master_priority = 0;
 	new->last_transition = timer_now();
 	new->adver_int = TIMER_HZ;

--- a/keepalived/vrrp/vrrp_print.c
+++ b/keepalived/vrrp/vrrp_print.c
@@ -130,6 +130,10 @@ vrrp_print(FILE *file, void *data)
 	if (vrrp->garp_delay)
 		fprintf(file, "   Gratuitous ARP delay = %d\n",
 		       vrrp->garp_delay/TIMER_HZ);
+	fprintf(file, "   Gratuitous ARP refresh = %lu\n",
+	       vrrp->garp_refresh.tv_sec/TIMER_HZ);
+	fprintf(file, "   Gratuitous ARP repeat = %d\n", vrrp->garp_rep);
+	fprintf(file, "   Gratuitous ARP refresh repeat = %d\n", vrrp->garp_refresh_rep);
 	fprintf(file, "   Virtual Router ID = %d\n", vrrp->vrid);
 	fprintf(file, "   Priority = %d\n", vrrp->base_priority);
 	fprintf(file, "   Advert interval = %d %s\n",

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -805,10 +805,9 @@ vrrp_master(vrrp_t * vrrp)
 		 * register a gratuitous arp thread delayed to 5 secs.
 		 */
 		if (vrrp_state_master_tx(vrrp, 0)) {
-			thread_add_timer(master, vrrp_gratuitous_arp_thread,
-					 vrrp,
-					 (vrrp->garp_delay) ?
-						vrrp->garp_delay : VRRP_GARP_DELAY);
+			if (vrrp->garp_delay)
+				thread_add_timer(master, vrrp_gratuitous_arp_thread,
+						 vrrp, vrrp->garp_delay);
 			vrrp_smtp_notifier(vrrp);
 		}
 	}


### PR DESCRIPTION
These patches update the man pages to include all configuration parameters and document the signals, removes some residual code left over from removing support for Linux ver 2.2, and makes some vrrp parameter defaults configurable at the global level.

Finally, one patch removes the use of the deprecated nl_join_groups() which I introduced to quickly resolve a problem with using libnl3.