### PR TITLE
vrrp: set router flag in neighbour advertisements

### DIFF
--- a/keepalived/vrrp/vrrp_ndisc.c
+++ b/keepalived/vrrp/vrrp_ndisc.c
@@ -148,6 +148,7 @@ ndisc_send_unsolicited_na(ip_address_t *ipaddress)
 
 	/* ICMPv6 Header */
 	icmp6h->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
+	icmp6h->icmp6_router = 1;
 
 	/* Override flag is set to indicate that the advertisement
 	 * should override an existing cache entry and update the


### PR DESCRIPTION
This is necessary in order to prevent the IPv6 stack on a node that
receives the unsolicited and overriding neighbour advertisement for the
VIP (that gets sent automatically when Keepalived transitions to MASTER
state) from immediately removing the VIP from its list of default
routers. See https://bugs.launchpad.net/bugs/1520517 for an example of
the problems this can cause.

Note that the approach in this patch simply unconditionally sets the
router flag. That is better than having it unconditionally unset (VRRP
stands for Virtual *Router* Redundancy Protocol, after all), but it
might not be appropriate whenever VRRP is used to fail over addresses
that are used for other tasks than being routers. Thus it might be
better to read in the interface's "forwarding" sysctl and set the router
flag accordingly, or making the value of the router flag configurable in
keepalived.conf.