### PR TITLE
Dynamic addition of interfaces from netlink msg

### DIFF
--- a/keepalived/include/vrrp_netlink.h
+++ b/keepalived/include/vrrp_netlink.h
@@ -81,6 +81,6 @@ extern int netlink_interface_lookup(void);
 extern int netlink_interface_refresh(void);
 extern void kernel_netlink_init(void);
 extern void kernel_netlink_close(void);
-extern int netlink_populate_intf_struct(interface_t *, struct rtattr*[], struct ifinfomsg *);
+extern int netlink_if_link_populate(interface_t *, struct rtattr*[], struct ifinfomsg *);
 
 #endif

--- a/keepalived/include/vrrp_netlink.h
+++ b/keepalived/include/vrrp_netlink.h
@@ -42,6 +42,7 @@
 
 /* local includes */
 #include "timer.h"
+#include "vrrp_if.h"
 
 /* types definitions */
 typedef struct _nl_handle {
@@ -80,5 +81,6 @@ extern int netlink_interface_lookup(void);
 extern int netlink_interface_refresh(void);
 extern void kernel_netlink_init(void);
 extern void kernel_netlink_close(void);
+extern int netlink_populate_intf_struct(interface_t *, struct rtattr*[], struct ifinfomsg *);
 
 #endif

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -514,7 +514,8 @@ netlink_request(nl_handle_t *nl, int family, int type)
 }
 
 int
-netlink_populate_intf_struct(interface_t *ifp, struct rtattr *tb[], struct ifinfomsg *ifi) {
+netlink_if_link_populate(interface_t *ifp, struct rtattr *tb[], struct ifinfomsg *ifi)
+{
 	char *name;
 	int i;
 
@@ -598,9 +599,11 @@ netlink_if_link_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 	/* Fill the interface structure */
 	ifp = (interface_t *) MALLOC(sizeof(interface_t));
 
-        status = netlink_populate_intf_struct(ifp, tb, ifi);
-        if (status < 0)
+        status = netlink_if_link_populate(ifp, tb, ifi);
+        if (status < 0) {
+            FREE(ifp);
             return -1;
+        }
 	/* Queue this new interface_t */
 	if_add_queue(ifp);
 	return 0;
@@ -765,7 +768,7 @@ netlink_reflect_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
                     } else {
                             memset(ifp, 0, sizeof(interface_t));
                     }
-                    status = netlink_populate_intf_struct(ifp, tb, ifi);
+                    status = netlink_if_link_populate(ifp, tb, ifi);
                     if (status < 0)
                             return -1;
 


### PR DESCRIPTION
When a tracked interface is deleted then recreated with the same config
VRRP groups tracking this interface will remain down. This is due to
tracking of stale information.

This patch listens for netlink messages for the creation of interfaces
and does one of two things.
i) If the interface doesn't exist in the vrrp interface list a new
interface structure is created and the information from the message is
used to fill the structure. This new interface is then added to the
interface queue.

ii) If the interface already exists in the queue we zero it and then
use the information in the message to fill the structure.

Signed-off-by: Anthony Dempsey <adempsey@brocade.com>