### PR TITLE
check: segfault when there is no real server for a virtual server.

### DIFF
--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -42,6 +42,9 @@ weigh_live_realservers(virtual_server_t * vs)
 	real_server_t *svr;
 	long count = 0;
 
+        if (LIST_ISEMPTY(vs->rs))
+                return;
+
 	for (e = LIST_HEAD(vs->rs); e; ELEMENT_NEXT(e)) {
 		svr = ELEMENT_DATA(e);
 		if (ISALIVE(svr))
@@ -152,6 +155,12 @@ init_service_rs(virtual_server_t * vs)
 {
 	element e;
 	real_server_t *rs;
+
+        if (LIST_ISEMPTY(vs->rs)) {
+		log_message(LOG_WARNING, "VS [%s] has no configured RS! Skipping RS activation."
+				       , FMT_VS(vs));
+                return 1;
+	}
 
 	for (e = LIST_HEAD(vs->rs); e; ELEMENT_NEXT(e)) {
 		rs = ELEMENT_DATA(e);

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -43,7 +43,7 @@ weigh_live_realservers(virtual_server_t * vs)
 	long count = 0;
 
         if (LIST_ISEMPTY(vs->rs))
-                return;
+                return count;
 
 	for (e = LIST_HEAD(vs->rs); e; ELEMENT_NEXT(e)) {
 		svr = ELEMENT_DATA(e);


### PR DESCRIPTION
It may happen that a VS is configured without any RS causing the check thread to segfault when accessing the RS data.
This patches fixes this issue.

