### PR TITLE
Various changes to signal handling, and closing file descriptors before exec'ing

### DIFF
--- a/configure
+++ b/configure
@@ -4821,7 +4821,7 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
-for ac_func in gettimeofday select socket strerror strtol uname
+for ac_func in gettimeofday select socket strerror strtol uname pipe2
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.in
+++ b/configure.in
@@ -321,7 +321,7 @@ dnl ----[ Checks for library functions ]----
 AC_PROG_GCC_TRADITIONAL
 AC_FUNC_MEMCMP
 AC_TYPE_SIGNAL
-AC_CHECK_FUNCS(gettimeofday select socket strerror strtol uname)
+AC_CHECK_FUNCS(gettimeofday select socket strerror strtol uname pipe2)
 
 dnl ----[ Process output target ]----
 OUTPUT_TARGET="$OUTPUT_TARGET keepalived/Makefile lib/Makefile"

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -316,26 +316,26 @@ which will transition together on any state change.
     smtp_alert
  }
 
-# Adds a script to be executed periodically. Its exit code will be
-# recorded for all VRRP instances which are monitoring it with
-# non-zero weight.
-vrrp_script <SCRIPT_NAME> {
-	script <QUOTED_STRING>	# path of script to execute
-	interval <INTEGER>	# seconds between script invocations, default 1 second
-	timeout	<INTEGER>	# seconds after which script is considered to have failed
-	weight<INTEGER:-254..254> # adjust priority by this weight, default 2
-	rise <INTEGER>		# required number of successes for OK transition
-	fall <INTEGER>		# required number of successes for KO transition
-}
+ # Adds a script to be executed periodically. Its exit code will be
+ # recorded for all VRRP instances which are monitoring it with
+ # non-zero weight.
+ vrrp_script <SCRIPT_NAME> {
+    script <QUOTED_STRING>	# path of script to execute
+    interval <INTEGER>	# seconds between script invocations, default 1 second
+    timeout	<INTEGER>	# seconds after which script is considered to have failed
+    weight<INTEGER:-254..254> # adjust priority by this weight, default 2
+    rise <INTEGER>		# required number of successes for OK transition
+    fall <INTEGER>		# required number of successes for KO transition
+ }
 
-# Parameters used for SSL GET check.
-# If none of the parameters are specified, the SSL context will be auto generated
-SSL {
-	password <STRING>	# password
-	ca <STRING>		# ca file
-	certificate <STRING>	# certificate file
-	key <STRING>		# key file
-}
+ # Parameters used for SSL GET check.
+ # If none of the parameters are specified, the SSL context will be auto generated
+ SSL {
+    password <STRING>	# password
+    ca <STRING>		# ca file
+    certificate <STRING>	# certificate file
+    key <STRING>		# key file
+ }
 
 .SH LVS CONFIGURATION
 contains subblocks of
@@ -469,8 +469,8 @@ A virtual_server can be a declaration of one of
            # considers service as down.
            notify_down <STRING>|<QUOTED-STRING>
 
-	   uthreshold <INTEGER>	# maximum number of connections to server
-	   lthreshold <INTEGER>	# minimum number of connections to server
+           uthreshold <INTEGER>	# maximum number of connections to server
+           lthreshold <INTEGER>	# minimum number of connections to server
 
            # pick one healthchecker
            # HTTP_GET|SSL_GET|TCP_CHECK|SMTP_CHECK|MISC_CHECK

--- a/genhash/http.c
+++ b/genhash/http.c
@@ -318,18 +318,9 @@ http_request_thread(thread_t * thread)
 		 ntohs(req->addr_port));
 	}
 	
-	if(req->dst){
-		if(req->dst->ai_family == AF_INET6 && !req->vhost) {
-			snprintf(str_request, GET_BUFFER_LENGTH, REQUEST_TEMPLATE_IPV6,
-				req->url, request_host, request_host_port);
-		} else {
-			snprintf(str_request, GET_BUFFER_LENGTH, REQUEST_TEMPLATE,
-				req->url, request_host, request_host_port);
-		}
-	} else {
-		snprintf(str_request, GET_BUFFER_LENGTH, REQUEST_TEMPLATE,
-			req->url, request_host, request_host_port);
-	}
+	snprintf(str_request, GET_BUFFER_LENGTH,
+		 (req->dst && req->dst->ai_family == AF_INET6 && !req->vhost) ? REQUEST_TEMPLATE_IPV6 : REQUEST_TEMPLATE,
+		  req->url, request_host, request_host_port);
 	
 	FREE(request_host_port);
 

--- a/genhash/layer4.c
+++ b/genhash/layer4.c
@@ -61,26 +61,15 @@ tcp_connect(int fd, REQ * req_obj)
 	val = fcntl(fd, F_GETFL, 0);
 	fcntl(fd, F_SETFL, val | O_NONBLOCK);
 
-	if(req_obj->dst){
-		if(req_obj->dst->ai_family == AF_INET6) {
-			long_inet = sizeof (struct sockaddr_in6);
-			memset(&adr_serv6, 0, long_inet);
-			adr_serv6.sin6_family = req_obj->dst->ai_family;
-			adr_serv6.sin6_port = req_obj->addr_port;
-			inet_pton(AF_INET6, req_obj->ipaddress, &adr_serv6.sin6_addr);
+	if(req_obj->dst && req_obj->dst->ai_family == AF_INET6) {
+		long_inet = sizeof (struct sockaddr_in6);
+		memset(&adr_serv6, 0, long_inet);
+		adr_serv6.sin6_family = AF_INET6;
+		adr_serv6.sin6_port = req_obj->addr_port;
+		inet_pton(AF_INET6, req_obj->ipaddress, &adr_serv6.sin6_addr);
 
-			/* Call connect function. */
-			ret = connect(fd, (struct sockaddr *) &adr_serv6, long_inet);
-		} else {
-			long_inet = sizeof (struct sockaddr_in);
-			memset(&adr_serv, 0, long_inet);
-			adr_serv.sin_family = req_obj->dst->ai_family;
-			adr_serv.sin_port = req_obj->addr_port;
-			inet_pton(AF_INET, req_obj->ipaddress, &adr_serv.sin_addr);
-
-			/* Call connect function. */
-			ret = connect(fd, (struct sockaddr *) &adr_serv, long_inet);
-		}
+		/* Call connect function. */
+		ret = connect(fd, (struct sockaddr *) &adr_serv6, long_inet);
 	} else {
 		long_inet = sizeof (struct sockaddr_in);
 		memset(&adr_serv, 0, long_inet);
@@ -242,23 +231,10 @@ tcp_connect_thread(thread_t * thread)
 {
 	SOCK *sock_obj = THREAD_ARG(thread);
 
-	if(req->dst){
-		if(req->dst->ai_family == AF_INET6) {
-			if ((sock_obj->fd = socket(AF_INET6, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
-				DBG("WEB connection fail to create socket.\n");
-				return 0;
-			}
-		} else {
-			if ((sock_obj->fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
-				DBG("WEB connection fail to create socket.\n");
-				return 0;
-			}
-		}
-	} else {
-		if ((sock_obj->fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
-			DBG("WEB connection fail to create socket.\n");
-			return 0;
-		}
+	if ((sock_obj->fd = socket((req->dst && req->dst->ai_family == AF_INET6) ? AF_INET6 : AF_INET,
+				   SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
+		DBG("WEB connection fail to create socket.\n");
+		return 0;
 	}
 
 	sock->status = tcp_connect(sock_obj->fd, req);

--- a/genhash/layer4.c
+++ b/genhash/layer4.c
@@ -244,18 +244,18 @@ tcp_connect_thread(thread_t * thread)
 
 	if(req->dst){
 		if(req->dst->ai_family == AF_INET6) {
-			if ((sock_obj->fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP)) == -1) {
+			if ((sock_obj->fd = socket(AF_INET6, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
 				DBG("WEB connection fail to create socket.\n");
 				return 0;
 			}
 		} else {
-			if ((sock_obj->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1) {
+			if ((sock_obj->fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
 				DBG("WEB connection fail to create socket.\n");
 				return 0;
 			}
 		}
 	} else {
-		if ((sock_obj->fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1) {
+		if ((sock_obj->fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
 			DBG("WEB connection fail to create socket.\n");
 			return 0;
 		}

--- a/genhash/main.c
+++ b/genhash/main.c
@@ -146,7 +146,7 @@ parse_cmdline(int argc, char **argv, REQ * req_obj)
 				if(res->ai_family == AF_INET) {
 					req_obj->dst = res;
 					ptr = &((struct sockaddr_in *) res->ai_addr)->sin_addr;
-					inet_ntop (res->ai_family, ptr, req_obj->ipaddress, INET6_ADDRSTRLEN);
+					inet_ntop (res->ai_family, ptr, req_obj->ipaddress, INET_ADDRSTRLEN);
 				} else if (res->ai_family == AF_INET6) {
 					req_obj->dst = res;
 					ptr = &((struct sockaddr_in6 *) res->ai_addr)->sin6_addr;

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -192,8 +192,7 @@ reload_check_thread(thread_t * thread)
 	log_message(LOG_INFO, "Got SIGHUP, reloading checker configuration");
 
 	/* Signals handling */
-	signal_reset();
-	signal_handler_destroy();
+	signal_handler_reset();
 
 	/* Destroy master thread */
 #ifdef _WITH_VRRP_

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -753,7 +753,7 @@ http_connect_thread(thread_t * thread)
 		return epilog(thread, 1, 1, 0) + 1;
 
 	/* Create the socket */
-	if ((fd = socket(co->dst.ss_family, SOCK_STREAM, IPPROTO_TCP)) == -1) {
+	if ((fd = socket(co->dst.ss_family, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
 		log_message(LOG_INFO, "WEB connection fail to create socket. Rescheduling.");
 		thread_add_timer(thread->master, http_connect_thread, checker,
 				checker->vs->delay_loop);

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -149,7 +149,7 @@ misc_check_thread(thread_t * thread)
 	}
 
 	/* Child part */
-	signal_handler_destroy();
+	signal_handler_notify();
 	closeall(0);
 
 	open("/dev/null", O_RDWR);

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -108,8 +108,6 @@ misc_check_thread(thread_t * thread)
 {
 	checker_t *checker;
 	misc_checker_t *misck_checker;
-	int status, ret;
-	pid_t pid;
 
 	checker = THREAD_ARG(thread);
 	misck_checker = CHECKER_ARG(checker);
@@ -129,48 +127,10 @@ misc_check_thread(thread_t * thread)
 	thread_add_timer(thread->master, misc_check_thread, checker,
 			 checker->vs->delay_loop);
 
-	/* Daemonization to not degrade our scheduling timer */
-	pid = fork();
-
-	/* In case of fork is error. */
-	if (pid < 0) {
-		log_message(LOG_INFO, "Failed fork process");
-		return -1;
-	}
-
-	/* In case of this is parent process */
-	if (pid) {
-		long timeout;
-		timeout = (misck_checker->timeout) ? misck_checker->timeout : checker->vs->delay_loop;
-
-		thread_add_child(thread->master, misc_check_child_thread,
-				 checker, pid, timeout);
-		return 0;
-	}
-
-	/* Child part */
-	signal_handler_notify();
-	closeall(0);
-
-	open("/dev/null", O_RDWR);
-	ret = dup(0);
-	if (ret < 0) {
-		log_message(LOG_INFO, "dup(0) error");
-	}
-
-	ret = dup(0);
-	if (ret < 0) {
-		log_message(LOG_INFO, "dup(0) error");
-	}
-
-	status = system_call(misck_checker->path);
-
-	if (status < 0 || !WIFEXITED(status))
-		status = 0; /* Script errors aren't server errors */
-	else
-		status = WEXITSTATUS(status);
-
-	exit(status);
+	/* Execute the script in a child process. Parent returns, child doesn't */
+	return system_call_script(thread->master, misc_check_child_thread,
+				  checker, (misck_checker->timeout) ? misck_checker->timeout : checker->vs->delay_loop,
+				  misck_checker->path);
 }
 
 int

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -271,7 +271,6 @@ misc_check_child_timeout_thread(thread_t * thread)
 	}
 
 	log_message(LOG_WARNING, "Process [%d] didn't respond to SIGTERM", pid);
-	waitpid(pid, NULL, 0);
 
 	return 0;
 }

--- a/keepalived/check/check_smtp.c
+++ b/keepalived/check/check_smtp.c
@@ -770,7 +770,7 @@ smtp_connect_thread(thread_t *thread)
 	smtp_host = smtp_checker->host_ptr;
 
 	/* Create the socket, failling here should be an oddity */
-	if ((sd = socket(smtp_host->dst.ss_family, SOCK_STREAM, IPPROTO_TCP)) == -1) {
+	if ((sd = socket(smtp_host->dst.ss_family, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
 		log_message(LOG_INFO, "SMTP_CHECK connection failed to create socket. Rescheduling.");
 		thread_add_timer(thread->master, smtp_connect_thread, checker,
 				 checker->vs->delay_loop);

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -199,8 +199,11 @@ ssl_connect(thread_t * thread, int new_req)
 
 	/* First round, create SSL context */
 	if (new_req) {
+		int bio_fd;
 		req->ssl = SSL_new(check_data->ssl->ctx);
 		req->bio = BIO_new_socket(thread->u.fd, BIO_NOCLOSE);
+		BIO_get_fd(req->bio, &bio_fd);
+		fcntl(bio_fd, F_SETFD, fcntl(bio_fd, F_GETFD) | FD_CLOEXEC);
 		SSL_set_bio(req->ssl, req->bio, req->bio);
 	}
 

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -197,7 +197,7 @@ tcp_connect_thread(thread_t * thread)
 		return 0;
 	}
 
-	if ((fd = socket(co->dst.ss_family, SOCK_STREAM, IPPROTO_TCP)) == -1) {
+	if ((fd = socket(co->dst.ss_family, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
 		log_message(LOG_INFO, "TCP connect fail to create socket. Rescheduling.");
 		thread_add_timer(thread->master, tcp_connect_thread, checker,
 				checker->vs->delay_loop);

--- a/keepalived/core/daemon.c
+++ b/keepalived/core/daemon.c
@@ -63,18 +63,8 @@ xdaemon(int nochdir, int noclose, int exitflag)
 	}
 
 	/* File descriptor close. */
-	if (!noclose) {
-		int fd;
-
-		fd = open("/dev/null", O_RDWR, 0);
-		if (fd != -1) {
-			dup2(fd, STDIN_FILENO);
-			dup2(fd, STDOUT_FILENO);
-			dup2(fd, STDERR_FILENO);
-			if (fd > 2)
-				close(fd);
-		}
-	}
+	if (!noclose)
+		set_std_fd(true);
 
 	umask(0);
 	return 0;

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -88,15 +88,15 @@ start_keepalived(void)
 #endif
 }
 
-/* SIGHUP handler */
+/* SIGHUP/USR1/USR2 handler */
 void
-sighup(void *v, int sig)
+propogate_signal(void *v, int sig)
 {
 	/* Signal child process */
 	if (vrrp_child > 0)
-		kill(vrrp_child, SIGHUP);
-	if (checkers_child > 0)
-		kill(checkers_child, SIGHUP);
+		kill(vrrp_child, sig);
+	if (checkers_child > 0 && sig == SIGHUP)
+		kill(checkers_child, sig);
 }
 
 /* Terminate handler */
@@ -123,7 +123,9 @@ void
 signal_init(void)
 {
 	signal_handler_init();
-	signal_set(SIGHUP, sighup, NULL);
+	signal_set(SIGHUP, propogate_signal, NULL);
+	signal_set(SIGUSR1, propogate_signal, NULL);
+	signal_set(SIGUSR2, propogate_signal, NULL);
 	signal_set(SIGINT, sigend, NULL);
 	signal_set(SIGTERM, sigend, NULL);
 	signal_ignore(SIGPIPE);

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -89,7 +89,7 @@ start_keepalived(void)
 }
 
 /* SIGHUP/USR1/USR2 handler */
-void
+static void
 propogate_signal(void *v, int sig)
 {
 	/* Signal child process */
@@ -100,7 +100,7 @@ propogate_signal(void *v, int sig)
 }
 
 /* Terminate handler */
-void
+static void
 sigend(void *v, int sig)
 {
 	int status;

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -584,7 +584,7 @@ smtp_connect(smtp_t * smtp)
 {
 	enum connect_result status;
 
-	if ((smtp->fd = socket(global_data->smtp_server.ss_family, SOCK_STREAM, IPPROTO_TCP)) == -1) {
+	if ((smtp->fd = socket(global_data->smtp_server.ss_family, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP)) == -1) {
 		DBG("SMTP connect fail to create socket.");
 		free_smtp_all(smtp);
 		return;

--- a/keepalived/libipvs-2.4/libipvs.c
+++ b/keepalived/libipvs-2.4/libipvs.c
@@ -35,7 +35,7 @@ int ipvs_init(void)
 	socklen_t len;
 
 	len = sizeof(ipvs_info);
-	if ((sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW)) == -1)
+	if ((sockfd = socket(AF_INET, SOCK_RAW | SOCK_CLOEXEC, IPPROTO_RAW)) == -1)
 		return -1;
 
 	ipvs_cmd = GET_CMD(IP_VS_SO_GET_INFO);

--- a/keepalived/libipvs-2.6/libipvs.c
+++ b/keepalived/libipvs-2.6/libipvs.c
@@ -168,7 +168,7 @@ int ipvs_init(void)
 #endif
 
 	len = sizeof(ipvs_info);
-	if ((sockfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW)) == -1)
+	if ((sockfd = socket(AF_INET, SOCK_RAW | SOCK_CLOEXEC, IPPROTO_RAW)) == -1)
 		return -1;
 
 	if (getsockopt(sockfd, IPPROTO_IP, IP_VS_SO_GET_INFO,

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1445,7 +1445,7 @@ open_vrrp_send_socket(sa_family_t family, int proto, int idx, int unicast)
 	ifp = if_get_by_ifindex(idx);
 
 	/* Create and init socket descriptor */
-	fd = socket(family, SOCK_RAW, proto);
+	fd = socket(family, SOCK_RAW | SOCK_CLOEXEC, proto);
 	if (fd < 0) {
 		log_message(LOG_INFO, "cant open raw socket. errno=%d", errno);
 		return -1;
@@ -1488,7 +1488,7 @@ open_vrrp_socket(sa_family_t family, int proto, int idx,
 	ifp = if_get_by_ifindex(idx);
 
 	/* open the socket */
-	fd = socket(family, SOCK_RAW, proto);
+	fd = socket(family, SOCK_RAW | SOCK_CLOEXEC, proto);
 	if (fd < 0) {
 		int err = errno;
 		log_message(LOG_INFO, "cant open raw socket. errno=%d", err);

--- a/keepalived/vrrp/vrrp_arp.c
+++ b/keepalived/vrrp/vrrp_arp.c
@@ -98,7 +98,7 @@ void gratuitous_arp_init(void)
 	garp_buffer = (char *)MALLOC(sizeof(arphdr_t) + ETHER_HDR_LEN);
 
 	/* Create the socket descriptor */
-	garp_fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_RARP));
+	garp_fd = socket(PF_PACKET, SOCK_RAW | SOCK_CLOEXEC, htons(ETH_P_RARP));
 
 	if (garp_fd > 0)
 		log_message(LOG_INFO, "Registering gratuitous ARP shared channel");

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -243,8 +243,7 @@ reload_vrrp_thread(thread_t * thread)
 	SET_RELOAD;
 
 	/* Signal handling */
-	signal_reset();
-	signal_handler_destroy();
+	signal_handler_reset();
 
 	/* Destroy master thread */
 	vrrp_dispatcher_release(vrrp_data);
@@ -349,6 +348,8 @@ start_vrrp_child(void)
 		return 0;
 	}
 
+	signal_handler_destroy();
+
 	/* Opening local VRRP syslog channel */
 	openlog(PROG_VRRP, LOG_PID | ((__test_bit(LOG_CONSOLE_BIT, &debug)) ? LOG_CONS : 0)
 			 , (log_facility==LOG_DAEMON) ? LOG_LOCAL1 : log_facility);
@@ -361,7 +362,6 @@ start_vrrp_child(void)
 	}
 
 	/* Create the new master thread */
-	signal_handler_destroy();
 	thread_destroy_master(master);
 	master = thread_make_master();
 

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -201,7 +201,7 @@ if_mii_probe(const char *ifname)
 {
 	uint16_t *data = (uint16_t *) (&ifr.ifr_data);
 	int phy_id;
-	int fd = socket(AF_INET, SOCK_DGRAM, 0);
+	int fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 	int status = 0;
 
 	if (fd < 0)
@@ -250,7 +250,7 @@ if_ethtool_status(const int fd)
 int
 if_ethtool_probe(const char *ifname)
 {
-	int fd = socket(AF_INET, SOCK_DGRAM, 0);
+	int fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 	int status = 0;
 
 	if (fd < 0)
@@ -266,7 +266,7 @@ if_ethtool_probe(const char *ifname)
 void
 if_ioctl_flags(interface_t * ifp)
 {
-	int fd = socket(AF_INET, SOCK_DGRAM, 0);
+	int fd = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 
 	if (fd < 0)
 		return;

--- a/keepalived/vrrp/vrrp_ndisc.c
+++ b/keepalived/vrrp/vrrp_ndisc.c
@@ -188,7 +188,7 @@ ndisc_init(void)
 				       sizeof(struct ndhdr) + sizeof(struct nd_opt_hdr) + ETH_ALEN);
 
 	/* Create the socket descriptor */
-	ndisc_fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_IPV6));
+	ndisc_fd = socket(PF_PACKET, SOCK_RAW | SOCK_CLOEXEC, htons(ETH_P_IPV6));
 }
 
 void

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -105,11 +105,14 @@ netlink_socket(nl_handle_t *nl, int flags, int group, ...)
 	nl->nl_pid = nl_socket_get_local_port(nl->sk);
 
 	nl->fd = nl_socket_get_fd(nl->sk);
+
+	/* Set CLOEXEC */
+	fcntl(nl->fd, F_SETFD, fcntl(nl->fd, F_GETFD) | FD_CLOEXEC);
 #else
 	socklen_t addr_len;
 	struct sockaddr_nl snl;
 
-	nl->fd = socket(AF_NETLINK, SOCK_RAW | flags, NETLINK_ROUTE);
+	nl->fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC | flags, NETLINK_ROUTE);
 	if (nl->fd < 0) {
 		log_message(LOG_INFO, "Netlink: Cannot open netlink socket : (%s)",
 		       strerror(errno));

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -1004,7 +1004,7 @@ vrrp_script_thread(thread_t * thread)
 	}
 
 	/* Child part */
-	signal_handler_destroy();
+	signal_handler_notify();
 	closeall(0);
 	open("/dev/null", O_RDWR);
 	ret = dup(0);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -1099,7 +1099,6 @@ vrrp_script_child_timeout_thread(thread_t * thread)
 	}
 
 	log_message(LOG_WARNING, "Process [%d] didn't respond to SIGTERM", pid);
-	waitpid(pid, NULL, 0);
 
 	return 0;
 }

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -979,52 +979,15 @@ static int
 vrrp_script_thread(thread_t * thread)
 {
 	vrrp_script_t *vscript = THREAD_ARG(thread);
-	int status, ret;
-	pid_t pid;
 
 	/* Register next timer tracker */
 	thread_add_timer(thread->master, vrrp_script_thread, vscript,
 			 vscript->interval);
 
-	/* Daemonization to not degrade our scheduling timer */
-	pid = fork();
-
-	/* In case of fork is error. */
-	if (pid < 0) {
-		log_message(LOG_INFO, "Failed fork process");
-		return -1;
-	}
-
-	/* In case of this is parent process */
-	if (pid) {
-		thread_add_child(thread->master, vrrp_script_child_thread,
-				 vscript, pid,
-				 (vscript->timeout) ? vscript->timeout : vscript->interval);
-		return 0;
-	}
-
-	/* Child part */
-	signal_handler_notify();
-	closeall(0);
-	open("/dev/null", O_RDWR);
-	ret = dup(0);
-	if (ret < 0) {
-		log_message(LOG_INFO, "dup(0) error");
-	}
-
-	ret = dup(0);
-	if (ret < 0) {
-		log_message(LOG_INFO, "dup(0) error");
-	}
-
-	status = system_call(vscript->script);
-
-	if (status < 0 || !WIFEXITED(status))
-		status = 0; /* Script errors aren't server errors */
-	else
-		status = WEXITSTATUS(status);
-
-	exit(status);
+        /* Execute the script in a child process. Parent returns, child doesn't */
+	return system_call_script(thread->master, vrrp_script_child_thread,
+				  vscript, (vscript->timeout) ? vscript->timeout : vscript->interval,
+				  vscript->script);
 }
 
 static int

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -49,20 +49,9 @@ system_call(const char *cmdline)
 	return retval;
 }
 
-/* Close all FDs >= a specified value */
-void
-closeall(int fd)
-{
-	int fdlimit = sysconf(_SC_OPEN_MAX);
-	while (fd < fdlimit)
-		close(fd++);
-}
-
 static void
 script_setup(void)
 {
-	closeall(0);
-
 	signal_handler_script();
 
 	set_std_fd(false);

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -76,7 +76,7 @@ notify_exec(char *cmd)
 	if (pid)
 		return 0;
 
-	signal_handler_destroy();
+	signal_handler_notify();
 	closeall(0);
 
 	open("/dev/null", O_RDWR);

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -76,7 +76,7 @@ notify_exec(char *cmd)
 	if (pid)
 		return 0;
 
-	signal_handler_notify();
+	signal_handler_script();
 	closeall(0);
 
 	open("/dev/null", O_RDWR);
@@ -118,7 +118,7 @@ system_call_script(thread_master_t *m, int (*func) (thread_t *), void * arg, lon
 	}
 
 	/* Child part */
-	signal_handler_notify();
+	signal_handler_script();
 	closeall(0);
 	open("/dev/null", O_RDWR);
 	ret = dup(0);

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -23,8 +23,10 @@
 #ifndef _NOTIFY_H
 #define _NOTIFY_H
 
+#include "scheduler.h"
+
 /* system includes */
-extern int system_call(char *cmdline);
+extern int system_call_script(thread_master_t *m, int (*func) (thread_t *), void * arg, long timer, const char* script);
 extern void closeall(int fd);
 extern int notify_exec(char *cmd);
 

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -27,7 +27,6 @@
 
 /* system includes */
 extern int system_call_script(thread_master_t *m, int (*func) (thread_t *), void * arg, long timer, const char* script);
-extern void closeall(int fd);
 extern int notify_exec(char *cmd);
 
 #endif

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -719,7 +719,7 @@ thread_child_handler(void * v, int sig)
 	 */
 	thread_t *thread;
 	pid_t pid;
-	int status = 77;
+	int status;
 	while ((pid = waitpid(-1, &status, WNOHANG))) {
 		if (pid == -1) {
 			if (errno == ECHILD)
@@ -734,9 +734,9 @@ thread_child_handler(void * v, int sig)
 				thread = t->next;
 				if (pid == t->u.c.pid) {
 					thread_list_delete(&m->child, t);
-					thread_list_add(&m->ready, t);
 					t->u.c.status = status;
 					t->type = THREAD_READY;
+					thread_list_add(&m->ready, t);
 					break;
 				}
 			}

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -51,6 +51,7 @@ void *signal_SIGUSR2_v;
 static int signal_pipe[2] = { -1, -1 };
 
 /* Local signal test */
+/* Currently unused
 int
 signal_pending(void)
 {
@@ -65,9 +66,10 @@ signal_pending(void)
 
 	return rc>0?1:0;
 }
+*/
 
 /* Signal flag */
-void
+static void
 signal_handler(int sig)
 {
 	if (write(signal_pipe[1], &sig, sizeof(int)) != sizeof(int)) {
@@ -196,52 +198,34 @@ signal_handler_init(void)
 	}
 }
 
-void
-signal_wait_handlers(void)
+static void
+signal_handlers_clear(void *state)
 {
-	struct sigaction sig;
-
-	sig.sa_handler = SIG_DFL;
-	sigemptyset(&sig.sa_mask);
-	sig.sa_flags = 0;
-
 	/* Ensure no more pending signals */
-	sigaction(SIGHUP, &sig, NULL);
-	sigaction(SIGINT, &sig, NULL);
-	sigaction(SIGTERM, &sig, NULL);
-	sigaction(SIGCHLD, &sig, NULL);
-	sigaction(SIGUSR1, &sig, NULL);
-	sigaction(SIGUSR2, &sig, NULL);
+	signal_set(SIGHUP, state, NULL);
+	signal_set(SIGINT, state, NULL);
+	signal_set(SIGTERM, state, NULL);
+	signal_set(SIGCHLD, state, NULL);
+	signal_set(SIGUSR1, state, NULL);
+	signal_set(SIGUSR2, state, NULL);
 
-	/* reset */
-	signal_SIGHUP_v = NULL;
-	signal_SIGINT_v = NULL;
-	signal_SIGTERM_v = NULL;
-	signal_SIGCHLD_v = NULL;
-	signal_SIGUSR1_v = NULL;
-	signal_SIGUSR2_v = NULL;
 }
 
-void signal_reset(void)
+void
+signal_handler_reset(void)
 {
-	signal_wait_handlers();
-	signal_SIGHUP_handler = NULL;
-	signal_SIGINT_handler = NULL;
-	signal_SIGTERM_handler = NULL;
-	signal_SIGCHLD_handler = NULL;
-	signal_SIGUSR1_handler = NULL;
-	signal_SIGUSR2_handler = NULL;
+	signal_handlers_clear(SIG_DFL);
 }
 
 void
 signal_handler_destroy(void)
 {
-	signal_wait_handlers();
+	signal_handlers_clear(SIG_IGN);
 	close(signal_pipe[1]);
 	close(signal_pipe[0]);
 	signal_pipe[1] = -1;
 	signal_pipe[0] = -1;
-}	
+}
 
 int
 signal_rfd(void)

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -156,7 +156,7 @@ signal_set(int signo, void (*func) (void *, int), void *v)
 void *
 signal_ignore(int signo)
 {
-	return signal_set(signo, NULL, NULL);
+	return signal_set(signo, (void*)SIG_IGN, NULL);
 }
 
 /* Handlers intialization */

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -156,7 +156,7 @@ signal_set(int signo, void (*func) (void *, int), void *v)
 	if (func != NULL)
 		sigprocmask(SIG_UNBLOCK, &sset, NULL);
 
-	return (void*)osig.sa_handler;
+	return ((osig.sa_flags & SA_SIGINFO) ? (void*)osig.sa_sigaction : (void*)osig.sa_handler);
 }
 
 /* Signal Ignore */

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -252,10 +252,10 @@ signal_handler_destroy(void)
 	signal_pipe[0] = -1;
 }
 
-/* Called prior to exec'ing a notify script. The script can reasonably
+/* Called prior to exec'ing a script. The script can reasonably
  * expect to have the standard signal disposition */
 void
-signal_handler_notify(void)
+signal_handler_script(void)
 {
 	struct sigaction ign, dfl;
 	int sig;

--- a/lib/signals.h
+++ b/lib/signals.h
@@ -31,6 +31,7 @@ extern void *signal_ignore(int signo);
 extern void signal_handler_init(void);
 extern void signal_handler_destroy(void);
 extern void signal_handler_reset(void);
+extern void signal_handler_notify(void);
 extern void signal_run_callback(void);
 
 extern int signal_rfd(void);

--- a/lib/signals.h
+++ b/lib/signals.h
@@ -31,7 +31,7 @@ extern void *signal_ignore(int signo);
 extern void signal_handler_init(void);
 extern void signal_handler_destroy(void);
 extern void signal_handler_reset(void);
-extern void signal_handler_notify(void);
+extern void signal_handler_script(void);
 extern void signal_run_callback(void);
 
 extern int signal_rfd(void);

--- a/lib/signals.h
+++ b/lib/signals.h
@@ -25,14 +25,13 @@
 #define _SIGNALS_H
 
 /* Prototypes */
-extern int signal_pending(void);
+/* Currently unused extern int signal_pending(void); */
 extern void *signal_set(int signo, void (*func) (void *, int), void *);
 extern void *signal_ignore(int signo);
 extern void signal_handler_init(void);
 extern void signal_handler_destroy(void);
-extern void signal_reset(void);
+extern void signal_handler_reset(void);
 extern void signal_run_callback(void);
-extern void signal_wait_handlers(void);
 
 extern int signal_rfd(void);
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include "utils.h"
+#include "signals.h"
 
 /* global vars */
 unsigned long debug = 0;
@@ -538,6 +539,9 @@ fork_exec(char **argv)
 			if (fd > 2)
 				close(fd);
 		}
+
+		signal_handler_script();
+
 		execvp(*argv, argv);
 		exit(EXIT_FAILURE);
 	} else {

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include "utils.h"
 #include "signals.h"
+#include "bitops.h"
 
 /* global vars */
 unsigned long debug = 0;
@@ -518,11 +519,27 @@ string_equal(const char *str1, const char *str2)
 	return (*str1 == 0 && *str2 == 0);
 }
 
+void
+set_std_fd(int force)
+{
+	int fd;
+
+	if (force || __test_bit(DONT_FORK_BIT, &debug)) {
+		fd = open("/dev/null", O_RDWR);
+		if (fd != -1) {
+			dup2(fd, STDIN_FILENO);
+			dup2(fd, STDOUT_FILENO);
+			dup2(fd, STDERR_FILENO);
+			if (fd > 2)
+				close(fd);
+		}
+	}
+}
+
 int
 fork_exec(char **argv)
 {
 	pid_t pid;
-	int fd;
 	int status;
 
 	pid = fork();
@@ -531,14 +548,7 @@ fork_exec(char **argv)
 
 	/* Child */
 	if (pid == 0) {
-		fd = open("/dev/null", O_RDWR, 0);
-		if (fd != -1) {
-			dup2(fd, STDIN_FILENO);
-			dup2(fd, STDOUT_FILENO);
-			dup2(fd, STDERR_FILENO);
-			if (fd > 2)
-				close(fd);
-		}
+		set_std_fd(false);
 
 		signal_handler_script();
 

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
@@ -72,6 +73,7 @@ uint32_t inet_broadcast(uint32_t, uint32_t);
 uint32_t inet_cidrtomask(uint8_t);
 extern char *get_local_name(void);
 extern int string_equal(const char *, const char *);
+extern void set_std_fd(int);
 extern int fork_exec(char **argv);
 
 #endif


### PR DESCRIPTION
I found some anomalies in the signal handling code. Some functions were being called twice, unnecessarily (e.g. calling signal_reset and signal_handler_destroy calls signal_wait_handlers twice).

Various other signal changes to make keepalived more robust, and also remove a race condition.

Make the parent process pass all relevant signals to child processes; this fixes issue #169

Optimise the closing of file descriptors prior to exec calls by i) only reopening /dev/null on fds 0/1/2 when running in foreground, and not closing all 1024 potential fds by using CLOEXEC.