### PR TITLE
Fix reloading and invoking notify scripts

### DIFF
--- a/lib/notify.c
+++ b/lib/notify.c
@@ -25,6 +25,7 @@
 #include <syslog.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <signal.h>
 #include "notify.h"
 #include "signals.h"
 #include "logger.h"
@@ -35,6 +36,9 @@ static int
 system_call(const char *cmdline)
 {
 	int retval;
+
+	/* system() fails if SIGCHLD is set to SIG_IGN */
+	signal_set(SIGCHLD, (void*)SIG_DFL, NULL);
 
 	retval = system(cmdline);
 

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -92,8 +92,6 @@ signal_set(int signo, void (*func) (void *, int), void *v)
 	struct sigaction sig;
 	struct sigaction osig;
 
-	assert(func != NULL);
-
 	if (func == (void*)SIG_IGN || func == (void*)SIG_DFL) {
 		sig.sa_handler = (void*)func;
 
@@ -242,7 +240,6 @@ signal_handlers_clear(void *state)
 	signal_set(SIGCHLD, state, NULL);
 	signal_set(SIGUSR1, state, NULL);
 	signal_set(SIGUSR2, state, NULL);
-
 }
 
 void


### PR DESCRIPTION
Commit 223ee0d introduced a problem with invoking notify scripts,
and also responding to SIGHUP. These are now resolved.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>