### PR TITLE
Fix compilation when ipsets not installed

### DIFF
--- a/keepalived/vrrp/vrrp_iptables.c
+++ b/keepalived/vrrp/vrrp_iptables.c
@@ -42,7 +42,9 @@
 
 #include "vrrp_iptables.h"
 #include "vrrp_iptables_calls.h"
+#ifdef _HAVE_LIBIPSET_
 #include "vrrp_ipset.h"
+#endif
 #include "logger.h"
 #include "memory.h"
 #include "global_data.h"


### PR DESCRIPTION
With apologies for not have spotted the problem. I though I had tested it.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>