### PR TITLE
Fix VRRP respawning when no VIPs specified

### DIFF
--- a/configure
+++ b/configure
@@ -3782,21 +3782,6 @@ fi
 
 done
 
-for ac_header in libnfnetlink/libnfnetlink.h
-do :
-  ac_fn_c_check_header_mongrel "$LINENO" "libnfnetlink/libnfnetlink.h" "ac_cv_header_libnfnetlink_libnfnetlink_h" "$ac_includes_default"
-if test "x$ac_cv_header_libnfnetlink_libnfnetlink_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBNFNETLINK_LIBNFNETLINK_H 1
-_ACEOF
-
-else
-  as_fn_error $? "
-  !!! Please install libnfnetlink headers.              !!!" "$LINENO" 5
-fi
-
-done
-
 ac_fn_c_check_decl "$LINENO" "ETHERTYPE_IPV6" "ac_cv_have_decl_ETHERTYPE_IPV6" "#include <net/ethernet.h>
 "
 if test "x$ac_cv_have_decl_ETHERTYPE_IPV6" = xyes; then :
@@ -4140,6 +4125,24 @@ fi
 
 
 
+
+if test "$USE_NL3" != "_WITHOUT_LIBNL_"; then
+  for ac_header in libnfnetlink/libnfnetlink.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "libnfnetlink/libnfnetlink.h" "ac_cv_header_libnfnetlink_libnfnetlink_h" "$ac_includes_default"
+if test "x$ac_cv_header_libnfnetlink_libnfnetlink_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBNFNETLINK_LIBNFNETLINK_H 1
+_ACEOF
+
+else
+  as_fn_error $? "
+    !!! Please install libnfnetlink headers.              !!!" "$LINENO" 5
+fi
+
+done
+
+fi
 
 IF_H_LINK_H_COLLISION="_WITHOUT_IF_H_LINK_H_COLLISION_"
 if test "${USE_NL3}" = "_HAVE_LIBNL3_"; then

--- a/configure.in
+++ b/configure.in
@@ -56,8 +56,6 @@ dnl [do we really need this ?] AC_CHECK_HEADERS(linux/netlink.h linux/rtnetlink.
 AC_CHECK_HEADERS(openssl/ssl.h openssl/md5.h openssl/err.h,,AC_MSG_ERROR([
   !!! OpenSSL is not properly installed on your system. !!!
   !!! Can not include OpenSSL headers files.            !!!]))
-AC_CHECK_HEADERS(libnfnetlink/libnfnetlink.h,,AC_MSG_ERROR([
-  !!! Please install libnfnetlink headers.              !!!]))
 AC_CHECK_DECL([ETHERTYPE_IPV6],[],[CFLAGS="$CFLAGS -DETHERTYPE_IPV6=0x86dd"],
   [[@%:@include <net/ethernet.h>]])
 
@@ -102,6 +100,11 @@ AC_CHECK_LIB(nl-3, nl_socket_alloc,
   ])
 
 AC_SUBST(USE_NL3)
+
+if test "$USE_NL3" != "_WITHOUT_LIBNL_"; then
+  AC_CHECK_HEADERS(libnfnetlink/libnfnetlink.h,,AC_MSG_ERROR([
+    !!! Please install libnfnetlink headers.              !!!]))
+fi
 
 dnl ----[Check if have linux/if.h and netlink/route/link.h namespace collision]----
 IF_H_LINK_H_COLLISION="_WITHOUT_IF_H_LINK_H_COLLISION_"

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1721,6 +1721,10 @@ vrrp_complete_instance(vrrp_t * vrrp)
 			vrrp->version = VRRP_VERSION_3;
 	}
 
+	/* Default to IPv4. This can only happen if no VIPs are specified. */
+	if (vrrp->family == AF_UNSPEC)
+		vrrp->family = AF_INET;
+
 	if (vrrp->accept) {
 		if (vrrp->version == VRRP_VERSION_2)
 		{
@@ -1795,7 +1799,7 @@ vrrp_complete_instance(vrrp_t * vrrp)
 		hdr_len = sizeof(struct ether_header) + sizeof(struct ip6_hdr) + sizeof(vrrphdr_t);
 		max_addr = (vrrp->ifp->mtu - hdr_len) / sizeof(struct in6_addr);
 	}
-	if (LIST_SIZE(vrrp->vip) > max_addr) {
+	if (!LIST_ISEMPTY(vrrp->vip) && LIST_SIZE(vrrp->vip) > max_addr) {
 		log_message(LOG_INFO, "(%s): Number of VIPs (%d) exceeds space available in packet (max %d addresses) - excess moved to eVIPs",
 				vrrp->iname, LIST_SIZE(vrrp->vip), max_addr);
 		for (i = 0, e = LIST_HEAD(vrrp->vip); e; i++, e = next) {


### PR DESCRIPTION
Commit b46dec58fa failed to check the the VIP list existed before
checking how many entries were in the list.

This commit also defaults the address family to IPv4 if no VIPs are
specified.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>