### PR TITLE
add a line about the 'include' keyword in keepalived.conf(5)

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -11,6 +11,9 @@ each layer being delimited by '{' and '}' pairs.
 .PP
 Comments start with '#' or '!' to the end of the line and can start
 anywhere in a line.
+.PP
+Keyword 'include' allows inclusion of other configuration files from within
+the main configuration file.
 .SH TOP HIERACHY
 .PP
 .B GLOBAL CONFIGURATION


### PR DESCRIPTION
This 'include' keyword exists since release 1.1.14 (2007-09-13), it's time to document it.