### PR TITLE
Allow routes and rules to use tables >= 256

### DIFF
--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -85,8 +85,13 @@ netlink_route(ip_route_t *iproute, int cmd)
 	req.n.nlmsg_len   = NLMSG_LENGTH(sizeof(struct rtmsg));
 	req.n.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE;
 	req.n.nlmsg_type  = cmd ? RTM_NEWROUTE : RTM_DELROUTE;
-	req.r.rtm_family  = IP_FAMILY(iproute->dst);;
-	req.r.rtm_table   = iproute->table ? iproute->table : RT_TABLE_MAIN;
+	req.r.rtm_family  = IP_FAMILY(iproute->dst);
+	if (iproute->table < 256)
+		req.r.rtm_table   = iproute->table ? iproute->table : RT_TABLE_MAIN;
+	else {
+		req.r.rtm_table = RT_TABLE_UNSPEC;
+		addattr32(&req.n, sizeof(req), RTA_TABLE, iproute->table);
+	}
 	req.r.rtm_scope   = RT_SCOPE_NOWHERE;
 
 	if (cmd) {

--- a/keepalived/vrrp/vrrp_iprule.c
+++ b/keepalived/vrrp/vrrp_iprule.c
@@ -69,7 +69,12 @@ netlink_rule(ip_rule_t *iprule, int cmd)
 	req.n.nlmsg_flags  = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL;
 	req.n.nlmsg_type   = cmd ? RTM_NEWRULE : RTM_DELRULE;
 	req.r.rtm_family   = IP_FAMILY(iprule->addr);
-	req.r.rtm_table    = iprule->table ? iprule->table : RT_TABLE_MAIN;
+	if (iprule->table < 256)
+		req.r.rtm_table = iprule->table ? iprule->table : RT_TABLE_MAIN;
+	else {
+		req.r.rtm_table = RT_TABLE_UNSPEC;
+		addattr32(&req.n, sizeof(req), FRA_TABLE, iprule->table);
+	}
 	req.r.rtm_type     = RTN_UNSPEC;
 	req.r.rtm_scope    = RT_SCOPE_UNIVERSE;
 	req.r.rtm_flags    = 0;


### PR DESCRIPTION
This resolves issue #214

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>