### PR TITLE
Reduce number of calls to getaddrinfo() reducing DNS lookups

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -28,7 +28,10 @@ global_defs {				# Block identification
        ...
     }
     notification_email_from <EMAIL ADDRESS> # Email From dealing with SMTP proto
+					   #   defaults to keepalived@<local host name>
     smtp_server <ADDRESS>|<DOMAIN_NAME>	   # SMTP server IP address or domain name
+    smtp_helo_name <HOST_NAME>		   # name to use in HELO messages
+					   #  defaults to local host name
     smtp_connect_timeout <INTEGER>	   # Number of seconds timeout connect
  					   #  remote SMTP server
     router_id <STRING>			   # String identifying router

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -38,12 +38,15 @@ and
         admin@example1.com
         ...
         }
- # From: from address that will be in header
+ # From: from address that will be in header (default keepalived@<local host name>
  notification_email_from admin@example.com
  smtp_server 127.0.0.1        # IP address or domain name
+ smtp_helo_name <HOST_NAME>   # name to use in HELO messages
+                              #  defaults to local host name
  smtp_connect_timeout 30      # integer, seconds
  router_id my_hostname        # string identifying the machine,
                               # (doesn't have to be hostname).
+                              # default: local host name
  vrrp_mcast_group4 224.0.0.18 # optional, default 224.0.0.18
  vrrp_mcast_group6 ff02::12   # optional, default ff02::12
 

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -66,6 +66,21 @@ smtpserver_handler(vector_t *strvec)
 	}
 }
 static void
+smtphelo_handler(vector_t *strvec)
+{
+	char *helo_name;
+
+	if (vector_size(strvec) < 2)
+		return;
+
+	helo_name = malloc(strlen(vector_slot(strvec, 1)) + 1);
+	if (!helo_name)
+		return;
+
+	strcpy(helo_name, vector_slot(strvec, 1));
+	global_data->smtp_helo_name = helo_name;
+}
+static void
 email_handler(vector_t *strvec)
 {
 	vector_t *email_vec = read_value_block(strvec);
@@ -301,6 +316,7 @@ global_init_keywords(void)
 	install_keyword("router_id", &routerid_handler);
 	install_keyword("notification_email_from", &emailfrom_handler);
 	install_keyword("smtp_server", &smtpserver_handler);
+	install_keyword("smtp_helo_name", &smtphelo_handler);
 	install_keyword("smtp_connect_timeout", &smtpto_handler);
 	install_keyword("notification_email", &email_handler);
 	install_keyword("vrrp_mcast_group4", &vrrp_mcast_group4_handler);

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -307,16 +307,13 @@ static int
 helo_cmd(thread_t * thread)
 {
 	smtp_t *smtp = THREAD_ARG(thread);
-	char *name;
 	char *buffer;
 
 	buffer = (char *) MALLOC(SMTP_BUFFER_MAX);
-	name = get_local_name();
-	snprintf(buffer, SMTP_BUFFER_MAX, SMTP_HELO_CMD, (name) ? name : "localhost");
+	snprintf(buffer, SMTP_BUFFER_MAX, SMTP_HELO_CMD, (global_data->smtp_helo_name) ? global_data->smtp_helo_name : "localhost");
 	if (send(thread->u.fd, buffer, strlen(buffer), 0) == -1)
 		smtp->stage = ERROR;
 	FREE(buffer);
-	FREE_PTR(name);
 
 	return 0;
 }

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -58,6 +58,7 @@ typedef struct _data {
 	char				*router_id;
 	char				*email_from;
 	struct sockaddr_storage		smtp_server;
+	char				*smtp_helo_name;
 	long				smtp_connection_to;
 	list				email;
 	struct sockaddr_storage		vrrp_mcast_group4;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -373,7 +373,7 @@ vrrp_in_chk(vrrp_t * vrrp, char *buffer, size_t buflen, bool check_vip_addr)
 		/* Set expected vrrp packet length */
 		expected_len = sizeof(vrrphdr_t) + (LIST_ISEMPTY(vrrp->vip) ? 0 : LIST_SIZE(vrrp->vip)) * sizeof(struct in6_addr);
 	} else {
-		log_message(LOG_INFO, "(%s): configured address family is %d, which is neither AF_INET or AF_INET6. This is probably a bug - please report");
+		log_message(LOG_INFO, "(%s): configured address family is %d, which is neither AF_INET or AF_INET6. This is probably a bug - please report", vrrp->iname, vrrp->family);
 		return VRRP_PACKET_KO;
 	}
 


### PR DESCRIPTION
Issue #199 identified that keepalived could be very slow to start up
if DNS queries resolving the local host name were very slow.

keepalived could call get_local_name() twice at startup for each of the
vrrp and checker threads, in order to get the router_id and also the
set the default email_from address, unless these were manually configured.
It also called getaddrinfo() for the local host name every time it sent an
email, in order to set the HELO string.

This commit reduces the total number of calls per thread to one, using
the returned name to set the router_id, email_from address and the HELO
name (which is now saved for reuse every time an email is sent).

In order to allow no DNS lookups to be made, an extra global configuration
parameter is introduced, smtp_helo_name, so that if router_id, smtp_email_from
and smtp_helo_name are all set in the configurationi (and also the smtp_server
is specified by IP address rather than by name), then no DNS queries will
be made.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>