### PR TITLE
Stop double free introduced in commit 9d028ac

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -38,7 +38,7 @@ and
         admin@example1.com
         ...
         }
- # From: from address that will be in header (default keepalived@<local host name>
+ # From: from address that will be in header (default keepalived@<local host name>)
  notification_email_from admin@example.com
  smtp_server 127.0.0.1        # IP address or domain name
  smtp_helo_name <HOST_NAME>   # name to use in HELO messages

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -42,7 +42,8 @@ set_default_router_id(data_t *data, char *new_id)
 	if (!new_id || !new_id[0])
 		return;
 
-	data->router_id = new_id;
+	data->router_id = MALLOC(strlen(new_id)+1);
+	strcpy(data->router_id, new_id);
 }
 
 static void

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -73,7 +73,7 @@ smtphelo_handler(vector_t *strvec)
 	if (vector_size(strvec) < 2)
 		return;
 
-	helo_name = malloc(strlen(vector_slot(strvec, 1)) + 1);
+	helo_name = MALLOC(strlen(vector_slot(strvec, 1)) + 1);
 	if (!helo_name)
 		return;
 


### PR DESCRIPTION
Commit 9d028ac introduced a double free in certain configuration
circumstances, which this resolves.

This commit also changes the malloc() introduced in that commit
to MALLOC().

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>