### PR TITLE
Better logging of shutdown process and version of code being run

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,11 +29,6 @@ profile:
 	@echo ""
 	@echo "Make complete"
 
-clean:
-	$(MAKE) -C lib clean
-	$(MAKE) -C keepalived clean
-	$(MAKE) -C genhash clean
-
 id: ID
 
 ID:
@@ -44,16 +39,42 @@ tags: TAGS
 TAGS:
 	find . -name "*.[chCH]" -print | etags -
 
-distclean:
+clean_sub:
+	$(MAKE) -C lib clean
+	$(MAKE) -C keepalived clean
+	$(MAKE) -C genhash clean
+
+clean_me:
+	rm -f *.[ao] *~ *.orig *.rej core
+
+clean: clean_sub clean_me
+
+distclean_sub:
 	$(MAKE) -C lib distclean
 	$(MAKE) -C keepalived distclean
 	$(MAKE) -C genhash distclean
+
+distclean_me: clean_me
 	rm -f Makefile
 	rm -f keepalived.spec
 	rm -f TAGS ID
 
-mrproper: distclean
+distclean: distclean_me distclean_sub
+
+tarclean_sub:
+	$(MAKE) -C lib tarclean
+	$(MAKE) -C keepalived tarclean
+	$(MAKE) -C genhash tarclean
+
+tarclean_me: distclean_me
 	rm -f config.*
+
+tarclean: tarclean_me tarclean_sub
+
+mrproper: tarclean_me
+	$(MAKE) -C lib mrproper
+	$(MAKE) -C keepalived mrproper
+	$(MAKE) -C genhash mrproper
 
 uninstall:
 	$(MAKE) -C keepalived uninstall
@@ -80,7 +101,7 @@ else ifeq (@SNMP_CHECKER_SUPPORT@, _WITH_SNMP_CHECKER_)
 endif
 endif
 
-tarball: mrproper
+tarball: tarclean
 	mkdir keepalived-@VERSION@
 	cp -a $(TARFILES) keepalived-@VERSION@
 	tar --exclude .git -czf $(TARBALL) keepalived-@VERSION@

--- a/genhash/Makefile.in
+++ b/genhash/Makefile.in
@@ -33,7 +33,7 @@ $(BIN)/$(EXEC): $(LIB_OBJS) $(OBJS)
 	$(CC) -o $(BIN)/$(EXEC) $(LIB_OBJS) $(OBJS) $(LDFLAGS)
 
 clean:
-	rm -f core *.o
+	rm -f *.[ao] *~ *.orig *.rej core
 
 distclean: clean
 	rm -f Makefile $(BIN)/$(EXEC)
@@ -48,7 +48,9 @@ install:
 	install -d $(DESTDIR)$(mandir)/man1
 	install -m 644 ../doc/man/man1/genhash.1 $(DESTDIR)$(mandir)/man1
 
-mrproper: clean distclean
+tarclean: distclean
+
+mrproper: tarclean
 	rm -f config.*
 
 # Code dependencies

--- a/keepalived/Makefile.in
+++ b/keepalived/Makefile.in
@@ -83,7 +83,9 @@ distclean:
 	$(MAKE) -C $$i distclean; done
 	rm -f Makefile $(BIN)/$(EXEC)
 
-mrproper: distclean
+tarclean: distclean
+
+mrproper: tarclean
 	rm -f config.*
 
 uninstall:

--- a/keepalived/check/Makefile.in
+++ b/keepalived/check/Makefile.in
@@ -27,7 +27,7 @@ HEADERS = $(OBJS:.o=.h)
 all:	$(OBJS)
 
 clean:
-	rm -f *.a *.o *~
+	rm -f *.[ao] *~ *.orig *.rej core
 
 distclean: clean
 	rm -f Makefile

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -82,6 +82,8 @@ stop_check(void)
 	 * Reached when terminate signal catched.
 	 * finally return to parent process.
 	 */
+	log_message(LOG_INFO, "Stopped");
+
 	closelog();
 	exit(0);
 }

--- a/keepalived/core/Makefile.in
+++ b/keepalived/core/Makefile.in
@@ -24,7 +24,7 @@ HEADERS = $(OBJS:.o=.h)
 all:	$(OBJS)
 
 clean:
-	rm -f *.a *.o *~
+	rm -f *.[ao] *~ *.orig *.rej core
 
 distclean: clean
 	rm -f Makefile

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -255,8 +255,11 @@ parse_cmdline(int argc, char **argv)
 									, long_options, NULL)) != EOF) {
 		switch (c) {
 		case 'v':
-			fprintf(stderr, "%s\n", VERSION_STRING);
-			fprintf(stderr, "%s\n", COPYRIGHT_STRING);
+			fprintf(stderr, "%s", VERSION_STRING);
+#ifdef GIT_COMMIT
+			fprintf(stderr, ", git commit %s", GIT_COMMIT);
+#endif
+			fprintf(stderr, "\n\n%s\n\n", COPYRIGHT_STRING);
 			fprintf(stderr, "Build options: %s\n", BUILD_OPTIONS);
 			exit(0);
 			break;
@@ -352,7 +355,11 @@ main(int argc, char **argv)
 
 	openlog(PROG, LOG_PID | ((__test_bit(LOG_CONSOLE_BIT, &debug)) ? LOG_CONS : 0)
 		    , log_facility);
-	log_message(LOG_INFO, "Starting " VERSION_STRING);
+#ifdef GIT_COMMIT
+	log_message(LOG_INFO, "Starting %s, git commit %s", VERSION_STRING, GIT_COMMIT);
+#else
+	log_message(LOG_INFO, "Starting %s", VERSION_STRING);
+#endif
 
 	/* Check if keepalived is already running */
 	if (keepalived_running(daemon_mode)) {
@@ -395,7 +402,11 @@ main(int argc, char **argv)
 	 * finally return from system
 	 */
 end:
+#ifdef GIT_COMMIT
+	log_message(LOG_INFO, "Stopped %s, git commit %s", VERSION_STRING, GIT_COMMIT);
+#else
 	log_message(LOG_INFO, "Stopped %s", VERSION_STRING);
+#endif
 
 	closelog();
 	exit(0);

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -27,6 +27,8 @@
 #include "bitops.h"
 #include "logger.h"
 
+#define CHILD_WAIT_SECS	5
+
 /* global var */
 char *conf_file = NULL;					/* Configuration file */
 int log_facility = LOG_DAEMON;				/* Optional logging facilities */
@@ -54,7 +56,6 @@ static struct {
 static void
 stop_keepalived(void)
 {
-	log_message(LOG_INFO, "Stopping " VERSION_STRING);
 	/* Just cleanup memory & exit */
 	signal_handler_destroy();
 	thread_destroy_master(master);
@@ -104,18 +105,75 @@ static void
 sigend(void *v, int sig)
 {
 	int status;
+	int ret;
+	int wait_count = 0;
+	sigset_t old_set, child_wait;
+	struct timespec timeout = { CHILD_WAIT_SECS, 0 };
+	struct timeval start_time, now;
 
 	/* register the terminate thread */
 	thread_add_terminate_event(master);
 
+	log_message(LOG_INFO, "Stopping");
+	sigprocmask(0, NULL, &old_set);
+	if (!sigismember(&old_set, SIGCHLD)) {
+		sigemptyset(&child_wait);
+		sigaddset(&child_wait, SIGCHLD);
+		sigprocmask(SIG_BLOCK, &child_wait, NULL);
+	}
+
 	if (vrrp_child > 0) {
 		kill(vrrp_child, SIGTERM);
-		waitpid(vrrp_child, &status, WNOHANG);
+		wait_count++;
 	}
 	if (checkers_child > 0) {
 		kill(checkers_child, SIGTERM);
-		waitpid(checkers_child, &status, WNOHANG);
+		wait_count++;
 	}
+
+	gettimeofday(&start_time, NULL);
+	while (wait_count) {
+		ret = sigtimedwait(&child_wait, NULL, &timeout);
+		if (ret == -1) {
+			if (errno == EINTR)
+				continue;
+			if (errno == EAGAIN)
+				break;
+		}
+
+		if (vrrp_child > 0 && vrrp_child == waitpid(vrrp_child, &status, WNOHANG)) {
+			report_child_status(status, vrrp_child, PROG_VRRP);
+			wait_count--;
+		}
+
+		if (checkers_child > 0 && checkers_child == waitpid(checkers_child, &status, WNOHANG)) {
+			report_child_status(status, checkers_child, PROG_CHECK);
+			wait_count--;
+		}
+		if (wait_count) {
+			gettimeofday(&now, NULL);
+			if (now.tv_usec < start_time.tv_usec) {
+				timeout.tv_nsec = (start_time.tv_usec - now.tv_usec) * 1000;
+				timeout.tv_sec = CHILD_WAIT_SECS - (now.tv_sec - start_time.tv_sec);
+			} else if (now.tv_usec == start_time.tv_usec) {
+				timeout.tv_nsec = 0;
+				timeout.tv_sec = CHILD_WAIT_SECS - (now.tv_sec - start_time.tv_sec);
+			} else {
+				timeout.tv_nsec = (1000000L + start_time.tv_usec - now.tv_usec) * 1000;
+				timeout.tv_sec = CHILD_WAIT_SECS - (now.tv_sec - start_time.tv_sec + 1);
+			}
+
+			timeout.tv_nsec = (start_time.tv_usec - now.tv_usec) * 1000;
+			timeout.tv_sec = CHILD_WAIT_SECS - (now.tv_sec - start_time.tv_sec);
+			if (timeout.tv_nsec < 0) {
+				timeout.tv_nsec += 1000000000L;
+				timeout.tv_sec--;
+			}
+		}
+	}
+
+	if (!sigismember(&old_set, SIGCHLD))
+		sigprocmask(SIG_UNBLOCK, &child_wait, NULL);
 }
 
 /* Initialize signal handler */
@@ -337,6 +395,8 @@ main(int argc, char **argv)
 	 * finally return from system
 	 */
 end:
+	log_message(LOG_INFO, "Stopped %s", VERSION_STRING);
+
 	closelog();
 	exit(0);
 }

--- a/keepalived/libipvs-2.4/Makefile.in
+++ b/keepalived/libipvs-2.4/Makefile.in
@@ -12,7 +12,7 @@ libipvs.a: libipvs.a(libipvs.o)
 libipvsc.o: libipvs.h
 
 clean:
-	rm -f *.a *.o *~
+	rm -f *.[ao] *~ *.orig *.rej core
 
 distclean: clean
 	rm -f Makefile

--- a/keepalived/vrrp/Makefile.in
+++ b/keepalived/vrrp/Makefile.in
@@ -45,7 +45,7 @@ HEADERS = $(OBJS:.o=.h)
 all:	$(OBJS)
 
 clean:
-	rm -f *.a *.o *~
+	rm -f *.[ao] *~ *.orig *.rej core
 
 distclean: clean
 	rm -f Makefile

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -90,7 +90,6 @@ stop_vrrp(void)
 #endif
 
 	/* Clean data */
-	free_global_data(global_data);
 	vrrp_dispatcher_release(vrrp_data);
 
 	/* This is not nice, but it significantly increases the chances
@@ -102,13 +101,15 @@ stop_vrrp(void)
 	if (!__test_bit(DONT_RELEASE_VRRP_BIT, &debug))
 		shutdown_vrrp_instances();
 
-	free_vrrp_data(vrrp_data);
-	free_vrrp_buffer();
-	free_interface_queue();
 	kernel_netlink_close();
 	thread_destroy_master(master);
 	gratuitous_arp_close();
 	ndisc_close();
+
+	free_global_data(global_data);
+	free_vrrp_data(vrrp_data);
+	free_vrrp_buffer();
+	free_interface_queue();
 
 	signal_handler_destroy();
 
@@ -121,6 +122,9 @@ stop_vrrp(void)
 	 * finally return to parent process.
 	 */
 	closelog();
+
+	log_message(LOG_INFO, "Stopped");
+
 	exit(0);
 }
 

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -121,9 +121,9 @@ stop_vrrp(void)
 	 * Reached when terminate signal catched.
 	 * finally return to parent process.
 	 */
-	closelog();
-
 	log_message(LOG_INFO, "Stopped");
+
+	closelog();
 
 	exit(0);
 }

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -485,8 +485,8 @@ if_join_vrrp_group(sa_family_t family, int *sd, interface_t *ifp, int proto)
 	}
 
 	if (ret < 0) {
-		log_message(LOG_INFO, "cant do IP%s_ADD_MEMBERSHIP errno=%s (%d)",
-			    (family == AF_INET) ? "" : "V6", strerror(errno), errno);
+		log_message(LOG_INFO, "(%s): cant do IP%s_ADD_MEMBERSHIP errno=%s (%d)",
+			    ifp->ifname, (family == AF_INET) ? "" : "V6", strerror(errno), errno);
 		close(*sd);
 		*sd = -1;
 	}
@@ -521,8 +521,8 @@ if_leave_vrrp_group(sa_family_t family, int sd, interface_t *ifp)
 	}
 
 	if (ret < 0) {
-		log_message(LOG_INFO, "cant do IP%s_DROP_MEMBERSHIP errno=%s (%d)",
-			    (family == AF_INET) ? "" : "V6", strerror(errno), errno);
+		log_message(LOG_INFO, "(%s): cant do IP%s_DROP_MEMBERSHIP errno=%s (%d)",
+			    ifp->ifname, (family == AF_INET) ? "" : "V6", strerror(errno), errno);
 		return -1;
 	}
 

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+git-commit.h

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -14,17 +14,37 @@ OBJS =	memory.o utils.o notify.o timer.o scheduler.o \
 	vector.o list.o html.o parser.o signals.o logger.o
 HEADERS = $(OBJS:.o=.h)
 
+GIT_COMMIT_FILE = git-commit.h
+
 .c.o:
 	$(COMPILE) -c $<
 
 all:	$(OBJS)
+	@[[ ! -f $(GIT_COMMIT_FILE) ]] && >$(GIT_COMMIT_FILE); \
+	if [[ -x $$(type -p git) ]]; then \
+		git rev-parse --is-inside-work-tree >/dev/null; \
+		if [[ $$? -eq 0 && $$(git describe --tags) =~ -[1-9][0-9]*-g[0-9a-f]{7}$$ ]]; then \
+			echo "#define GIT_COMMIT \"$$(git describe --tags)\"" >$(GIT_COMMIT_FILE).new; \
+			diff -q $(GIT_COMMIT_FILE) $(GIT_COMMIT_FILE).new 2>/dev/null >/dev/null; \
+			if [[ $$? -eq 0 ]]; then \
+				rm $(GIT_COMMIT_FILE).new; \
+			else \
+				mv $(GIT_COMMIT_FILE).new $(GIT_COMMIT_FILE); \
+			fi; \
+		fi; \
+	fi
 
 clean:
-	rm -f *.a *.o *~
+	rm -f *.[ao] *~ *.orig *.rej core
 
 distclean: clean
 	rm -f config.h
 	rm -f Makefile
+
+tarclean: distclean
+
+mrproper: tarclean
+	rm -f $(GIT_COMMIT_FILE) $(GIT_COMMIT_FILE).new
 
 memory.o: memory.c memory.h utils.h bitops.h
 utils.o: utils.c utils.h memory.h

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -28,4 +28,6 @@
 #define COPYRIGHT_STRING	"Copyright (C) 2001-@VERSION_YEAR@ Alexandre Cassen, <acassen@gmail.com>"
 #define	BUILD_OPTIONS		"@BUILD_OPTS@"
 
+#include "git-commit.h"
+
 #endif

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -103,6 +103,7 @@ typedef struct _thread_master {
 extern thread_master_t *master;
 
 /* Prototypes. */
+extern void report_child_status(int, pid_t, const char *);
 extern thread_master_t *thread_make_master(void);
 extern thread_t *thread_add_terminate_event(thread_master_t *);
 extern void thread_destroy_master(thread_master_t *);


### PR DESCRIPTION
These commits make the parent process wait for the child processes to terminate, and reports the termination reason if they don't exit with status 0, and also if keepalived is not built from a released version it reports the git commit from which the code was built.

The purpose of these commits principally relates to issue #159 - VIPs not being removed - where it may be caused by the vrrp child process terminating before completing its closedown processing, but also for any future bug reports where it is useful to know exactly what code version is being run.