### PR TITLE
Configure LVS syncd at global level, a few other lvs syncd changes and three minor fixes

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -37,7 +37,9 @@ global_defs {				# Block identification
     router_id <STRING>			   # String identifying router
     vrrp_mcast_group4 <IPv4 ADDRESS>	   # optional, default 224.0.0.18
     vrrp_mcast_group6 <IPv6 ADDRESS>	   # optional, default ff02::12
-    lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE>	# Binding interface and vrrp instance for lvs syncd
+    lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE>	[<SYNC_ID>]
+					   # Binding interface, vrrp instance and optional
+					   #  syncid (0 to 255) for lvs syncd
     vrrp_garp_master_delay <INTEGER>	   # delay in seconds for second set of gratuitous ARP
 					   #  messages after MASTER state transition, default 5
     vrrp_garp_master_repeat <INTEGER>	   # how many gratuitous ARP messages after MASTER

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -37,6 +37,7 @@ global_defs {				# Block identification
     router_id <STRING>			   # String identifying router
     vrrp_mcast_group4 <IPv4 ADDRESS>	   # optional, default 224.0.0.18
     vrrp_mcast_group6 <IPv6 ADDRESS>	   # optional, default ff02::12
+    lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE>	# Binding interface and vrrp instance for lvs syncd
     vrrp_garp_master_delay <INTEGER>	   # delay in seconds for second set of gratuitous ARP
 					   #  messages after MASTER state transition, default 5
     vrrp_garp_master_repeat <INTEGER>	   # how many gratuitous ARP messages after MASTER
@@ -218,7 +219,6 @@ vrrp_instance <STRING> {		# VRRP instance declaration
       <IP ADDRESS>			#  adverts to following list of ip address
       ...				#  in unicast design fashion
     }
-    lvs_sync_daemon_interface <STRING>	# Binding interface for lvs syncd
 
     # The following garp parameters take their defaults from the global config for vrrp_garp_master_...
     # See their descriptions for the meaning of the parameters.

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -50,6 +50,8 @@ and
  vrrp_mcast_group4 224.0.0.18 # optional, default 224.0.0.18
  vrrp_mcast_group6 ff02::12   # optional, default ff02::12
 
+ lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE> # Binding interface and vrrp instance for lvs syncd
+
  # delay for second set of gratuitous ARPs after transition to MASTER
  vrrp_garp_master_delay 10    # secs, default 5, 0 for no second set
 
@@ -287,9 +289,6 @@ which will transition together on any state change.
       <IPADDR>
       ...
     }
-
-    # Binding interface for lvs syncd
-    lvs_sync_daemon_interface eth1
 
     # interface specific settings, same as global parameters; default to global parameters
     garp_master_delay 10

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -50,7 +50,9 @@ and
  vrrp_mcast_group4 224.0.0.18 # optional, default 224.0.0.18
  vrrp_mcast_group6 ff02::12   # optional, default ff02::12
 
- lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE> # Binding interface and vrrp instance for lvs syncd
+ lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE> [<SYNC_ID>]
+                              # Binding interface, vrrp instance and optional
+                              #  syncid for lvs syncd
 
  # delay for second set of gratuitous ARPs after transition to MASTER
  vrrp_garp_master_delay 10    # secs, default 5, 0 for no second set
@@ -112,7 +114,7 @@ and
  #   master even when the master is still running, due to the master or
  #   backup systems being busy, they are not processing the vrrp packets.
  vrrp_priority <-20 to 19>    # Set the vrrp child process priority
-			      #   Negative values increase priority.
+                              #   Negative values increase priority.
  checker_priority <-20 to 19> # Set the checker child process priority
  vrrp_no_swap                 # Set the vrrp child process non swappable
  checker_no_swap              # Set the checker child process non swappable
@@ -172,12 +174,12 @@ and
  # recorded for all VRRP instances which are monitoring it with
  # non-zero weight.
  vrrp_script <SCRIPT_NAME> {
-    script <STRING>|<QUOTED-STRING>	# path of script to execute
-    interval <INTEGER>	# seconds between script invocations, default 1 second
-    timeout <INTEGER>	# seconds after which script is considered to have failed
-    weight <INTEGER:-254..254>	# adjust priority by this weight, default 2
-    rise <INTEGER>		# required number of successes for OK transition
-    fall <INTEGER>		# required number of successes for KO transition
+    script <STRING>|<QUOTED-STRING> # path of script to execute
+    interval <INTEGER>  # seconds between script invocations, default 1 second
+    timeout <INTEGER>   # seconds after which script is considered to have failed
+    weight <INTEGER:-254..254>  # adjust priority by this weight, default 2
+    rise <INTEGER>              # required number of successes for OK transition
+    fall <INTEGER>              # required number of successes for KO transition
  }
 .PP
 .SH VRRP synchronization group(s)
@@ -218,7 +220,7 @@ and
     # using addresses in global_defs above.
     smtp_alert
 
-    global_tracking	# All VRRP share same tracking conf
+    global_tracking     # All VRRP share same tracking conf
  }
 
 .SH VRRP instance(s)
@@ -247,7 +249,7 @@ which will transition together on any state change.
     # VMAC interface
     vmac_xmit_base
 
-    native_ipv6		# force instance to use IPv6 (when mixed IPv4 and IPv6 config).
+    native_ipv6         # force instance to use IPv6 (when mixed IPv4 and IPv6 config).
 
     # Ignore VRRP interface faults (default unset)
     dont_track_primary
@@ -276,7 +278,7 @@ which will transition together on any state change.
     mcast_src_ip <IPADDR>
     unicast_src_ip <IPADDR>
 
-    version <2 or 3>		# VRRP version to run on interface
+    version <2 or 3>            # VRRP version to run on interface
                                 #  default is global parameter vrrp_version.
 
     # Do not send VRRP adverts over VRRP multicast group.
@@ -365,7 +367,7 @@ which will transition together on any state change.
         to 192.168.2.0/24 table 1
     }
 
-    accept	# Allow the non-master owner to process the packets destined to VIP
+    accept    # Allow the non-master owner to process the packets destined to VIP
 
     # VRRP will normally preempt a lower priority
     # machine when a higher priority machine comes
@@ -375,11 +377,11 @@ which will transition together on any state change.
     # NOTE: For this to work, the initial state of this
     # entry must be BACKUP.
     nopreempt
-    preempt		# for backwards compatibility
+    preempt             # for backwards compatibility
 
     # See description of global vrrp_skip_check_adv_addr, which
     # sets the default value. Defaults to vrrp_skip_check_adv_addr
-    skip_check_adv_addr [on|off|true|false|yes|no]	# Default on if no word specified
+    skip_check_adv_addr [on|off|true|false|yes|no]      # Default on if no word specified
 
     # See description of global vrrp_strict
     # If vrrp_strict is not specified, it takes the value of vrrp_strict
@@ -400,7 +402,7 @@ which will transition together on any state change.
     notify_master <STRING>|<QUOTED-STRING>
     notify_backup <STRING>|<QUOTED-STRING>
     notify_fault <STRING>|<QUOTED-STRING>
-    notify_stop <STRING>|<QUOTED-STRING>	# run when stopping vrrp
+    notify_stop <STRING>|<QUOTED-STRING>      # run when stopping vrrp
     notify <STRING>|<QUOTED-STRING>
     smtp_alert
  }
@@ -408,10 +410,10 @@ which will transition together on any state change.
  # Parameters used for SSL GET check.
  # If none of the parameters are specified, the SSL context will be auto generated
  SSL {
-    password <STRING>	# password
-    ca <STRING>		# ca file
-    certificate <STRING>	# certificate file
-    key <STRING>		# key file
+    password <STRING>   # password
+    ca <STRING>         # ca file
+    certificate <STRING>  # certificate file
+    key <STRING>        # key file
  }
 
 .SH LVS CONFIGURATION
@@ -486,8 +488,8 @@ A virtual_server can be a declaration of one of
     # suspend healthchecker's activity
     ha_suspend
 
-    lvs_sched	# synonym for lb_algo
-    lvs_method	# synonym for lb_kind
+    lvs_sched   # synonym for lb_algo
+    lvs_method  # synonym for lb_kind
 
     # VirtualHost string for HTTP_GET or SSL_GET
     # eg virtualhost www.firewall.loc
@@ -548,8 +550,8 @@ A virtual_server can be a declaration of one of
            # considers service as down.
            notify_down <STRING>|<QUOTED-STRING>
 
-           uthreshold <INTEGER>	# maximum number of connections to server
-           lthreshold <INTEGER>	# minimum number of connections to server
+           uthreshold <INTEGER> # maximum number of connections to server
+           lthreshold <INTEGER> # minimum number of connections to server
 
            # pick one healthchecker
            # HTTP_GET|SSL_GET|TCP_CHECK|SMTP_CHECK|MISC_CHECK

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -96,6 +96,11 @@ start_check(void)
 		stop_check();
 		return;
 	}
+
+	/* Remove any entries left over from previous invocation */
+	if (!reload)
+		ipvs_flush_cmd();
+
 	init_checkers_queue();
 #ifdef _WITH_VRRP_
 	init_interface_queue();

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -94,7 +94,7 @@ ip_family_handler(vector_t *strvec)
 	else if (0 == strcmp(vector_slot(strvec, 1), "inet6"))
 		vs->af = AF_INET6;
 	else
-		log_message(LOG_INFO, "unknown address family %s", vector_slot(strvec, 1));
+		log_message(LOG_INFO, "unknown address family %s", (char *)vector_slot(strvec, 1));
 }
 static void
 delay_handler(vector_t *strvec)

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -153,6 +153,7 @@ alloc_global_data(void)
 		new->enable_snmp_checker = true;
 #endif
 	}
+	new->lvs_syncd_syncid = -1;
 
 	if (snmp_socket) {
 		new->snmp_socket = MALLOC(strlen(snmp_socket + 1));
@@ -233,12 +234,15 @@ dump_global_data(data_t * data)
 				    , data->email_from);
 		dump_list(data->email);
 	}
-	if (data->lvs_syncd_vrrp)
+	if (data->lvs_syncd_vrrp) {
 		log_message(LOG_INFO, " LVS syncd vrrp instance = %s"
 				    , data->lvs_syncd_vrrp->iname);
-	if (data->lvs_syncd_if)
-		log_message(LOG_INFO, " LVS syncd interface = %s"
+		if (data->lvs_syncd_if)
+			log_message(LOG_INFO, " LVS syncd interface = %s"
 				    , data->lvs_syncd_if);
+		log_message(LOG_INFO, " LVS syncd syncid = %d"
+				    , data->lvs_syncd_syncid);
+	}
 	if (data->vrrp_mcast_group4.ss_family) {
 		log_message(LOG_INFO, " VRRP IPv4 mcast group = %s"
 				    , inet_sockaddrtos(&data->vrrp_mcast_group4));

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -204,6 +204,8 @@ free_global_data(data_t * data)
 #ifdef _WITH_SNMP_
 	FREE_PTR(data->snmp_socket);
 #endif
+	FREE_PTR(data->lvs_syncd_if);
+	FREE_PTR(data->lvs_syncd_vrrp_name);
 	FREE(data);
 }
 
@@ -231,6 +233,12 @@ dump_global_data(data_t * data)
 				    , data->email_from);
 		dump_list(data->email);
 	}
+	if (data->lvs_syncd_vrrp)
+		log_message(LOG_INFO, " LVS syncd vrrp instance = %s"
+				    , data->lvs_syncd_vrrp->iname);
+	if (data->lvs_syncd_if)
+		log_message(LOG_INFO, " LVS syncd interface = %s"
+				    , data->lvs_syncd_if);
 	if (data->vrrp_mcast_group4.ss_family) {
 		log_message(LOG_INFO, " VRRP IPv4 mcast group = %s"
 				    , inet_sockaddrtos(&data->vrrp_mcast_group4));

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -95,6 +95,26 @@ email_handler(vector_t *strvec)
 	free_strvec(email_vec);
 }
 static void
+lvs_syncd_handler(vector_t *strvec)
+{
+	if (global_data->lvs_syncd_if) {
+		log_message(LOG_INFO, "lvs_sync_daemon has already been specified as %s %s - ignoring", global_data->lvs_syncd_if, global_data->lvs_syncd_vrrp_name);
+		return;
+	}
+
+	if (vector_size(strvec) != 3) {
+		log_message(LOG_INFO, "lvs_sync_daemon requires interface and VRRP instance");
+		return;
+	}
+
+	global_data->lvs_syncd_if = set_value(strvec);
+
+	global_data->lvs_syncd_vrrp_name = MALLOC(strlen(vector_slot(strvec, 2)) + 1);
+	if (!global_data->lvs_syncd_vrrp_name)
+		return;
+	strcpy(global_data->lvs_syncd_vrrp_name, vector_slot(strvec, 2));
+}
+static void
 vrrp_mcast_group4_handler(vector_t *strvec)
 {
 	struct sockaddr_storage *mcast = &global_data->vrrp_mcast_group4;
@@ -365,6 +385,7 @@ global_init_keywords(void)
 	install_keyword("smtp_helo_name", &smtphelo_handler);
 	install_keyword("smtp_connect_timeout", &smtpto_handler);
 	install_keyword("notification_email", &email_handler);
+	install_keyword("lvs_sync_daemon", &lvs_syncd_handler);
 	install_keyword("vrrp_mcast_group4", &vrrp_mcast_group4_handler);
 	install_keyword("vrrp_mcast_group6", &vrrp_mcast_group6_handler);
 	install_keyword("vrrp_garp_master_delay", &vrrp_garp_delay_handler);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -97,13 +97,15 @@ email_handler(vector_t *strvec)
 static void
 lvs_syncd_handler(vector_t *strvec)
 {
+	int syncid;
+
 	if (global_data->lvs_syncd_if) {
 		log_message(LOG_INFO, "lvs_sync_daemon has already been specified as %s %s - ignoring", global_data->lvs_syncd_if, global_data->lvs_syncd_vrrp_name);
 		return;
 	}
 
-	if (vector_size(strvec) != 3) {
-		log_message(LOG_INFO, "lvs_sync_daemon requires interface and VRRP instance");
+	if (vector_size(strvec) < 3 || vector_size(strvec) > 4) {
+		log_message(LOG_INFO, "lvs_sync_daemon requires interface, VRRP instance and optional syncid");
 		return;
 	}
 
@@ -113,6 +115,13 @@ lvs_syncd_handler(vector_t *strvec)
 	if (!global_data->lvs_syncd_vrrp_name)
 		return;
 	strcpy(global_data->lvs_syncd_vrrp_name, vector_slot(strvec, 2));
+	if (vector_size(strvec) >= 4) {
+		syncid = atoi(vector_slot(strvec,3));
+		if (syncid < 0 || syncid > 255)
+			log_message(LOG_INFO, "Invalid syncid - defaulting to vrid");
+		else
+			global_data->lvs_syncd_syncid = syncid;
+	}
 }
 static void
 vrrp_mcast_group4_handler(vector_t *strvec)

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -43,6 +43,7 @@
 /* local includes */
 #include "list.h"
 #include "timer.h"
+#include "vrrp.h"
 
 /* constants */
 #define DEFAULT_SMTP_SERVER 0x7f000001
@@ -64,11 +65,15 @@ typedef struct _data {
 	list				email;
 	struct sockaddr_storage		vrrp_mcast_group4;
 	struct sockaddr_storage		vrrp_mcast_group6;
+	char				*lvs_syncd_if;	  /* handle LVS sync daemon state using this */
+	vrrp_t				*lvs_syncd_vrrp;  /* instance FSM & running on specific interface
+							   * => eth0 for example. */
+	char				*lvs_syncd_vrrp_name; /* Only used during configuration */
 	int				vrrp_garp_delay;
 	timeval_t			vrrp_garp_refresh;
 	int				vrrp_garp_rep;
 	int				vrrp_garp_refresh_rep;
-	int				vrrp_version;            /* VRRP version (2 or 3) */
+	int				vrrp_version;	/* VRRP version (2 or 3) */
 	char				vrrp_iptables_inchain[XT_EXTENSION_MAXNAMELEN];
 	char				vrrp_iptables_outchain[XT_EXTENSION_MAXNAMELEN];
 	int				block_ipv4;

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -65,9 +65,9 @@ typedef struct _data {
 	list				email;
 	struct sockaddr_storage		vrrp_mcast_group4;
 	struct sockaddr_storage		vrrp_mcast_group6;
-	char				*lvs_syncd_if;	  /* handle LVS sync daemon state using this */
-	vrrp_t				*lvs_syncd_vrrp;  /* instance FSM & running on specific interface
-							   * => eth0 for example. */
+	char				*lvs_syncd_if;		/* handle LVS sync daemon state using this */
+	vrrp_t				*lvs_syncd_vrrp;	/* instance FSM & running on specific interface */
+	int				lvs_syncd_syncid;	/* => eth0 for example. */
 	char				*lvs_syncd_vrrp_name; /* Only used during configuration */
 	int				vrrp_garp_delay;
 	timeval_t			vrrp_garp_refresh;

--- a/keepalived/include/ipvswrapper.h
+++ b/keepalived/include/ipvswrapper.h
@@ -30,6 +30,7 @@
 #include <sys/param.h>
 #include <arpa/inet.h>
 #include <asm/types.h>
+#include <stdbool.h>
 
 #include <net/if.h>
 #include <netinet/ip_icmp.h>
@@ -63,6 +64,7 @@
 #ifdef _HAVE_IPVS_SYNCD_
 #define IPVS_STARTDAEMON	IP_VS_SO_SET_STARTDAEMON
 #define IPVS_STOPDAEMON		IP_VS_SO_SET_STOPDAEMON
+#define IPVS_FLUSH		IP_VS_SO_SET_FLUSH
 #define IPVS_MASTER		IP_VS_STATE_MASTER
 #define IPVS_BACKUP		IP_VS_STATE_BACKUP
 #else
@@ -70,6 +72,7 @@
 #define IPVS_STOPDAEMON		2
 #define IPVS_MASTER		3
 #define IPVS_BACKUP		4
+#define IPVS_FLUSH		5
 #endif
 
 /* Macro */
@@ -91,11 +94,12 @@ do {						\
 /* prototypes */
 extern int ipvs_start(void);
 extern void ipvs_stop(void);
+extern void ipvs_flush_cmd(void);
 extern virtual_server_group_t *ipvs_get_group_by_name(char *, list);
 extern void ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge);
 extern void ipvs_group_remove_entry(virtual_server_t *, virtual_server_group_entry_t *);
 extern int ipvs_cmd(int, virtual_server_t *, real_server_t *);
-extern void ipvs_syncd_cmd(int, char *, int, int);
+extern void ipvs_syncd_cmd(int, char *, int, int, bool);
 extern void ipvs_syncd_master(char *, int);
 extern void ipvs_syncd_backup(char *, int);
 

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -165,10 +165,6 @@ typedef struct _vrrp_t {
 	struct sockaddr_storage master_saddr;		/* Store last heard Master address */
 	uint8_t			master_priority;	/* Store last heard priority */
 	timeval_t		last_transition;	/* Store transition time */
-	char			*lvs_syncd_if;		/* handle LVS sync daemon state using this
-							 * instance FSM & running on specific interface
-							 * => eth0 for example.
-							 */
 	int			garp_delay;		/* Delay to launch gratuitous ARP */
 	timeval_t		garp_refresh;		/* Next scheduled gratuitous ARP refresh */
 	timeval_t		garp_refresh_timer;	/* Next scheduled gratuitous ARP timer */

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2232,15 +2232,13 @@ clear_diff_vrrp_vip_list(vrrp_t *vrrp, struct ipt_handle* h, list l, list n)
 }
 
 static void
-clear_diff_vrrp_vip(vrrp_t * old_vrrp, int type)
+clear_diff_vrrp_vip(vrrp_t *old_vrrp, vrrp_t *vrrp)
 {
 #ifdef _HAVE_LIBIPTC_
 	int tries = 0;
 	int res = 0;
 #endif
 	struct ipt_handle *h = NULL;
-
-	vrrp_t *vrrp = vrrp_exist(old_vrrp);
 
 	if (!old_vrrp->iptable_rules_set)
 		return;
@@ -2259,26 +2257,23 @@ clear_diff_vrrp_vip(vrrp_t * old_vrrp, int type)
 
 /* Clear virtual routes not present in the new data */
 static void
-clear_diff_vrrp_vroutes(vrrp_t * old_vrrp)
+clear_diff_vrrp_vroutes(vrrp_t *old_vrrp, vrrp_t *vrrp)
 {
-	vrrp_t *vrrp = vrrp_exist(old_vrrp);
 	clear_diff_routes(old_vrrp->vroutes, vrrp->vroutes);
 }
 
 /* Clear virtual rules not present in the new data */
 static void
-clear_diff_vrrp_vrules(vrrp_t * old_vrrp)
+clear_diff_vrrp_vrules(vrrp_t *old_vrrp, vrrp_t *vrrp)
 {
-	vrrp_t *vrrp = vrrp_exist(old_vrrp);
 	clear_diff_rules(old_vrrp->vrules, vrrp->vrules);
 }
 
 /* Keep the state from before reload */
 static void
-reset_vrrp_state(vrrp_t * old_vrrp)
+reset_vrrp_state(vrrp_t *old_vrrp, vrrp_t *vrrp)
 {
 	/* Keep VRRP state, ipsec AH seq_number */
-	vrrp_t *vrrp = vrrp_exist(old_vrrp);
 	vrrp->state = old_vrrp->state;
 	vrrp->init_state = old_vrrp->state;
 	vrrp->wantstate = old_vrrp->state;
@@ -2335,14 +2330,13 @@ clear_diff_vrrp(void)
 			 * If this vrrp instance exist in new
 			 * data, then perform a VIP|EVIP diff.
 			 */
-			clear_diff_vrrp_vip(vrrp, VRRP_VIP_TYPE);
-			clear_diff_vrrp_vip(vrrp, VRRP_EVIP_TYPE);
+			clear_diff_vrrp_vip(vrrp, new_vrrp);
 
 			/* virtual routes diff */
-			clear_diff_vrrp_vroutes(vrrp);
+			clear_diff_vrrp_vroutes(vrrp, new_vrrp);
 
 			/* virtual rules diff */
-			clear_diff_vrrp_vrules(vrrp);
+			clear_diff_vrrp_vrules(vrrp, new_vrrp);
 
 			/*
 			 * Remove VMAC if it existed in old vrrp instance,
@@ -2354,7 +2348,7 @@ clear_diff_vrrp(void)
 			}
 
 			/* reset the state */
-			reset_vrrp_state(vrrp);
+			reset_vrrp_state(vrrp, new_vrrp);
 		}
 	}
 }

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1748,7 +1748,7 @@ shutdown_vrrp_instances(void)
 			ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL,
 				       (vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:
 									  IPVS_BACKUP,
-				       vrrp->vrid);
+				       vrrp->vrid, false);
 #endif
 	}
 }

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -175,6 +175,14 @@ start_vrrp(void)
 			stop_vrrp();
 			return;
 		}
+
+#ifdef _HAVE_IPVS_SYNCD_
+		/* If we are managing the sync daemon, then stop any
+		 * instances of it that may have been running if
+		 * we terminated abnormally */
+		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_MASTER, 0);
+		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_BACKUP, 0);
+#endif
 	}
 #endif
 

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -309,7 +309,7 @@ reload_vrrp_thread(thread_t * thread)
 		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL,
 		       (global_data->lvs_syncd_vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:
 										 IPVS_BACKUP,
-		       global_data->lvs_syncd_vrrp->vrid, false);
+		       global_data->lvs_syncd_syncid, false);
 #endif
 	free_global_data(global_data);
 	free_interface_queue();
@@ -339,7 +339,7 @@ reload_vrrp_thread(thread_t * thread)
 		ipvs_syncd_cmd(IPVS_STARTDAEMON, NULL,
 			       (global_data->lvs_syncd_vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:
 											 IPVS_BACKUP,
-			       global_data->lvs_syncd_vrrp->vrid, false);
+			       global_data->lvs_syncd_syncid, false);
 #endif
 
 	/* free backup data */

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -180,8 +180,8 @@ start_vrrp(void)
 		/* If we are managing the sync daemon, then stop any
 		 * instances of it that may have been running if
 		 * we terminated abnormally */
-		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_MASTER, 0);
-		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_BACKUP, 0);
+		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_MASTER, 0, true);
+		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_BACKUP, 0, true);
 #endif
 	}
 #endif
@@ -309,7 +309,7 @@ reload_vrrp_thread(thread_t * thread)
 		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL,
 		       (global_data->lvs_syncd_vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:
 										 IPVS_BACKUP,
-		       global_data->lvs_syncd_vrrp->vrid);
+		       global_data->lvs_syncd_vrrp->vrid, false);
 #endif
 	free_global_data(global_data);
 	free_interface_queue();
@@ -339,7 +339,7 @@ reload_vrrp_thread(thread_t * thread)
 		ipvs_syncd_cmd(IPVS_STARTDAEMON, NULL,
 			       (global_data->lvs_syncd_vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:
 											 IPVS_BACKUP,
-			       global_data->lvs_syncd_vrrp->vrid);
+			       global_data->lvs_syncd_vrrp->vrid, false);
 #endif
 
 	/* free backup data */

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -295,6 +295,14 @@ reload_vrrp_thread(thread_t * thread)
 	kernel_netlink_close();
 	thread_destroy_master(master);
 	master = thread_make_master();
+#ifdef _HAVE_IPVS_SYNCD_
+	/* TODO - Note: this didn't work if we found ipvs_syndc on vrrp before on old_vrrp */
+	if (global_data->lvs_syncd_if)
+		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL,
+		       (global_data->lvs_syncd_vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:
+										 IPVS_BACKUP,
+		       global_data->lvs_syncd_vrrp->vrid);
+#endif
 	free_global_data(global_data);
 	free_interface_queue();
 	free_vrrp_buffer();
@@ -317,6 +325,14 @@ reload_vrrp_thread(thread_t * thread)
 	mem_allocated = 0;
 #endif
 	start_vrrp();
+
+#ifdef _HAVE_IPVS_SYNCD_
+	if (global_data->lvs_syncd_if)
+		ipvs_syncd_cmd(IPVS_STARTDAEMON, NULL,
+			       (global_data->lvs_syncd_vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:
+											 IPVS_BACKUP,
+			       global_data->lvs_syncd_vrrp->vrid);
+#endif
 
 	/* free backup data */
 	free_vrrp_data(old_vrrp_data);

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -198,7 +198,6 @@ free_vrrp(void *data)
 
 	FREE(vrrp->iname);
 	FREE_PTR(vrrp->send_buffer);
-	FREE_PTR(vrrp->lvs_syncd_if);
 	FREE_PTR(vrrp->script_backup);
 	FREE_PTR(vrrp->script_master);
 	FREE_PTR(vrrp->script_fault);
@@ -250,9 +249,6 @@ dump_vrrp(void *data)
 	if (vrrp->saddr.ss_family)
 		log_message(LOG_INFO, "   Using src_ip = %s"
 				    , inet_sockaddrtos(&vrrp->saddr));
-	if (vrrp->lvs_syncd_if)
-		log_message(LOG_INFO, "   Running LVS sync daemon on interface = %s",
-		       vrrp->lvs_syncd_if);
 	if (vrrp->garp_delay)
 		log_message(LOG_INFO, "   Gratuitous ARP delay = %d",
 		       vrrp->garp_delay/TIMER_HZ);

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -825,10 +825,9 @@ netlink_reflect_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 			status = netlink_if_link_populate(ifp, tb, ifi);
 			if (status < 0)
 				return -1;
-
-			} else {
-				if (__test_bit(LOG_DETAIL_BIT, &debug))
-					log_message(LOG_INFO, "Unknown interface %s deleted", (char *)tb[IFLA_IFNAME]);
+		} else {
+			if (__test_bit(LOG_DETAIL_BIT, &debug))
+				log_message(LOG_INFO, "Unknown interface %s deleted", (char *)tb[IFLA_IFNAME]);
 			return 0;
 		}
 	}

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -465,7 +465,17 @@ static void
 vrrp_lvs_syncd_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
-	vrrp->lvs_syncd_if = set_value(strvec);
+
+	log_message(LOG_INFO, "(%s): Specifying lvs_sync_daemon_interface against a vrrp is deprecated.", vrrp->iname);  /* Deprecated after v1.2.19 */
+	log_message(LOG_INFO, "      %*sPlease use global lvs_sync_daemon_interface and lvs_sync_daemon_vrrp", (int)strlen(vrrp->iname) - 2, "");
+
+	if (global_data->lvs_syncd_if) {
+		log_message(LOG_INFO, "(%s): lvs_sync_daemon_interface has already been specified as %s - ignoring", vrrp->iname, global_data->lvs_syncd_if);
+		return;
+	}
+
+	global_data->lvs_syncd_if = set_value(strvec);
+	global_data->lvs_syncd_vrrp = vrrp;
 }
 static void
 vrrp_garp_delay_handler(vector_t *strvec)

--- a/keepalived/vrrp/vrrp_print.c
+++ b/keepalived/vrrp/vrrp_print.c
@@ -141,9 +141,6 @@ vrrp_print(FILE *file, void *data)
 	if (vrrp->strict_mode)
 		fprintf(file, "   Enforcing VRRP compliance\n");
 	fprintf(file, "   Using src_ip = %s\n", inet_sockaddrtos(&vrrp->saddr));
-	if (vrrp->lvs_syncd_if)
-		fprintf(file, "   Runing LVS sync daemon on interface = %s\n",
-		       vrrp->lvs_syncd_if);
 	if (vrrp->garp_delay)
 		fprintf(file, "   Gratuitous ARP delay = %d\n",
 		       vrrp->garp_delay/TIMER_HZ);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -235,10 +235,11 @@ vrrp_init_state(list l)
 			|| vrrp->wantstate == VRRP_STATE_GOTO_MASTER) {
 #ifdef _HAVE_IPVS_SYNCD_
 			/* Check if sync daemon handling is needed */
-			if (vrrp->lvs_syncd_if)
+			if (global_data->lvs_syncd_if)
 				ipvs_syncd_cmd(IPVS_STARTDAEMON,
-					       vrrp->lvs_syncd_if, IPVS_MASTER,
-					       vrrp->vrid);
+					       global_data->lvs_syncd_if,
+					       IPVS_MASTER,
+					       global_data->lvs_syncd_vrrp->vrid);
 #endif
 #ifdef _WITH_SNMP_RFCV3_
 			vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PREEMPTED;
@@ -249,10 +250,12 @@ vrrp_init_state(list l)
 			    + VRRP_TIMER_SKEW(vrrp);
 #ifdef _HAVE_IPVS_SYNCD_
 			/* Check if sync daemon handling is needed */
-			if (vrrp->lvs_syncd_if)
+			if (global_data->lvs_syncd_if &&
+			    global_data->lvs_syncd_vrrp == vrrp)
 				ipvs_syncd_cmd(IPVS_STARTDAEMON,
-					       vrrp->lvs_syncd_if, IPVS_BACKUP,
-					       vrrp->vrid);
+					       global_data->lvs_syncd_if,
+					       IPVS_BACKUP,
+					       global_data->lvs_syncd_vrrp->vrid);
 #endif
 			log_message(LOG_INFO, "VRRP_Instance(%s) Entering BACKUP STATE",
 			       vrrp->iname);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -239,7 +239,7 @@ vrrp_init_state(list l)
 				ipvs_syncd_cmd(IPVS_STARTDAEMON,
 					       global_data->lvs_syncd_if,
 					       IPVS_MASTER,
-					       global_data->lvs_syncd_vrrp->vrid);
+					       global_data->lvs_syncd_vrrp->vrid, false);
 #endif
 #ifdef _WITH_SNMP_RFCV3_
 			vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PREEMPTED;
@@ -255,7 +255,7 @@ vrrp_init_state(list l)
 				ipvs_syncd_cmd(IPVS_STARTDAEMON,
 					       global_data->lvs_syncd_if,
 					       IPVS_BACKUP,
-					       global_data->lvs_syncd_vrrp->vrid);
+					       global_data->lvs_syncd_vrrp->vrid, false);
 #endif
 			log_message(LOG_INFO, "VRRP_Instance(%s) Entering BACKUP STATE",
 			       vrrp->iname);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -239,7 +239,8 @@ vrrp_init_state(list l)
 				ipvs_syncd_cmd(IPVS_STARTDAEMON,
 					       global_data->lvs_syncd_if,
 					       IPVS_MASTER,
-					       global_data->lvs_syncd_vrrp->vrid, false);
+					       global_data->lvs_syncd_syncid,
+					       false);
 #endif
 #ifdef _WITH_SNMP_RFCV3_
 			vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PREEMPTED;
@@ -255,7 +256,8 @@ vrrp_init_state(list l)
 				ipvs_syncd_cmd(IPVS_STARTDAEMON,
 					       global_data->lvs_syncd_if,
 					       IPVS_BACKUP,
-					       global_data->lvs_syncd_vrrp->vrid, false);
+					       global_data->lvs_syncd_syncid,
+					       false);
 #endif
 			log_message(LOG_INFO, "VRRP_Instance(%s) Entering BACKUP STATE",
 			       vrrp->iname);

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -1118,12 +1118,12 @@ vrrp_snmp_instance(struct variable *vp, oid *name, size_t *length,
 		return (u_char *)&long_ret;
 
 	case VRRP_SNMP_INSTANCE_USELVSSYNCDAEMON:
-		long_ret = (rt->lvs_syncd_if)?1:2;
+		long_ret = (global_data->lvs_syncd_vrrp == rt)?1:2;
 		return (u_char *)&long_ret;
 	case VRRP_SNMP_INSTANCE_LVSSYNCINTERFACE:
-		if (rt->lvs_syncd_if) {
-			*var_len = strlen(rt->lvs_syncd_if);
-			return (u_char *)rt->lvs_syncd_if;
+		if (global_data->lvs_syncd_vrrp == rt) {
+			*var_len = strlen(global_data->lvs_syncd_if);
+			return (u_char *)global_data->lvs_syncd_if;
 		}
 		break;
 	case VRRP_SNMP_INSTANCE_SYNCGROUP:

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -436,6 +436,9 @@ set_value(vector_t *strvec)
 	char *alloc;
 
 	alloc = (char *) MALLOC(size + 1);
+	if (!alloc)
+		return NULL;
+
 	memcpy(alloc, str, size);
 
 	return alloc;


### PR DESCRIPTION
The main change is to change the lvs_syncd configuration to be global rather than against a vrrp instance, due to confusion that has existed regarding configuring lvs_sync_daemon_if on multiple vrrp instances. Configuration against vrrp instances is still supported but logged as deprecated.

This should satisfy the request for clarification re configuring lvs_sync_daemon in issue #237.

Restarting following an abnormal termination of keepalived now tidies up any residue ipvs and lvs syncd configuration, and also the syncid can be configured but defaults to the vrid as before.

