### PR TITLE
Allow sending second set off gratuitous ARP messages after receiving lower priority advert

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -10,6 +10,10 @@ file is compounded by three configurations parts :
 There is 2 valid comment valid string : # or ! If you want to add comment
 in you configuration file use this char.
 
+0.1. Parameter syntax
+
+<BOOL> is one of on|off|true|false|yes|no
+
 1. Globals configurations
 
 This block is divided in 2 sub-block :
@@ -44,12 +48,19 @@ global_defs {				# Block identification
 					   #  messages after MASTER state transition, default 5
     vrrp_garp_master_repeat <INTEGER>	   # how many gratuitous ARP messages after MASTER
 					   #  state transition should be sent, default 5
+    vrrp_garp_lower_prio_delay <INTEGER>   # delay for second set of gratuitous ARPs after lower
+					   #  priority advert received when MASTER
+    vrrp_garp_lower_prio_repeat <INTEGER>  # number of gratuitous ARP messages to send at a time
+					   #  after lower priority advert received when MASTER
     vrrp_garp_master_refresh <INTEGER>	   # Periodic delay in seconds sending
 					   #  gratuitous ARP while in MASTER state
 					   #  Default: 0 (no refreshing)
     vrrp_garp_master_refresh_repeat <INTEGER> # how many gratuitous ARP messages shoule be sent
 					   #  at each periodic repeat
 					   #  Default: once (per period)
+    vrrp_lower_prio_no_advert [<BOOL>]     # If a lower priority advert is received, just discard
+					   # it and don't send another advert. This causes adherence
+					   # to the RFCs.
     vrrp_version <INTEGER:2..3>            # Default VRRP version (default 2)
     vrrp_iptables [keepalived_in [keepalived_out]]     # default INPUT
 					   # Specifies the iptables chains to add entries to
@@ -60,6 +71,8 @@ global_defs {				# Block identification
 					   #   0 VIPs
 					   #   unicast peers
 					   #   IPv6 addresses in VRRP version 2
+					   # Sets:
+					   #   vrrp_lower_priority_dont_send_advert
 					   # The following 4 options can be used if vrrp or checker processes
 					   #   are timing out. This can be seen by a backup vrrp instance becoming
 					   #   master even when the master is still running, due to the master or
@@ -222,16 +235,23 @@ vrrp_instance <STRING> {		# VRRP instance declaration
       ...				#  in unicast design fashion
     }
 
-    # The following garp parameters take their defaults from the global config for vrrp_garp_master_...
+    # The following garp parameters take their defaults from the global config for vrrp_garp_...
     # See their descriptions for the meaning of the parameters.
     garp_master_delay <INTEGER>
     garp_master_repeat <INTEGER>
+    garp_lower_priority_delay <INTEGER>
+    garp_lower_priority_repeat <INTEGER>
     garp_master_refresh <INTEGER>
     garp_master_refresh_repeat <INTEGER>
 
     virtual_router_id <INTEGER-0..255>	# VRRP VRID
     priority <INTEGER-0..255>		# VRRP PRIO
     advert_int <INTEGER>		# VRRP Advert interval (use default)
+
+    lower_prio_no_advert		# If a lower priority advert is received, don't
+					# don't send another advert. This causes adherence
+					# to the RFCs (defaults to global
+					# vrrp_lower_priority_dont_send_advert).
 
     # Note: authentication was removed from the VRRPv2 specification by RFC3768 in 2004.
     #   Use of this option is non-compliant and can cause problems; avoid using if possible,
@@ -264,9 +284,9 @@ vrrp_instance <STRING> {		# VRRP instance declaration
     nopreempt					# Override VRRP RFC preemption default
     preempt_delay				# Seconds after startup until
 						#  preemption. 0 (default) to 1,000
-    strict_mode [on|off|true|false|yes|no]      # See description of global vrrp_strict
-					        # If vrrp_strict is not specified, it takes the value of vrrp_strict
-					        # If strict_mode without a parameter is specified, it defaults to on
+    strict_mode [<BOOL]				# See description of global vrrp_strict
+						# If vrrp_strict is not specified, it takes the value of vrrp_strict
+						# If strict_mode without a parameter is specified, it defaults to on
     debug					# Debug level
     notify_master <STRING>|<QUOTED-STRING>	# Same as vrrp_sync_group
     notify_backup <STRING>|<QUOTED-STRING>	# Same as vrrp_sync_group
@@ -506,4 +526,3 @@ virtual_server group <STRING>      {	# VS group declaration
         }
     }
 }
-

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -14,6 +14,9 @@ anywhere in a line.
 .PP
 Keyword 'include' allows inclusion of other configuration files from within
 the main configuration file.
+.SH PARAMETER SYNTAX
+.B <BOOL>
+is one of on|off|true|false|yes|no
 .SH TOP HIERACHY
 .PP
 .B GLOBAL CONFIGURATION
@@ -71,6 +74,10 @@ and
 
  # number of gratuitous ARP messages to send at a time while MASTER
  vrrp_garp_master_refresh_repeat 2 # default 1
+
+ # If a lower priority advert is received, don't don't send another advert. This causes
+ # adherence to the RFCs (defaults to global vrrp_lower_priority_no_advert).
+ vrrp_lower_prio_no_advert [<BOOL>]
 
  # Set the default VRRP version to use
  vrrp_version <2 or 3>        # default version 2
@@ -305,6 +312,7 @@ which will transition together on any state change.
     garp_lower_prio_repeat 1
     garp_master_refresh 60
     garp_master_refresh_repeat 2
+    lower_prio_no_advert [<BOOL>]
 
     # arbitrary unique number 0..255
     # used to differentiate multiple instances of vrrpd

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -60,6 +60,12 @@ and
  # number of gratuitous ARP messages to send at a time after transition to MASTER
  vrrp_garp_master_repeat 1    # default 5
 
+ # delay for second set of gratuitous ARPs after lower priority advert received when MASTER
+ vrrp_garp_lower_prio_delay 10
+
+ # number of gratuitous ARP messages to send at a time after lower priority advert received when MASTER
+ vrrp_garp_lower_prio_repeat 1
+
  # minimum time interval for refreshing gratuitous ARPs while MASTER
  vrrp_garp_master_refresh 60  # secs, default 0 (no refreshing)
 
@@ -295,6 +301,8 @@ which will transition together on any state change.
     # interface specific settings, same as global parameters; default to global parameters
     garp_master_delay 10
     garp_master_repeat 1
+    garp_lower_prio_delay 10
+    garp_lower_prio_repeat 1
     garp_master_refresh 60
     garp_master_refresh_repeat 2
 

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -86,6 +86,9 @@ set_vrrp_defaults(data_t * data)
 	data->vrrp_garp_rep = VRRP_GARP_REP;
 	data->vrrp_garp_refresh_rep = VRRP_GARP_REFRESH_REP;
 	data->vrrp_garp_delay = VRRP_GARP_DELAY;
+	data->vrrp_garp_lower_prio_delay = -1;
+	data->vrrp_garp_lower_prio_rep = -1;
+	data->vrrp_lower_prio_no_advert = false;
 	data->vrrp_version = VRRP_VERSION_2;
 	strcpy(data->vrrp_iptables_inchain, "INPUT");
 	data->block_ipv4 = 0;
@@ -96,9 +99,9 @@ set_vrrp_defaults(data_t * data)
 	strcpy(data->vrrp_ipset_address6, "keepalived6");
 	strcpy(data->vrrp_ipset_address_iface6, "keepalived_if6");
 #endif
-	data->vrrp_check_unicast_src = 0;
-	data->vrrp_skip_check_adv_addr = 0;
-	data->vrrp_strict = 0;
+	data->vrrp_check_unicast_src = false;
+	data->vrrp_skip_check_adv_addr = false;
+	data->vrrp_strict = false;
 }
 
 /* email facility functions */
@@ -251,14 +254,15 @@ dump_global_data(data_t * data)
 		log_message(LOG_INFO, " VRRP IPv6 mcast group = %s"
 				    , inet_sockaddrtos(&data->vrrp_mcast_group6));
 	}
-	if (data->vrrp_garp_delay)
-		log_message(LOG_INFO, " Gratuitous ARP delay = %d",
+	log_message(LOG_INFO, " Gratuitous ARP delay = %d",
 		       data->vrrp_garp_delay/TIMER_HZ);
-	if (!timer_isnull(data->vrrp_garp_refresh))
-		log_message(LOG_INFO, " Gratuitous ARP refresh timer = %lu",
-		       data->vrrp_garp_refresh.tv_sec);
 	log_message(LOG_INFO, " Gratuitous ARP repeat = %d", data->vrrp_garp_rep);
+	log_message(LOG_INFO, " Gratuitous ARP refresh timer = %lu",
+		       data->vrrp_garp_refresh.tv_sec);
 	log_message(LOG_INFO, " Gratuitous ARP refresh repeat = %d", data->vrrp_garp_refresh_rep);
+	log_message(LOG_INFO, " Gratuitous ARP lower priority delay = %d", data->vrrp_garp_lower_prio_delay / TIMER_HZ);
+	log_message(LOG_INFO, " Gratuitous ARP lower priority repeat = %d", data->vrrp_garp_lower_prio_rep);
+	log_message(LOG_INFO, " Send advert after receive lower priority advert = %s", data->vrrp_lower_prio_no_advert ? "false" : "true");
 	log_message(LOG_INFO, " VRRP default protocol version = %d", data->vrrp_version);
 	if (data->vrrp_iptables_inchain[0])
 		log_message(LOG_INFO," Iptables input chain = %s", data->vrrp_iptables_inchain);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -153,23 +153,51 @@ vrrp_garp_delay_handler(vector_t *strvec)
 	global_data->vrrp_garp_delay = atoi(vector_slot(strvec, 1)) * TIMER_HZ;
 }
 static void
+vrrp_garp_rep_handler(vector_t *strvec)
+{
+	global_data->vrrp_garp_rep = atoi(vector_slot(strvec, 1));
+	if (global_data->vrrp_garp_rep < 1)
+		global_data->vrrp_garp_rep = 1;
+}
+static void
 vrrp_garp_refresh_handler(vector_t *strvec)
 {
 	global_data->vrrp_garp_refresh.tv_sec = atoi(vector_slot(strvec, 1));
 }
 static void
-vrrp_garp_rep_handler(vector_t *strvec)
-{
-	global_data->vrrp_garp_rep = atoi(vector_slot(strvec, 1));
-	if ( global_data->vrrp_garp_rep < 1 )
-		global_data->vrrp_garp_rep = 1;
-}
-static void
 vrrp_garp_refresh_rep_handler(vector_t *strvec)
 {
 	global_data->vrrp_garp_refresh_rep = atoi(vector_slot(strvec, 1));
-	if ( global_data->vrrp_garp_refresh_rep < 1 )
+	if (global_data->vrrp_garp_refresh_rep < 1)
 		global_data->vrrp_garp_refresh_rep = 1;
+}
+static void
+vrrp_garp_lower_prio_delay_handler(vector_t *strvec)
+{
+	global_data->vrrp_garp_lower_prio_delay = atoi(vector_slot(strvec, 1)) * TIMER_HZ;
+}
+static void
+vrrp_garp_lower_prio_rep_handler(vector_t *strvec)
+{
+	global_data->vrrp_garp_lower_prio_rep = atoi(vector_slot(strvec, 1));
+	/* Allow 0 GARP messages to be sent */
+	if (global_data->vrrp_garp_lower_prio_rep < 0)
+		global_data->vrrp_garp_lower_prio_rep = 0;
+}
+static void
+vrrp_lower_prio_no_advert_handler(vector_t *strvec)
+{
+	int res;
+
+	if (vector_size(strvec) >= 2) {
+		res = check_true_false(vector_slot(strvec,1));
+		if (res < 0)
+			log_message(LOG_INFO, "Invalid value for vrrp_lower_prio_no_advert specified");
+		else
+			global_data->vrrp_lower_prio_no_advert = res;
+	}
+	else
+		global_data->vrrp_lower_prio_no_advert = true;
 }
 static void
 vrrp_iptables_handler(vector_t *strvec)
@@ -401,6 +429,9 @@ global_init_keywords(void)
 	install_keyword("vrrp_garp_master_repeat", &vrrp_garp_rep_handler);
 	install_keyword("vrrp_garp_master_refresh", &vrrp_garp_refresh_handler);
 	install_keyword("vrrp_garp_master_refresh_repeat", &vrrp_garp_refresh_rep_handler);
+	install_keyword("vrrp_garp_lower_prio_delay", &vrrp_garp_lower_prio_delay_handler);
+	install_keyword("vrrp_garp_lower_prio_repeat", &vrrp_garp_lower_prio_rep_handler);
+	install_keyword("vrrp_lower_prio_no_advert", &vrrp_lower_prio_no_advert_handler);
 	install_keyword("vrrp_version", &vrrp_version_handler);
 	install_keyword("vrrp_iptables", &vrrp_iptables_handler);
 #ifdef _HAVE_LIBIPSET_

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -340,6 +340,8 @@ parse_cmdline(int argc, char **argv)
 int
 main(int argc, char **argv)
 {
+	int report_stopped = true;
+
 	/* Init debugging level */
 	debug = 0;
 
@@ -364,6 +366,7 @@ main(int argc, char **argv)
 	/* Check if keepalived is already running */
 	if (keepalived_running(daemon_mode)) {
 		log_message(LOG_INFO, "daemon is already running");
+		report_stopped = false;
 		goto end;
 	}
 
@@ -402,11 +405,13 @@ main(int argc, char **argv)
 	 * finally return from system
 	 */
 end:
+	if (report_stopped) {
 #ifdef GIT_COMMIT
-	log_message(LOG_INFO, "Stopped %s, git commit %s", VERSION_STRING, GIT_COMMIT);
+		log_message(LOG_INFO, "Stopped %s, git commit %s", VERSION_STRING, GIT_COMMIT);
 #else
-	log_message(LOG_INFO, "Stopped %s", VERSION_STRING);
+		log_message(LOG_INFO, "Stopped %s", VERSION_STRING);
 #endif
+	}
 
 	closelog();
 	exit(0);

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -73,6 +73,9 @@ typedef struct _data {
 	timeval_t			vrrp_garp_refresh;
 	int				vrrp_garp_rep;
 	int				vrrp_garp_refresh_rep;
+	int				vrrp_garp_lower_prio_delay;
+	int				vrrp_garp_lower_prio_rep;
+	bool				vrrp_lower_prio_no_advert;
 	int				vrrp_version;	/* VRRP version (2 or 3) */
 	char				vrrp_iptables_inchain[XT_EXTENSION_MAXNAMELEN];
 	char				vrrp_iptables_outchain[XT_EXTENSION_MAXNAMELEN];
@@ -84,9 +87,9 @@ typedef struct _data {
 	char				vrrp_ipset_address6[IPSET_MAXNAMELEN];
 	char				vrrp_ipset_address_iface6[IPSET_MAXNAMELEN];
 #endif
-	char				vrrp_check_unicast_src;
-	char				vrrp_skip_check_adv_addr;
-	char				vrrp_strict;
+	bool				vrrp_check_unicast_src;
+	bool				vrrp_skip_check_adv_addr;
+	bool				vrrp_strict;
 	char				vrrp_process_priority;
 	char				checker_process_priority;
 	bool				vrrp_no_swap;

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -170,6 +170,10 @@ typedef struct _vrrp_t {
 	timeval_t		garp_refresh_timer;	/* Next scheduled gratuitous ARP timer */
 	int			garp_rep;		/* gratuitous ARP repeat value */
 	int			garp_refresh_rep;	/* refresh gratuitous ARP repeat value */
+        int			garp_lower_prio_delay;	/* Delay to second set or ARP messages */
+        int			garp_lower_prio_rep;	/* Number of ARP messages to send at a time */
+        int			lower_prio_no_advert;	/* Don't send advert after lower prio
+							 * advert received */
 	int			vrid;			/* virtual id. from 1(!) to 255 */
 	int			base_priority;		/* configured priority value */
 	int			effective_priority;	/* effective priority value */

--- a/keepalived/include/vrrp_scheduler.h
+++ b/keepalived/include/vrrp_scheduler.h
@@ -61,6 +61,6 @@ do {						\
 extern void vrrp_dispatcher_release(vrrp_data_t *);
 extern int vrrp_dispatcher_init(thread_t *);
 extern int vrrp_read_dispatcher_thread(thread_t *);
-extern int vrrp_gratuitous_arp_thread(thread_t *);
+extern int vrrp_lower_prio_gratuitous_arp_thread(thread_t *);
 
 #endif

--- a/keepalived/include/vrrp_scheduler.h
+++ b/keepalived/include/vrrp_scheduler.h
@@ -61,5 +61,6 @@ do {						\
 extern void vrrp_dispatcher_release(vrrp_data_t *);
 extern int vrrp_dispatcher_init(thread_t *);
 extern int vrrp_read_dispatcher_thread(thread_t *);
+extern int vrrp_gratuitous_arp_thread(thread_t *);
 
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1484,6 +1484,9 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		}
 		vrrp_send_adv(vrrp, vrrp->effective_priority);
 		vrrp_send_link_update(vrrp, vrrp->garp_rep);
+		if (vrrp->garp_delay)
+			thread_add_timer(master, vrrp_gratuitous_arp_thread,
+					 vrrp, vrrp->garp_delay);
 		return 0;
 	} else if (hd->priority == 0) {
 		vrrp_send_adv(vrrp, vrrp->effective_priority);

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1482,11 +1482,14 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 			vrrp->ipsecah_counter->seq_number = ntohl(ah->seq_number) + 1;
 			vrrp->ipsecah_counter->cycle = 0;
 		}
-		vrrp_send_adv(vrrp, vrrp->effective_priority);
-		vrrp_send_link_update(vrrp, vrrp->garp_rep);
-		if (vrrp->garp_delay)
-			thread_add_timer(master, vrrp_gratuitous_arp_thread,
-					 vrrp, vrrp->garp_delay);
+		if (!vrrp->lower_prio_no_advert)
+			vrrp_send_adv(vrrp, vrrp->effective_priority);
+		if (vrrp->garp_lower_prio_rep) {
+			vrrp_send_link_update(vrrp, vrrp->garp_lower_prio_rep);
+			if (vrrp->garp_lower_prio_delay)
+				thread_add_timer(master, vrrp_lower_prio_gratuitous_arp_thread,
+						 vrrp, vrrp->garp_lower_prio_delay);
+		}
 		return 0;
 	} else if (hd->priority == 0) {
 		vrrp_send_adv(vrrp, vrrp->effective_priority);
@@ -1772,6 +1775,9 @@ vrrp_complete_instance(vrrp_t * vrrp)
 	interface_t *ifp;
 	bool interface_already_existed = false;
 
+	if (vrrp->strict_mode == -1)
+		vrrp->strict_mode = global_data->vrrp_strict;
+
 	if (vrrp->family == AF_INET6) {
 		if (vrrp->version == VRRP_VERSION_2 && vrrp->strict_mode) {
 			log_message(LOG_INFO,"(%s): cannot use IPv6 with VRRP version 2; setting version 3", vrrp->iname);
@@ -1907,6 +1913,13 @@ vrrp_complete_instance(vrrp_t * vrrp)
 	if (!vrrp->adver_int)
 		vrrp->adver_int = VRRP_ADVER_DFL * TIMER_HZ;
 	vrrp->master_adver_int = vrrp->adver_int;
+
+	if (vrrp->garp_lower_prio_rep == -1)
+		vrrp->garp_lower_prio_rep = vrrp->strict_mode ? 0 : global_data->vrrp_garp_lower_prio_rep;
+	if (vrrp->garp_lower_prio_delay == -1)
+		vrrp->garp_lower_prio_delay = vrrp->strict_mode ? 0 : global_data->vrrp_garp_lower_prio_delay;
+	if (vrrp->lower_prio_no_advert == -1)
+		vrrp->lower_prio_no_advert = vrrp->strict_mode ? true : global_data->vrrp_lower_prio_no_advert;
 
 	/* Set a default interface name for the vmac if needed */
 	if (__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags)) {
@@ -2107,6 +2120,12 @@ vrrp_complete_init(void)
 	unsigned int ifindex;
 	unsigned int ifindex_o;
 	size_t max_mtu_len = 0;
+
+	/* Set defaults of not specified, depending on strict mode */
+	if (global_data->vrrp_garp_lower_prio_rep == -1)
+		global_data->vrrp_garp_lower_prio_rep = global_data->vrrp_garp_rep;
+	if (global_data->vrrp_garp_lower_prio_delay == -1)
+		global_data->vrrp_garp_lower_prio_delay = global_data->vrrp_garp_delay;
 
 	/* Complete VRRP instance initialization */
 	l = vrrp_data->vrrp;

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -242,21 +242,20 @@ dump_vrrp(void *data)
 	log_message(LOG_INFO, "   Running on device = %s", IF_NAME(vrrp->ifp));
 	if (vrrp->dont_track_primary)
 		log_message(LOG_INFO, "   VRRP interface tracking disabled");
-	if (vrrp->skip_check_adv_addr)
-		log_message(LOG_INFO, "   Skip checking advert IP addresses");
-	if (vrrp->strict_mode)
-		log_message(LOG_INFO, "   Enforcing strict VRRP compliance");
+	log_message(LOG_INFO, "   Skip checking advert IP addresses = %s", vrrp->skip_check_adv_addr ? "yes" : "no");
+	log_message(LOG_INFO, "   Enforcing strict VRRP compliance = %s", vrrp->strict_mode ? "yes" : "no");
 	if (vrrp->saddr.ss_family)
 		log_message(LOG_INFO, "   Using src_ip = %s"
 				    , inet_sockaddrtos(&vrrp->saddr));
-	if (vrrp->garp_delay)
-		log_message(LOG_INFO, "   Gratuitous ARP delay = %d",
+	log_message(LOG_INFO, "   Gratuitous ARP delay = %d",
 		       vrrp->garp_delay/TIMER_HZ);
-	if (!timer_isnull(vrrp->garp_refresh))
-		log_message(LOG_INFO, "   Gratuitous ARP refresh timer = %lu",
-		       vrrp->garp_refresh.tv_sec);
 	log_message(LOG_INFO, "   Gratuitous ARP repeat = %d", vrrp->garp_rep);
+	log_message(LOG_INFO, "   Gratuitous ARP refresh timer = %lu",
+		       vrrp->garp_refresh.tv_sec);
 	log_message(LOG_INFO, "   Gratuitous ARP refresh repeat = %d", vrrp->garp_refresh_rep);
+	log_message(LOG_INFO, "   Gratuitous ARP lower priority delay = %d", vrrp->garp_lower_prio_delay / TIMER_HZ);
+	log_message(LOG_INFO, "   Gratuitous ARP lower priority repeat = %d", vrrp->garp_lower_prio_rep);
+	log_message(LOG_INFO, "   Send advert after receive lower priority advert = %s", vrrp->lower_prio_no_advert ? "false" : "true");
 	log_message(LOG_INFO, "   Virtual Router ID = %d", vrrp->vrid);
 	log_message(LOG_INFO, "   Priority = %d", vrrp->base_priority);
 	log_message(LOG_INFO, "   Advert interval = %d %s",
@@ -377,6 +376,10 @@ alloc_vrrp(char *iname)
 	new->garp_rep = global_data->vrrp_garp_rep;
 	new->garp_refresh_rep = global_data->vrrp_garp_refresh_rep;
 	new->garp_delay = global_data->vrrp_garp_delay;
+        new->garp_lower_prio_delay = -1;
+        new->garp_lower_prio_rep = -1;
+        new->lower_prio_no_advert = -1;
+
 	new->skip_check_adv_addr = global_data->vrrp_skip_check_adv_addr;
 	new->strict_mode = global_data->vrrp_strict;
 

--- a/keepalived/vrrp/vrrp_print.c
+++ b/keepalived/vrrp/vrrp_print.c
@@ -141,13 +141,15 @@ vrrp_print(FILE *file, void *data)
 	if (vrrp->strict_mode)
 		fprintf(file, "   Enforcing VRRP compliance\n");
 	fprintf(file, "   Using src_ip = %s\n", inet_sockaddrtos(&vrrp->saddr));
-	if (vrrp->garp_delay)
-		fprintf(file, "   Gratuitous ARP delay = %d\n",
+	fprintf(file, "   Gratuitous ARP delay = %d\n",
 		       vrrp->garp_delay/TIMER_HZ);
-	fprintf(file, "   Gratuitous ARP refresh = %lu\n",
-	       vrrp->garp_refresh.tv_sec/TIMER_HZ);
 	fprintf(file, "   Gratuitous ARP repeat = %d\n", vrrp->garp_rep);
+	fprintf(file, "   Gratuitous ARP refresh = %lu\n",
+		       vrrp->garp_refresh.tv_sec/TIMER_HZ);
 	fprintf(file, "   Gratuitous ARP refresh repeat = %d\n", vrrp->garp_refresh_rep);
+	fprintf(file, "   Gratuitous ARP lower priority delay = %d", vrrp->garp_lower_prio_delay / TIMER_HZ);
+	fprintf(file, "   Gratuitous ARP lower priority repeat = %d", vrrp->garp_lower_prio_rep);
+	fprintf(file, "   Send advert after receive lower priority advert = %s", vrrp->lower_prio_no_advert ? "false" : "true");
 	fprintf(file, "   Virtual Router ID = %d\n", vrrp->vrid);
 	fprintf(file, "   Priority = %d\n", vrrp->base_priority);
 	fprintf(file, "   Advert interval = %d %s\n",

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -736,13 +736,25 @@ vrrp_goto_master(vrrp_t * vrrp)
 }
 
 /* Delayed gratuitous ARP thread */
-int
+static int
 vrrp_gratuitous_arp_thread(thread_t * thread)
 {
 	vrrp_t *vrrp = THREAD_ARG(thread);
 
 	/* Simply broadcast the gratuitous ARP */
 	vrrp_send_link_update(vrrp, vrrp->garp_rep);
+
+	return 0;
+}
+
+/* Delayed gratuitous ARP thread after receiving a lower priority advert */
+int
+vrrp_lower_prio_gratuitous_arp_thread(thread_t * thread)
+{
+	vrrp_t *vrrp = THREAD_ARG(thread);
+
+	/* Simply broadcast the gratuitous ARP */
+	vrrp_send_link_update(vrrp, vrrp->garp_lower_prio_rep);
 
 	return 0;
 }

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -444,6 +444,18 @@ set_value(vector_t *strvec)
 	return alloc;
 }
 
+/* Checks for on/true/yes or off/false/no */
+int
+check_true_false(char *str)
+{
+	if (!strcmp(str, "true") || !strcmp(str, "on") || !strcmp(str, "yes"))
+		return true;
+	if (!strcmp(str, "false") || !strcmp(str, "off") || !strcmp(str, "no"))
+		return false;
+
+	return -1;	/* error */
+}
+
 void skip_block(void)
 {
 	/* Don't process the rest of the configuration block */

--- a/lib/parser.h
+++ b/lib/parser.h
@@ -72,6 +72,7 @@ extern int read_line(char *, int);
 extern vector_t *read_value_block(vector_t *);
 extern void alloc_value_block(vector_t *, void (*alloc_func) (vector_t *));
 extern void *set_value(vector_t *);
+extern int check_true_false(char *);
 extern void skip_block(void);
 extern void init_data(char *, vector_t * (*init_keywords) (void));
 


### PR DESCRIPTION
Issue #277 identified that only one set of gratuitous ARP messages was sent after receiving a lower priority advert, whereas two sets would be sent, if configured, after transition to master.

These commits allow the sending of a second set of gratuitous ARP messages, and the configuration of that and resolve issue #277.