### PR TITLE
Attempt to fix build breakage

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -284,7 +284,7 @@ vrrp_instance <STRING> {		# VRRP instance declaration
     nopreempt					# Override VRRP RFC preemption default
     preempt_delay				# Seconds after startup until
 						#  preemption. 0 (default) to 1,000
-    strict_mode [<BOOL]				# See description of global vrrp_strict
+    strict_mode [<BOOL>]			# See description of global vrrp_strict
 						# If vrrp_strict is not specified, it takes the value of vrrp_strict
 						# If strict_mode without a parameter is specified, it defaults to on
     debug					# Debug level

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -153,7 +153,7 @@ typedef struct _vrrp_t {
 	int			dont_track_primary;	/* If set ignores ifp faults */
 	bool			skip_check_adv_addr;	/* If set, don't check the VIPs in subsequent
 							 * adverts from the same master */
-	bool			strict_mode;		/* Enforces strict VRRP compliance */
+	int			strict_mode;		/* Enforces strict VRRP compliance */
 	unsigned long		vmac_flags;		/* VRRP VMAC flags */
 	char			vmac_ifname[IFNAMSIZ];	/* Name of VRRP VMAC interface */
 	unsigned int		vmac_ifindex;		/* ifindex of vmac interface */

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -381,7 +381,7 @@ alloc_vrrp(char *iname)
         new->lower_prio_no_advert = -1;
 
 	new->skip_check_adv_addr = global_data->vrrp_skip_check_adv_addr;
-	new->strict_mode = global_data->vrrp_strict;
+	new->strict_mode = -1;
 
 	list_add(vrrp_data->vrrp, new);
 }

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -21,16 +21,22 @@ GIT_COMMIT_FILE = git-commit.h
 	$(COMPILE) -c $<
 
 all:	$(OBJS)
-	@[[ ! -f $(GIT_COMMIT_FILE) ]] && >$(GIT_COMMIT_FILE); \
-	if [[ -x $$(type -p git) ]]; then \
+	@if [ ! -f $(GIT_COMMIT_FILE) ]; then \
+		>$(GIT_COMMIT_FILE); \
+	fi; \
+	if [ -x `type -p git` ]; then \
 		git rev-parse --is-inside-work-tree >/dev/null; \
-		if [[ $$? -eq 0 && $$(git describe --tags) =~ -[1-9][0-9]*-g[0-9a-f]{7}$$ ]]; then \
-			echo "#define GIT_COMMIT \"$$(git describe --tags)\"" >$(GIT_COMMIT_FILE).new; \
-			diff -q $(GIT_COMMIT_FILE) $(GIT_COMMIT_FILE).new 2>/dev/null >/dev/null; \
-			if [[ $$? -eq 0 ]]; then \
-				rm $(GIT_COMMIT_FILE).new; \
-			else \
-				mv $(GIT_COMMIT_FILE).new $(GIT_COMMIT_FILE); \
+		if [ $$? -eq 0 ]; then \
+			GIT_REV=`git describe --tags`; \
+			echo $${GIT_REV} | grep -qE -- "-[1-9][0-9]*-g[0-9a-f]{7}$$"; \
+			if [ $$? -eq 0 ]; then \
+				echo "#define GIT_COMMIT \"$${GIT_REV}\"" >$(GIT_COMMIT_FILE).new; \
+				diff -q $(GIT_COMMIT_FILE) $(GIT_COMMIT_FILE).new 2>/dev/null >/dev/null; \
+				if [ $$? -eq 0 ]; then \
+					rm $(GIT_COMMIT_FILE).new; \
+				else \
+					mv $(GIT_COMMIT_FILE).new $(GIT_COMMIT_FILE); \
+				fi; \
 			fi; \
 		fi; \
 	fi


### PR DESCRIPTION
Unfortunately all my systems worked with the previous version of lib/Makefile.in, but I have replaced all the [[ ]] constructs with [ ] and also $(cmd) constructs with `cmd`. I have also replace the =~.