### PR TITLE
Install VRRP-MIB when applicable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -85,11 +85,8 @@ install:
 	$(MAKE) -C genhash install
 ifeq (@SNMP_SUPPORT@, _WITH_SNMP_)
 	mkdir -p $(DESTDIR)/usr/share/snmp/mibs/
-ifeq (@SNMP_RFC2_SUPPORT@, _WITH_SNMP_RFC2_)
+ifeq (@SNMP_RFCV2_SUPPORT@, _WITH_SNMP_RFCV2_)
 	cp -f doc/VRRP-MIB $(DESTDIR)/usr/share/snmp/mibs/
-endif
-ifeq (@SNMP_RFC3_SUPPORT@, _WITH_SNMP_RFC3_)
-	cp -f doc/VRRPv3-MIB $(DESTDIR)/usr/share/snmp/mibs/
 endif
 ifeq (@SNMP_RFCV3_SUPPORT@, _WITH_SNMP_RFCV3_)
 	cp -f doc/VRRPv3-MIB $(DESTDIR)/usr/share/snmp/mibs/


### PR DESCRIPTION
It appears that the condition in Makefile.in for installing VRRP-MIB
was using a non-existent macro, SNMP_RFC2_SUPPORT. This patch removes
two conditions from Makefile.in that use undefined macros and adds a
condition to install VRRP-MIB when SNMP_RFCV2_SUPPORT is set
appropriately.