### PR TITLE
Updated range for virtual_router_id and priority in doc/keepalived.conf.SYNOPSIS

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -244,8 +244,8 @@ vrrp_instance <STRING> {		# VRRP instance declaration
     garp_master_refresh <INTEGER>
     garp_master_refresh_repeat <INTEGER>
 
-    virtual_router_id <INTEGER-0..255>	# VRRP VRID
-    priority <INTEGER-0..255>		# VRRP PRIO
+    virtual_router_id <INTEGER-1..255>	# VRRP VRID
+    priority <INTEGER-1..255>		# VRRP PRIO
     advert_int <INTEGER>		# VRRP Advert interval (use default)
 
     lower_prio_no_advert		# If a lower priority advert is received, don't


### PR DESCRIPTION
Apr 22 18:09:27 localhost Keepalived_vrrp[22943]: VRRP Error : VRID not valid !
Apr 22 18:09:27 localhost Keepalived_vrrp[22943]:              must be between 1 & 255. reconfigure !

Apr 22 18:08:08 localhost Keepalived_vrrp[22843]: (VI_1): Priority not valid! must be between 1 & 255. Reconfigure !