### PR TITLE
Allow smtp_server domain names with '-' characters to be parsed correctly

### DIFF
--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -59,11 +59,15 @@ smtpto_handler(vector_t *strvec)
 static void
 smtpserver_handler(vector_t *strvec)
 {
-	int ret;
-	ret = inet_stosockaddr(vector_slot(strvec, 1), SMTP_PORT_STR, &global_data->smtp_server);
-	if (ret < 0) {
+	int ret = -1;
+
+	/* It can't be an IP address if it contains '-' or '/', and 
+	   inet_stosockaddr() modifies the string if it contains either of them */
+	if (!strpbrk(vector_slot(strvec, 1), "-/"))
+		ret = inet_stosockaddr(vector_slot(strvec, 1), SMTP_PORT_STR, &global_data->smtp_server);
+
+	if (ret < 0)
 		domain_stosockaddr(vector_slot(strvec, 1), SMTP_PORT_STR, &global_data->smtp_server);
-	}
 }
 static void
 smtphelo_handler(vector_t *strvec)


### PR DESCRIPTION
This may not be the best way of resolving the problem, but it does work.

I will have a think to see if there is a better way of fixing this, and if so I will submit a further patch. It may be that inet_stosockaddr() shouldn't modify the string passed to it (or restore it if it does modify it), and I'll have a look to see what implications that might have.

This resolves issue #309