### PR TITLE
More verbose logging on (effective) priorities

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1470,6 +1470,9 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		       "VRRP_Instance(%s) Dropping received VRRP packet...",
 		       vrrp->iname);
 		return 0;
+	} else if (hd->priority == 0) {
+		vrrp_send_adv(vrrp, vrrp->effective_priority);
+		return 0;
 	} else if (hd->priority < vrrp->effective_priority) {
 		/* We receive a lower prio adv we just refresh remote ARP cache */
 		log_message(LOG_INFO, "VRRP_Instance(%s) Received lower prio advert"
@@ -1490,9 +1493,6 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 				thread_add_timer(master, vrrp_lower_prio_gratuitous_arp_thread,
 						 vrrp, vrrp->garp_lower_prio_delay);
 		}
-		return 0;
-	} else if (hd->priority == 0) {
-		vrrp_send_adv(vrrp, vrrp->effective_priority);
 		return 0;
 	} else if (hd->priority > vrrp->effective_priority ||
 		   (hd->priority == vrrp->effective_priority &&

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1475,8 +1475,8 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		return 0;
 	} else if (hd->priority < vrrp->effective_priority) {
 		/* We receive a lower prio adv we just refresh remote ARP cache */
-		log_message(LOG_INFO, "VRRP_Instance(%s) Received lower prio advert"
-				      ", forcing new election", vrrp->iname);
+		log_message(LOG_INFO, "VRRP_Instance(%s) Received lower prio advert %d"
+				      ", forcing new election", vrrp->iname, hd->priority);
 		if (proto == IPPROTO_IPSEC_AH) {
 			ah = (ipsec_ah_t *) (buf + sizeof(struct iphdr));
 			log_message(LOG_INFO, "VRRP_Instance(%s) IPSEC-AH : Syncing seq_num"
@@ -1502,8 +1502,8 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		 */
 		vrrp_send_adv(vrrp, vrrp->effective_priority);
 
-		log_message(LOG_INFO, "VRRP_Instance(%s) Received higher prio advert"
-				    , vrrp->iname);
+		log_message(LOG_INFO, "VRRP_Instance(%s) Received higher prio advert %d"
+				    , vrrp->iname, hd->priority);
 		if (proto == IPPROTO_IPSEC_AH) {
 			ah = (ipsec_ah_t *) (buf + sizeof(struct iphdr));
 			log_message(LOG_INFO, "VRRP_Instance(%s) IPSEC-AH : Syncing seq_num"

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -759,6 +759,20 @@ vrrp_lower_prio_gratuitous_arp_thread(thread_t * thread)
 	return 0;
 }
 
+/* Set effective priorty, issue message on changes */
+static void
+vrrp_set_effective_priority(vrrp_t *vrrp, int new_prio)
+{
+	if (vrrp->effective_priority == new_prio)
+		return;
+
+	log_message(LOG_INFO, "VRRP_Instance(%s) Effective priority = %d",
+		    vrrp->iname, new_prio);
+
+	vrrp->effective_priority = new_prio;
+}
+
+
 /* Update VRRP effective priority based on multiple checkers.
  * This is a thread which is executed every adver_int.
  */
@@ -781,7 +795,7 @@ vrrp_update_priority(thread_t * thread)
 
 	if (vrrp->base_priority == VRRP_PRIO_OWNER) {
 		/* we will not run a PRIO_OWNER into a non-PRIO_OWNER */
-		vrrp->effective_priority = VRRP_PRIO_OWNER;
+		vrrp_set_effective_priority(vrrp, VRRP_PRIO_OWNER);
 	} else {
 		/* WARNING! we must compute new_prio on a signed int in order
 		   to detect overflows and avoid wrapping. */
@@ -790,7 +804,7 @@ vrrp_update_priority(thread_t * thread)
 			new_prio = 1;
 		else if (new_prio >= VRRP_PRIO_OWNER)
 			new_prio = VRRP_PRIO_OWNER - 1;
-		vrrp->effective_priority = new_prio;
+		vrrp_set_effective_priority(vrrp, new_prio);
 	}
 
 	/* Register next priority update thread */


### PR DESCRIPTION
While using the weight feature and analysing its effect it is helpful to have additional log info on the effective priority of a keepalived instance and received priorities of other instances.

Furthermore there's a oddity regarding a potentially shaded if clause for prority == 0 detection. It seems like this clause is shaded by the if clause right above it. If so the if clause is obsolete, or (which is in this PR) it should be "taken out of the shadow".