### PR TITLE
configure: fix macvlan detection with musl libc

### DIFF
--- a/configure
+++ b/configure
@@ -4540,7 +4540,7 @@ $as_echo_n "checking for kernel macvlan support... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-    #include <bits/sockaddr.h>
+    #include <sys/socket.h>
     #include <linux/if_link.h>
     int macvlan;
 

--- a/configure.ac
+++ b/configure.ac
@@ -319,7 +319,7 @@ dnl ----[ Checks for kernel VMAC support ]----
 CPPFLAGS="$CPPFLAGS -I$kernelinc"
 AC_MSG_CHECKING([for kernel macvlan support])
 AC_TRY_COMPILE([
-    #include <bits/sockaddr.h>
+    #include <sys/socket.h>
     #include <linux/if_link.h>
     int macvlan;
   ], [


### PR DESCRIPTION
The check for macvlan support in the configure script includes
<bits/sockaddr.h>. As this header file doesn't exist in musl libc,
macvlan detection fails.

Additionally, a comment in glibc's <bits/sockaddr.h> says never to
include it directly, but to use <sys/socket.h> instead.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>