### PR TITLE
Initialise structs by member names

### DIFF
--- a/genhash/layer4.c
+++ b/genhash/layer4.c
@@ -35,7 +35,7 @@
 enum connect_result
 tcp_connect(int fd, REQ * req_obj)
 {
-	struct linger li = { 0 };
+	struct linger li;
 	int long_inet;
 	struct sockaddr_in adr_serv;
 	struct sockaddr_in6 adr_serv6;
@@ -45,8 +45,7 @@ tcp_connect(int fd, REQ * req_obj)
 	/* free the tcp port after closing the socket descriptor */
 	li.l_onoff = 1;
 	li.l_linger = 0;
-	setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *) &li,
-		   sizeof (struct linger));
+	setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *) &li, sizeof (struct linger));
 
 #ifdef _WITH_SO_MARK_
 	if (req->mark) {

--- a/keepalived/core/layer4.c
+++ b/keepalived/core/layer4.c
@@ -28,7 +28,7 @@
 enum connect_result
 tcp_bind_connect(int fd, conn_opts_t *co)
 {
-	struct linger li = { 0 };
+	struct linger li;
 	socklen_t addrlen;
 	int ret;
 	int val;

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -108,7 +108,10 @@ sigend(void *v, int sig)
 	int ret;
 	int wait_count = 0;
 	sigset_t old_set, child_wait;
-	struct timespec timeout = { CHILD_WAIT_SECS, 0 };
+	struct timespec timeout = {
+		.tv_sec = CHILD_WAIT_SECS,
+		.tv_nsec = 0
+	};
 	struct timeval start_time, now;
 
 	/* register the terminate thread */

--- a/keepalived/include/vrrp_scheduler.h
+++ b/keepalived/include/vrrp_scheduler.h
@@ -62,5 +62,6 @@ extern void vrrp_dispatcher_release(vrrp_data_t *);
 extern int vrrp_dispatcher_init(thread_t *);
 extern int vrrp_read_dispatcher_thread(thread_t *);
 extern int vrrp_lower_prio_gratuitous_arp_thread(thread_t *);
+extern void vrrp_set_effective_priority(vrrp_t *, int);
 
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1485,8 +1485,8 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		return 0;
 	} else if (hd->priority < vrrp->effective_priority) {
 		/* We receive a lower prio adv we just refresh remote ARP cache */
-		log_message(LOG_INFO, "VRRP_Instance(%s) Received lower prio advert"
-				      ", forcing new election", vrrp->iname);
+		log_message(LOG_INFO, "VRRP_Instance(%s) Received lower prio advert %d"
+				      ", forcing new election", vrrp->iname, hd->priority);
 		if (proto == IPPROTO_IPSEC_AH) {
 			ah = (ipsec_ah_t *) (buf + sizeof(struct iphdr));
 			log_message(LOG_INFO, "VRRP_Instance(%s) IPSEC-AH : Syncing seq_num"
@@ -1512,8 +1512,8 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		 */
 		vrrp_send_adv(vrrp, vrrp->effective_priority);
 
-		log_message(LOG_INFO, "VRRP_Instance(%s) Received higher prio advert"
-				    , vrrp->iname);
+		log_message(LOG_INFO, "VRRP_Instance(%s) Received higher prio advert %d"
+				    , vrrp->iname, hd->priority);
 		if (proto == IPPROTO_IPSEC_AH) {
 			ah = (ipsec_ah_t *) (buf + sizeof(struct iphdr));
 			log_message(LOG_INFO, "VRRP_Instance(%s) IPSEC-AH : Syncing seq_num"

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1480,6 +1480,9 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		       "VRRP_Instance(%s) Dropping received VRRP packet...",
 		       vrrp->iname);
 		return 0;
+	} else if (hd->priority == 0) {
+		vrrp_send_adv(vrrp, vrrp->effective_priority);
+		return 0;
 	} else if (hd->priority < vrrp->effective_priority) {
 		/* We receive a lower prio adv we just refresh remote ARP cache */
 		log_message(LOG_INFO, "VRRP_Instance(%s) Received lower prio advert"
@@ -1500,9 +1503,6 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 				thread_add_timer(master, vrrp_lower_prio_gratuitous_arp_thread,
 						 vrrp, vrrp->garp_lower_prio_delay);
 		}
-		return 0;
-	} else if (hd->priority == 0) {
-		vrrp_send_adv(vrrp, vrrp->effective_priority);
 		return 0;
 	} else if (hd->priority > vrrp->effective_priority ||
 		   (hd->priority == vrrp->effective_priority &&

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -416,8 +416,12 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
 		char buf[4096];
 		struct iovec iov = { buf, sizeof buf };
 		struct sockaddr_nl snl;
-		struct msghdr msg =
-		    { (void *) &snl, sizeof snl, &iov, 1, NULL, 0, 0 };
+		struct msghdr msg = {
+			.msg_name = &snl,
+			.msg_namelen = sizeof(snl),
+			.msg_iov = &iov,
+			.msg_iovlen = 1,
+		};
 		struct nlmsghdr *h;
 
 		status = recvmsg(nl->fd, &msg, 0);
@@ -538,7 +542,12 @@ netlink_talk(nl_handle_t *nl, struct nlmsghdr *n)
 	int ret, flags;
 	struct sockaddr_nl snl;
 	struct iovec iov = { (void *) n, n->nlmsg_len };
-	struct msghdr msg = { (void *) &snl, sizeof snl, &iov, 1, NULL, 0, 0 };
+	struct msghdr msg = {
+		.msg_name = &snl,
+		.msg_namelen = sizeof(snl),
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+	};
 
 	memset(&snl, 0, sizeof snl);
 	snl.nl_family = AF_NETLINK;

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -414,7 +414,10 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
 
 	while (1) {
 		char buf[4096];
-		struct iovec iov = { buf, sizeof buf };
+		struct iovec iov = {
+			.iov_base = buf,
+			.iov_len = sizeof buf
+		};
 		struct sockaddr_nl snl;
 		struct msghdr msg = {
 			.msg_name = &snl,
@@ -544,7 +547,10 @@ netlink_talk(nl_handle_t *nl, struct nlmsghdr *n)
 	int status;
 	int ret, flags;
 	struct sockaddr_nl snl;
-	struct iovec iov = { (void *) n, n->nlmsg_len };
+	struct iovec iov = {
+		.iov_base = n,
+		.iov_len = n->nlmsg_len
+	};
 	struct msghdr msg = {
 		.msg_name = &snl,
 		.msg_namelen = sizeof(snl),

--- a/keepalived/vrrp/vrrp_netlink.c
+++ b/keepalived/vrrp/vrrp_netlink.c
@@ -421,6 +421,9 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
 			.msg_namelen = sizeof(snl),
 			.msg_iov = &iov,
 			.msg_iovlen = 1,
+			.msg_control = NULL,
+			.msg_controllen = 0,
+			.msg_flags = 0
 		};
 		struct nlmsghdr *h;
 
@@ -547,6 +550,9 @@ netlink_talk(nl_handle_t *nl, struct nlmsghdr *n)
 		.msg_namelen = sizeof(snl),
 		.msg_iov = &iov,
 		.msg_iovlen = 1,
+		.msg_control = NULL,
+		.msg_controllen = 0,
+		.msg_flags = 0
 	};
 
 	memset(&snl, 0, sizeof snl);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -767,6 +767,20 @@ vrrp_lower_prio_gratuitous_arp_thread(thread_t * thread)
 	return 0;
 }
 
+/* Set effective priorty, issue message on changes */
+static void
+vrrp_set_effective_priority(vrrp_t *vrrp, int new_prio)
+{
+	if (vrrp->effective_priority == new_prio)
+		return;
+
+	log_message(LOG_INFO, "VRRP_Instance(%s) Effective priority = %d",
+		    vrrp->iname, new_prio);
+
+	vrrp->effective_priority = new_prio;
+}
+
+
 /* Update VRRP effective priority based on multiple checkers.
  * This is a thread which is executed every adver_int.
  */
@@ -789,7 +803,7 @@ vrrp_update_priority(thread_t * thread)
 
 	if (vrrp->base_priority == VRRP_PRIO_OWNER) {
 		/* we will not run a PRIO_OWNER into a non-PRIO_OWNER */
-		vrrp->effective_priority = VRRP_PRIO_OWNER;
+		vrrp_set_effective_priority(vrrp, VRRP_PRIO_OWNER);
 	} else {
 		/* WARNING! we must compute new_prio on a signed int in order
 		   to detect overflows and avoid wrapping. */
@@ -798,7 +812,7 @@ vrrp_update_priority(thread_t * thread)
 			new_prio = 1;
 		else if (new_prio >= VRRP_PRIO_OWNER)
 			new_prio = VRRP_PRIO_OWNER - 1;
-		vrrp->effective_priority = new_prio;
+		vrrp_set_effective_priority(vrrp, new_prio);
 	}
 
 	/* Register next priority update thread */

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -768,7 +768,7 @@ vrrp_lower_prio_gratuitous_arp_thread(thread_t * thread)
 }
 
 /* Set effective priorty, issue message on changes */
-static void
+void
 vrrp_set_effective_priority(vrrp_t *vrrp, int new_prio)
 {
 	if (vrrp->effective_priority == new_prio)

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -1002,7 +1002,7 @@ vrrp_snmp_instance_priority(int action,
 		   thread. Otherwise, we should set it equal to the
 		   base priority. */
 		if (vrrp->sync)
-			vrrp->effective_priority = vrrp->base_priority;
+			vrrp_set_effective_priority(vrrp, vrrp->base_priority);
 //TODO - could affect accept
 		break;
 	}

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -65,7 +65,10 @@ signal_pending(void)
 {
 	fd_set readset;
 	int rc;
-	struct timeval timeout = { 0, 0 };
+	struct timeval timeout = {
+		.tv_sec = 0,
+		.tv_usec = 0
+	};
 
 	FD_ZERO(&readset);
 	FD_SET(signal_pipe[0], &readset);


### PR DESCRIPTION
This pull request enhances and supersedes pull request #319.

The original commit removed initialisation of 3 fields of struct msghdr, which are reinstated in commit eaabcc1.

Commit 4239ede extends the idea of the original commit, and updates all other structure initialisations to use field names.