### PR TITLE
Fix preempt issue from fault state

### DIFF
--- a/doc/KEEPALIVED-MIB
+++ b/doc/KEEPALIVED-MIB
@@ -22,13 +22,15 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201605221540Z"
+     LAST-UPDATED "201606030000Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
-     LAST-UPDATED "201605221540Z"
+     REVISION-UPDATED "201606030000Z"
+     DESCRIPTION "update comment for vrrpInstancePreemptDelay"
+     REVISION-UPDATED "201605221540Z"
      DESCRIPTION "smtpServerPort added"
      REVISION "201510270000Z"
      DESCRIPTION "routerId added to traps variables"
@@ -496,7 +498,7 @@ vrrpInstancePreemptDelay OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-        "Delay after startup until preemption can happen. 0 means that there is no delay."
+        "Delay after startup or lower priority advert received until preemption can happen. 0 means that there is no delay."
     ::= { vrrpInstanceEntry 14 }
 
 vrrpInstanceAuthType OBJECT-TYPE

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -318,8 +318,8 @@ vrrp_instance <STRING> {		# VRRP instance declaration
     }
 
     nopreempt					# Override VRRP RFC preemption default
-    preempt_delay				# Seconds after startup until
-						#  preemption. 0 (default) to 1,000
+    preempt_delay				# Seconds after startup or seeing a lower priority master
+						#  until preemption. 0 (default) to 1,000
     strict_mode [<BOOL>]			# See description of global vrrp_strict
 						# If vrrp_strict is not specified, it takes the value of vrrp_strict
 						# If strict_mode without a parameter is specified, it defaults to on

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -446,7 +446,7 @@ which will transition together on any state change.
     # If strict_mode without a parameter is specified, it defaults to on
     strict_mode [on|off|true|false|yes|no]
 
-    # Seconds after startup until preemption
+    # Seconds after startup or seeing a lower priority master until preemption
     # (if not disabled by "nopreempt").
     # Range: 0 (default) to 1000
     # NOTE: For this to work, the initial state of this

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -203,7 +203,6 @@ typedef struct _vrrp_t {
 							 * prio is allowed.  0 means no delay.
 							 */
 	timeval_t		preempt_time;		/* Time after which preemption can happen */
-	int			preempt_delay_active;
 	int			state;			/* internal state (init/backup/master) */
 	int			init_state;		/* the initial state of the instance */
 	int			wantstate;		/* user explicitly wants a state (back/mast) */

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1541,10 +1541,6 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 	} else if (hd->priority > vrrp->effective_priority ||
 		   (hd->priority == vrrp->effective_priority &&
 		    vrrp_saddr_cmp(&vrrp->pkt_saddr, vrrp) > 0)) {
-		/* We send a last advert here in order to refresh remote MASTER
-		 * coming up to force link update at MASTER side.
-		 */
-		vrrp_send_adv(vrrp, vrrp->effective_priority);
 
 		log_message(LOG_INFO, "VRRP_Instance(%s) Received higher prio advert %d"
 				    , vrrp->iname, hd->priority);

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2362,7 +2362,7 @@ vrrp_complete_init(void)
 					}
 
 					notify_group_exec(sgroup, sgroup->state);
-#ifdef _WITH_SNMP_
+#ifdef _WITH_SNMP_KEEPALIVED_
 					vrrp_snmp_group_trap(sgroup);
 #endif
 				}

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1590,8 +1590,7 @@ vrrp_state_fault_rx(vrrp_t * vrrp, char *buf, int buflen)
 		log_message(LOG_INFO, "VRRP_Instance(%s) Dropping received VRRP packet..."
 				    , vrrp->iname);
 		return 0;
-	} else if (vrrp->effective_priority > hd->priority ||
-		   hd->priority == VRRP_PRIO_OWNER) {
+	} else if (vrrp->effective_priority > hd->priority) {
 		if (!vrrp->nopreempt)
 			return 1;
 	}

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1967,6 +1967,14 @@ vrrp_complete_instance(vrrp_t * vrrp)
 
 	if (vrrp->nopreempt && vrrp->init_state == VRRP_STATE_MAST)
 		log_message(LOG_INFO, "(%s): Warning - nopreempt will not work with initial state MASTER", vrrp->iname);
+	if (vrrp->strict_mode && vrrp->preempt_delay) {
+		log_message(LOG_INFO, "(%s): preempt_delay is incompatible with strict mode - resetting", vrrp->iname);
+		vrrp->preempt_delay = 0;
+	}
+	if (vrrp->nopreempt && vrrp->preempt_delay) {
+		log_message(LOG_INFO, "(%s): preempt_delay is incompatible with nopreempt mode - resetting", vrrp->iname);
+		vrrp->preempt_delay = 0;
+	}
 
 	vrrp->state = VRRP_STATE_INIT;
 

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -909,10 +909,12 @@ vrrp_fault(vrrp_t * vrrp)
 			vrrp_snmp_instance_trap(vrrp);
 #endif
 			vrrp->last_transition = timer_now();
+			log_message(LOG_INFO, "VRRP_Instance(%s): Entering BACKUP STATE", vrrp->iname);
 		} else {
 #ifdef _WITH_SNMP_RFCV3_
 			vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PREEMPTED;
 #endif
+			log_message(LOG_INFO, "VRRP_Instance(%s): Transition to MASTER STATE", vrrp->iname);
 			vrrp_goto_master(vrrp);
 		}
 	}

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -40,6 +40,7 @@
 #include "notify.h"
 #include "list.h"
 #include "logger.h"
+#include "timer.h"
 #include "main.h"
 #include "smtp.h"
 #include "signals.h"
@@ -685,7 +686,7 @@ vrrp_leave_fault(vrrp_t * vrrp, char *buffer, int len)
 	if (!VRRP_ISUP(vrrp))
 		return;
 
-	if (vrrp_state_fault_rx(vrrp, buffer, len)) {
+	if (vrrp_state_fault_rx(vrrp, buffer, len) == VRRP_STATE_MAST) {
 		if (!vrrp->sync || vrrp_sync_leave_fault(vrrp)) {
 			log_message(LOG_INFO,
 			       "VRRP_Instance(%s) prio is higher than received advert",
@@ -905,6 +906,8 @@ vrrp_fault(vrrp_t * vrrp)
 		if (vrrp->init_state == VRRP_STATE_BACK) {
 			vrrp->state = VRRP_STATE_BACK;
 			notify_instance_exec(vrrp, VRRP_STATE_BACK);
+			if (vrrp->preempt_delay)
+				vrrp->preempt_time = timer_add_long(timer_now(), vrrp->preempt_delay);
 #ifdef _WITH_SNMP_KEEPALIVED_
 			vrrp_snmp_instance_trap(vrrp);
 #endif


### PR DESCRIPTION
The main commit is the penultimate one (fix preempt delay), which resolves the issue of preempt_delay and nopreempt being ignored when transitioning out of fault state.

While investigating the issue, a number of other issues were found relating to state changes following receiving adverts, and included are commits relating to those issues.

This pull request should resolve issue #296.