### PR TITLE
Fix IPv4 vIP removal when addr matches pre-existing interface addr

### DIFF
--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -110,10 +110,16 @@ netlink_ipaddress(ip_address_t *ipaddress, int cmd)
 		addattr_l(&req.n, sizeof(req), IFA_LOCAL,
 			  &ipaddress->u.sin.sin_addr, sizeof(ipaddress->u.sin.sin_addr));
 
-		if (cmd == IPADDRESS_ADD)
+		if (cmd == IPADDRESS_ADD) {
 			if (ipaddress->u.sin.sin_brd.s_addr)
 				addattr_l(&req.n, sizeof(req), IFA_BROADCAST,
 					  &ipaddress->u.sin.sin_brd, sizeof(ipaddress->u.sin.sin_brd));
+		}
+		else {
+			/* IPADDRESS_DEL */
+			addattr_l(&req.n, sizeof(req), IFA_ADDRESS.
+				  &ipaddress->u.sin.sin_addr, sizeof(ipaddress->u.sin.sin_addr));
+		}
 	}
 
 	if (cmd == IPADDRESS_ADD)


### PR DESCRIPTION
For IPv4 vIPs keepalived adds a /32 to the underlying interface. If
this address matches an address already configured, e.g. a /24, when
this vIP is eventually removed due to a configuration change or
keepalived shutdown, the original address matching the vIP, outside
of keepalived's control, is removed instead. This behaviour is
incorrect. The /32 added by keepalived should be the address being
removed. Keepalived should not be touching any addresses it does not
create.

This commit re-instates d80c171 which was removed in ef73279. The
IFA_ADDRESS attribute is included in the netlink delete address
message so that the /32 keepalived added is removed instead of the
pre-existing interface address.