### PR TITLE
Remove double includes in check_daemon.c

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -28,8 +28,6 @@
 #include "check_ssl.h"
 #include "check_api.h"
 #include "global_data.h"
-#include "ipwrapper.h"
-#include "ipvswrapper.h"
 #include "pidfile.h"
 #include "daemon.h"
 #include "signals.h"


### PR DESCRIPTION
"ipwrapper.h" and "ipvswrapper.h" are already included on lines 23 and 24