### PR TITLE
Add temporary workaround re segfault when reloading with vmacs

### DIFF
--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -308,7 +308,10 @@ netlink_link_del_vmac(vrrp_t *vrrp)
 	/* Reset arp_ignore and arp_filter on the base interface if necessary */
 	base_ifp = if_get_by_ifindex(vrrp->ifp->base_ifindex);
 
-	if (vrrp->family == AF_INET)
+	if (!base_ifp)
+		log_message(LOG_INFO, "(%s) No interface found for ifindex %d (%s), probably due to corruption.",
+			    vrrp->iname, vrrp->ifp->base_ifindex, vrrp->ifp->ifname);
+	else if (vrrp->family == AF_INET)
 		reset_interface_parameters(base_ifp);
 
 	memset(&req, 0, sizeof (req));


### PR DESCRIPTION
Issue #365 identified that the vrrp child process intermittently
segfaults when reloading configuration. Investigation has shown
that vrrp->ifp->ifindex (and vrrp->ifp->ifname) are being overwritten,
and hence in netlink_link_del_vmac() function if_get_by_ifindex() is
returning null (since it is passed an invalid ifindex), and this return
value is passed unchecked to reset_interface_parameters(), which
then causes the segfault.

This commit is a temporary workaround to test the return value of
if_get_by_ifindex() and if it is NULL, then reset_interface_parameters()
isn't called, but an error message is logged.

Further investigation is needed to ascertain why the fields in the
interface struct are being overwritten.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>