### PR TITLE
Resolve a segfault when reloading keepalived with vmacs

### DIFF
--- a/configure
+++ b/configure
@@ -630,6 +630,8 @@ VERSION_YEAR
 VERSION_DATE
 VERSION
 VRRP_AUTH_SUPPORT
+MEM_CHECK_LOG
+MEM_CHECK
 DFLAGS
 SO_MARK_SUPPORT
 SHA1_SUPPORT
@@ -724,6 +726,8 @@ enable_sha1
 enable_vrrp_auth
 enable_libiptc
 enable_libipset
+enable_mem_check
+enable_mem_check_log
 enable_debug
 enable_profile
 '
@@ -1357,6 +1361,8 @@ Optional Features:
   --disable-vrrp-auth     compile without VRRP authentication
   --disable-libiptc       compile without libiptc
   --disable-libipset      compile without libipset
+  --enable-mem-check      compile with memory alloc checking
+  --enable-mem-check-log  compile with memory alloc checking writing to syslog
   --enable-debug          compile with debugging flags
   --enable-profile        compile with profiling flags
 
@@ -3350,6 +3356,16 @@ if test "${enable_libipset+set}" = set; then :
   enableval=$enable_libipset;
 fi
 
+# Check whether --enable-mem-check was given.
+if test "${enable_mem_check+set}" = set; then :
+  enableval=$enable_mem_check;
+fi
+
+# Check whether --enable-mem-check-log was given.
+if test "${enable_mem_check_log+set}" = set; then :
+  enableval=$enable_mem_check_log;
+fi
+
 # Check whether --enable-debug was given.
 if test "${enable_debug+set}" = set; then :
   enableval=$enable_debug;
@@ -5109,6 +5125,18 @@ if test "${enable_debug}" = "yes"; then
 
 fi
 
+MEM_CHECK_LOG=_NO_MEM_CHECK_LOG_
+if test "${enable_mem_check}" = "yes"; then
+  MEM_CHECK=_MEM_CHECK_
+  if test "${enable_mem_check_log}" = "yes"; then
+    MEM_CHECK_LOG=_MEM_CHECK_LOG_
+  fi
+else
+  MEM_CHECK=_NO_MEM_CHECK_
+fi
+
+
+
 VRRP_AUTH_SUPPORT="_WITHOUT_VRRP_AUTH_"
 if test "$enable_vrrp" != "no"; then
   if test "${enable_vrrp_auth}" != "no"; then
@@ -5130,7 +5158,7 @@ fi
 
 
 
-APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} ${DFLAGS}"
+APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} -D${MEM_CHECK} -D${MEM_CHECK_LOG} ${DFLAGS}"
 BUILD_OPTS=`echo ${APP_DEFS} | sed -e 's/ "$//' -e 's/.*"//' -e 's/-D//g' -e 's/_ / /g' -e 's/ _/ /g' -e 's/^_//' -e 's/_$//'`
 
 
@@ -6670,6 +6698,16 @@ if test "${DFLAGS}" = "-D_DEBUG_"; then
   echo "Use Debug flags          : Yes"
 else
   echo "Use Debug flags          : No"
+fi
+if test "${MEM_CHECK}" = "_MEM_CHECK_"; then
+  echo "Memory alloc check       : Yes"
+  if test "${MEM_CHECK_LOG}" = "_MEM_CHECK_LOG_"; then
+    echo "Memory alloc check log   : Yes"
+  else
+    echo "Memory alloc check log   : No"
+  fi
+else
+  echo "Memory alloc check       : No"
 fi
 if test "${USE_NL3}" = "_HAVE_LIBNL3_"; then
   echo "libnl version            : 3"

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,10 @@ AC_ARG_ENABLE(libiptc,
   [  --disable-libiptc       compile without libiptc])
 AC_ARG_ENABLE(libipset,
   [  --disable-libipset      compile without libipset])
+AC_ARG_ENABLE(mem-check,
+  [  --enable-mem-check      compile with memory alloc checking])
+AC_ARG_ENABLE(mem-check-log,
+  [  --enable-mem-check-log  compile with memory alloc checking writing to syslog])
 AC_ARG_ENABLE(debug,
   [  --enable-debug          compile with debugging flags])
 AC_ARG_ENABLE(profile,
@@ -578,6 +582,19 @@ if test "${enable_debug}" = "yes"; then
   AC_SUBST(DFLAGS)
 fi
 
+dnl ----[ Memory alloc check or not ? ]----
+MEM_CHECK_LOG=_NO_MEM_CHECK_LOG_
+if test "${enable_mem_check}" = "yes"; then
+  MEM_CHECK=_MEM_CHECK_
+  if test "${enable_mem_check_log}" = "yes"; then
+    MEM_CHECK_LOG=_MEM_CHECK_LOG_
+  fi
+else
+  MEM_CHECK=_NO_MEM_CHECK_
+fi
+AC_SUBST(MEM_CHECK)
+AC_SUBST(MEM_CHECK_LOG)
+
 dnl ----[ check for VRRP authentication support ]----
 VRRP_AUTH_SUPPORT="_WITHOUT_VRRP_AUTH_"
 if test "$enable_vrrp" != "no"; then
@@ -601,7 +618,7 @@ AC_SUBST(IPVS_SUPPORT)
 AC_SUBST(IPVS_USE_NL)
 AC_SUBST(VRRP_SUPPORT)
 
-APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} ${DFLAGS}"
+APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} -D${MEM_CHECK} -D${MEM_CHECK_LOG} ${DFLAGS}"
 BUILD_OPTS=`echo ${APP_DEFS} | sed -e 's/ "$//' -e 's/.*"//' -e 's/-D//g' -e 's/_ / /g' -e 's/ _/ /g' -e 's/^_//' -e 's/_$//'`
 AC_SUBST(APP_DEFS)
 AC_SUBST(BUILD_OPTS)
@@ -715,6 +732,16 @@ if test "${DFLAGS}" = "-D_DEBUG_"; then
   echo "Use Debug flags          : Yes"
 else
   echo "Use Debug flags          : No"
+fi
+if test "${MEM_CHECK}" = "_MEM_CHECK_"; then
+  echo "Memory alloc check       : Yes"
+  if test "${MEM_CHECK_LOG}" = "_MEM_CHECK_LOG_"; then
+    echo "Memory alloc check log   : Yes"
+  else
+    echo "Memory alloc check log   : No"
+  fi
+else
+  echo "Memory alloc check       : No"
 fi
 if test "${USE_NL3}" = "_HAVE_LIBNL3_"; then
   echo "libnl version            : 3"

--- a/genhash/http.c
+++ b/genhash/http.c
@@ -132,7 +132,7 @@ finalize(thread_t * thread)
 	if (req->verbose) {
 		printf("\n");
 		printf(HTML_HASH);
-		dump_buffer((char *) digest, digest_length);
+		dump_buffer((char *) digest, digest_length, stdout);
 
 		printf(HTML_HASH_FINAL);
 	}
@@ -152,7 +152,7 @@ http_dump_header(char *buffer, int size)
 {
 	int r;
 
-	dump_buffer(buffer, size);
+	dump_buffer(buffer, size, stdout);
 	printf(HTTP_HEADER_ASCII);
 	for (r = 0; r < size; r++)
 		printf("%c", buffer[r]);
@@ -178,7 +178,7 @@ http_process_stream(SOCK * sock_obj, int r)
 			if (r) {
 				if (req->verbose) {
 					printf(HTML_HEADER_HEXA);
-					dump_buffer(sock_obj->extracted, r);
+					dump_buffer(sock_obj->extracted, r, stdout);
 				}
 				memmove(sock_obj->buffer, sock_obj->extracted, r);
 				HASH_UPDATE(sock_obj, sock_obj->buffer, r);
@@ -199,7 +199,7 @@ http_process_stream(SOCK * sock_obj, int r)
 		}
 	} else if (sock_obj->size) {
 		if (req->verbose)
-			dump_buffer(sock_obj->buffer, r);
+			dump_buffer(sock_obj->buffer, r, stdout);
 		HASH_UPDATE(sock_obj, sock_obj->buffer, sock_obj->size);
 		sock_obj->size = 0;
 	}

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -71,7 +71,7 @@ stop_check(void)
 	free_interface_queue();
 #endif
 
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 	keepalived_free_final("Healthcheck child process");
 #endif
 
@@ -293,6 +293,10 @@ start_check_child(void)
 	/* Opening local CHECK syslog channel */
 	openlog(PROG_CHECK, LOG_PID | ((__test_bit(LOG_CONSOLE_BIT, &debug)) ? LOG_CONS : 0)
 			  , (log_facility==LOG_DAEMON) ? LOG_LOCAL2 : log_facility);
+
+#ifdef _MEM_CHECK_
+        mem_log_init(PROG_CHECK);
+#endif
 
 	/* Child process part, write pidfile */
 	if (!pidfile_write(checkers_pidfile, getpid())) {

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -75,7 +75,7 @@ stop_keepalived(void)
 	if (__test_bit(DAEMON_CHECKERS, &daemon_mode))
 		pidfile_rm(checkers_pidfile);
 
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 	keepalived_free_final("Parent process");
 #endif
 }
@@ -289,6 +289,9 @@ usage(const char *prog)
 #endif
 	fprintf(stderr, "  -m, --core-dump              Produce core dump if terminate abnormally\n");
 	fprintf(stderr, "  -M, --core-dump-pattern=PATN Also set /proc/sys/kernel/core_pattern to PATN (default 'core')\n");
+#ifdef _MEM_CHECK_LOG_
+	fprintf(stderr, "  -L, --mem-check-log          Log malloc/frees to syslog\n");
+#endif
 	fprintf(stderr, "  -v, --version                Display the version number\n");
 	fprintf(stderr, "  -h, --help                   Display this help message\n");
 }
@@ -321,6 +324,9 @@ parse_cmdline(int argc, char **argv)
  #endif
 		{"core-dump",         no_argument,       0, 'm'},
 		{"core-dump-pattern", optional_argument, 0, 'M'},
+#ifdef _MEM_CHECK_LOG_
+		{"mem-check-log",     no_argument,       0, 'm'},
+#endif
 		{"version",           no_argument,       0, 'v'},
 		{"help",              no_argument,       0, 'h'},
 		{0, 0, 0, 0}
@@ -407,6 +413,11 @@ parse_cmdline(int argc, char **argv)
 		case 'm':
 			create_core_dump = true;
 			break;
+#ifdef _MEM_CHECK_LOG_
+		case 'L':
+			__set_bit(MEM_CHECK_LOG_BIT, &debug);
+			break;
+#endif
 		default:
 			exit(0);
 			break;
@@ -446,6 +457,10 @@ main(int argc, char **argv)
 	log_message(LOG_INFO, "Starting %s, git commit %s", VERSION_STRING, GIT_COMMIT);
 #else
 	log_message(LOG_INFO, "Starting %s", VERSION_STRING);
+#endif
+
+#ifdef _MEM_CHECK_
+	mem_log_init(PROG);
 #endif
 
 	/* Handle any core file requirements */

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -149,6 +149,7 @@ extern interface_t *base_if_get_by_ifindex(const int);
 extern interface_t *base_if_get_by_ifp(interface_t *);
 extern interface_t *if_get_by_ifname(const char *);
 extern list get_if_list(void);
+extern void reset_interface_queue(void);
 #ifdef _HAVE_VRRP_VMAC_
 extern void if_vmac_reflect_flags(const int, const unsigned long);
 #endif
@@ -160,6 +161,7 @@ extern int if_monitor_thread(thread_t *);
 extern void init_interface_queue(void);
 extern void init_interface_linkbeat(void);
 extern void free_interface_queue(void);
+extern void free_old_interface_queue(void);
 extern int if_join_vrrp_group(sa_family_t, int *, interface_t *, int);
 extern int if_leave_vrrp_group(sa_family_t, int, interface_t *);
 extern int if_setsockopt_bindtodevice(int *, interface_t *);

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -123,7 +123,7 @@ stop_vrrp(void)
 
 	signal_handler_destroy();
 
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 	keepalived_free_final("VRRP Child process");
 #endif
 
@@ -436,6 +436,10 @@ start_vrrp_child(void)
 	/* Opening local VRRP syslog channel */
 	openlog(PROG_VRRP, LOG_PID | ((__test_bit(LOG_CONSOLE_BIT, &debug)) ? LOG_CONS : 0)
 			 , (log_facility==LOG_DAEMON) ? LOG_LOCAL1 : log_facility);
+
+#ifdef _MEM_CHECK_
+	mem_log_init(PROG_VRRP);
+#endif
 
 	/* Child process part, write pidfile */
 	if (!pidfile_write(vrrp_pidfile, getpid())) {

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -326,7 +326,6 @@ reload_vrrp_thread(thread_t * thread)
 		       global_data->lvs_syncd_syncid, false);
 #endif
 	free_global_data(global_data);
-	free_interface_queue();
 	free_vrrp_buffer();
 	gratuitous_arp_close();
 	ndisc_close();
@@ -341,6 +340,7 @@ reload_vrrp_thread(thread_t * thread)
 	/* Save previous conf data */
 	old_vrrp_data = vrrp_data;
 	vrrp_data = NULL;
+	reset_interface_queue();
 
 	/* Reload the conf */
 #ifdef _DEBUG_
@@ -358,6 +358,7 @@ reload_vrrp_thread(thread_t * thread)
 
 	/* free backup data */
 	free_vrrp_data(old_vrrp_data);
+	free_old_interface_queue();
 	UNSET_RELOAD;
 
 	return 0;

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -63,6 +63,9 @@ typedef uint8_t u8;
 static list if_queue;
 static struct ifreq ifr;
 
+static list old_if_queue;
+static list old_garp_delay;
+
 /* Global vars */
 list garp_delay;
 
@@ -131,6 +134,16 @@ list
 get_if_list(void)
 {
 	return if_queue;
+}
+
+void
+reset_interface_queue(void)
+{
+	old_if_queue = if_queue;
+	old_garp_delay = garp_delay;
+
+	if_queue = NULL;
+	garp_delay = NULL;
 }
 
 #ifdef _HAVE_VRRP_VMAC_
@@ -535,6 +548,13 @@ free_interface_queue(void)
 {
 	free_list(&if_queue);
 	free_list(&garp_delay);
+}
+
+void
+free_old_interface_queue(void)
+{
+	free_list(&old_if_queue);
+	free_list(&old_garp_delay);
 }
 
 void

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -306,10 +306,14 @@ netlink_link_del_vmac(vrrp_t *vrrp)
 		return -1;
 
 	/* Reset arp_ignore and arp_filter on the base interface if necessary */
-	base_ifp = if_get_by_ifindex(vrrp->ifp->base_ifindex);
+	if (vrrp->family == AF_INET) {
+		base_ifp = if_get_by_ifindex(vrrp->ifp->base_ifindex);
 
-	if (vrrp->family == AF_INET)
-		reset_interface_parameters(base_ifp);
+		if (base_ifp)
+			reset_interface_parameters(base_ifp);
+		else
+			log_message(LOG_INFO, "Unable to find base interface for vrrp instance %s", vrrp->iname);
+	}
 
 	memset(&req, 0, sizeof (req));
 

--- a/lib/bitops.h
+++ b/lib/bitops.h
@@ -66,6 +66,9 @@ enum global_bits {
 	DONT_RESPAWN_BIT = 6,
 	RELEASE_VIPS_BIT = 7,
 	MEM_ERR_DETECT_BIT = 8,
+#ifdef _MEM_CHECK_LOG_
+	MEM_CHECK_LOG_BIT = 9,
+#endif
 };
 
 #endif

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -22,31 +22,43 @@
  * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@linux-vs.org>
  */
 
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 #include <assert.h>
+#include <unistd.h>
 #endif
+
+#ifdef _DEBUG_
+#include <stdio.h>
+#endif
+
+#include <errno.h>
+#include <string.h>
 
 #include "memory.h"
 #include "utils.h"
 #include "bitops.h"
+#include "logger.h"
 
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 /* Global var */
 size_t mem_allocated;		/* Total memory used in Bytes */
 size_t max_mem_allocated;	/* Maximum memory used in Bytes */
 #endif
 
-void *
+static void *
 xalloc(unsigned long size)
 {
 	void *mem = malloc(size);
 
 	if (mem == NULL) {
-		perror("Keepalived");
+		if (__test_bit(DONT_FORK_BIT, &debug))
+			perror("Keepalived");
+		else
+			log_message(LOG_INFO, "Keepalived xalloc() error - %s", strerror(errno));
 		exit(EXIT_FAILURE);
 	}
 
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 	mem_allocated += size - sizeof(long);
 	if (mem_allocated > max_mem_allocated)
 		max_mem_allocated = mem_allocated;
@@ -85,7 +97,7 @@ zalloc(unsigned long size)
  *
  */
 
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 
 typedef struct {
 	int type;
@@ -104,6 +116,8 @@ static MEMCHECK alloc_list[MAX_ALLOC_LIST];
 static int number_alloc_list = 0;
 static int n = 0;		/* Alloc list pointer */
 static int f = 0;		/* Free list pointer */
+
+static FILE *log_op = NULL;
 
 void *
 keepalived_malloc(unsigned long size, char *file, char *function, int line)
@@ -136,10 +150,13 @@ keepalived_malloc(unsigned long size, char *file, char *function, int line)
 	alloc_list[i].csum = check;
 	alloc_list[i].type = 9;
 
-	if (__test_bit(DONT_FORK_BIT, &debug))
-		printf("zalloc[%3d:%3d], %p, %4ld at %s, %3d, %s\n",
-		       i, number_alloc_list, buf, size, file, line,
-		       function);
+	fprintf(log_op, "zalloc[%3d:%3d], %p, %4ld at %s, %3d, %s\n",
+	       i, number_alloc_list, buf, size, file, line, function);
+#ifdef _MEM_CHECK_LOG_
+	if (__test_bit(MEM_CHECK_LOG_BIT, &debug))
+		log_message(LOG_INFO, "zalloc[%3d:%3d], %p, %4ld at %s, %3d, %s\n",
+		       i, number_alloc_list, buf, size, file, line, function);
+#endif
 
 	n++;
 	return buf;
@@ -163,9 +180,8 @@ keepalived_free(void *buffer, char *file, char *function, int line)
 		alloc_list[i].func = function;
 		alloc_list[i].line = line;
 		alloc_list[i].type = 2;
-		if (__test_bit(LOG_CONSOLE_BIT, &debug))
-			printf("free NULL in %s, %3d, %s\n", file,
-			       line, function);
+		fprintf(log_op, "free NULL in %s, %3d, %s\n", file,
+		       line, function);
 
 		__set_bit(MEM_ERR_DETECT_BIT, &debug);	/* Memory Error detect */
 
@@ -179,19 +195,17 @@ keepalived_free(void *buffer, char *file, char *function, int line)
 				mem_allocated -= alloc_list[i].size - sizeof(long);
 			} else {
 				alloc_list[i].type = 1;	/* Overrun */
-				if (__test_bit(LOG_CONSOLE_BIT, &debug)) {
-					printf("free corrupt, buffer overrun [%3d:%3d], %p, %4ld at %s, %3d, %s\n",
-					       i, number_alloc_list,
-					       buf, alloc_list[i].size, file,
-					       line, function);
-					dump_buffer(alloc_list[i].ptr,
-						    alloc_list[i].size + sizeof (long));
-					printf("Check_sum\n");
-					dump_buffer((char *) &alloc_list[i].csum,
-						    sizeof(long));
+				fprintf(log_op, "free corrupt, buffer overrun [%3d:%3d], %p, %4ld at %s, %3d, %s\n",
+				       i, number_alloc_list,
+				       buf, alloc_list[i].size, file,
+				       line, function);
+				dump_buffer(alloc_list[i].ptr,
+					    alloc_list[i].size + sizeof (long), log_op);
+				fprintf(log_op, "Check_sum\n");
+				dump_buffer((char *) &alloc_list[i].csum,
+					    sizeof(long), log_op);
 
-					__set_bit(MEM_ERR_DETECT_BIT, &debug);
-				}
+				__set_bit(MEM_ERR_DETECT_BIT, &debug);
 			}
 			break;
 		}
@@ -200,7 +214,7 @@ keepalived_free(void *buffer, char *file, char *function, int line)
 
 	/*  Not found */
 	if (i == number_alloc_list) {
-		printf("Free ERROR %p\n", buffer);
+		fprintf(log_op, "Free ERROR %p not found\n", buffer);
 		number_alloc_list++;
 
 		assert(number_alloc_list < MAX_ALLOC_LIST);
@@ -219,10 +233,15 @@ keepalived_free(void *buffer, char *file, char *function, int line)
 	if (buffer != NULL)
 		free(buffer);
 
-	if (__test_bit(LOG_CONSOLE_BIT, &debug))
-		printf("free  [%3d:%3d], %p, %4ld at %s, %3d, %s\n",
+	fprintf(log_op, "free  [%3d:%3d], %p, %4ld at %s, %3d, %s\n",
+	       i, number_alloc_list, buf,
+	       alloc_list[i].size, file, line, function);
+#ifdef _MEM_CHECK_LOG_
+	if (__test_bit(MEM_CHECK_LOG_BIT, &debug))
+		log_message(LOG_INFO, "free  [%3d:%3d], %p, %4ld at %s, %3d, %s\n",
 		       i, number_alloc_list, buf,
 		       alloc_list[i].size, file, line, function);
+#endif
 
 	free_list[f].file = file;
 	free_list[f].line = line;
@@ -245,29 +264,29 @@ keepalived_free_final(char *banner)
 	int i, j;
 	i = 0;
 
-	printf("\n---[ Keepalived memory dump for (%s)]---\n\n", banner);
+	fprintf(log_op, "\n---[ Keepalived memory dump for (%s)]---\n\n", banner);
 
 	while (i < number_alloc_list) {
 		switch (alloc_list[i].type) {
 		case 3:
 			badptr++;
-			printf
-			    ("null pointer to realloc(nil,%ld)! at %s, %3d, %s\n",
+			fprintf
+			    (log_op, "null pointer to realloc(nil,%ld)! at %s, %3d, %s\n",
 			     alloc_list[i].size, alloc_list[i].file,
 			     alloc_list[i].line, alloc_list[i].func);
 			break;
 		case 4:
 			badptr++;
-			printf
-			    ("pointer not found in table to free(%p) [%3d:%3d], at %s, %3d, %s\n",
+			fprintf
+			    (log_op, "pointer not found in table to free(%p) [%3d:%3d], at %s, %3d, %s\n",
 			     alloc_list[i].ptr, i, number_alloc_list,
 			     alloc_list[i].file, alloc_list[i].line,
 			     alloc_list[i].func);
 			for (j = 0; j < 256; j++)
 				if (free_list[j].ptr == alloc_list[i].ptr)
 					if (free_list[j].type == 8)
-						printf
-						    ("  -> pointer allready released at [%3d:%3d], at %s, %3d, %s\n",
+						fprintf
+						    (log_op, "  -> pointer allready released at [%3d:%3d], at %s, %3d, %s\n",
 						     (int) free_list[j].csum,
 						     number_alloc_list,
 						     free_list[j].file,
@@ -276,25 +295,25 @@ keepalived_free_final(char *banner)
 			break;
 		case 2:
 			badptr++;
-			printf("null pointer to free(nil)! at %s, %3d, %s\n",
+			fprintf(log_op, "null pointer to free(nil)! at %s, %3d, %s\n",
 			       alloc_list[i].file, alloc_list[i].line,
 			       alloc_list[i].func);
 			break;
 		case 1:
 			overrun++;
-			printf("%p [%3d:%3d], %4ld buffer overrun!:\n",
+			fprintf(log_op, "%p [%3d:%3d], %4ld buffer overrun!:\n",
 			       alloc_list[i].ptr, i, number_alloc_list,
 			       alloc_list[i].size);
-			printf(" --> source of malloc: %s, %3d, %s\n",
+			fprintf(log_op, " --> source of malloc: %s, %3d, %s\n",
 			       alloc_list[i].file, alloc_list[i].line,
 			       alloc_list[i].func);
 			break;
 		case 9:
 			sum += alloc_list[i].size;
-			printf("%p [%3d:%3d], %4ld not released!:\n",
+			fprintf(log_op, "%p [%3d:%3d], %4ld not released!:\n",
 			       alloc_list[i].ptr, i, number_alloc_list,
 			       alloc_list[i].size);
-			printf(" --> source of malloc: %s, %3d, %s\n",
+			fprintf(log_op, " --> source of malloc: %s, %3d, %s\n",
 			       alloc_list[i].file, alloc_list[i].line,
 			       alloc_list[i].func);
 			break;
@@ -302,18 +321,18 @@ keepalived_free_final(char *banner)
 		i++;
 	}
 
-	printf("\n\n---[ Keepalived memory dump summary for (%s) ]---\n", banner);
-	printf("Total number of bytes not freed...: %d\n", sum);
-	printf("Number of entries not freed.......: %d\n", n);
-	printf("Maximum allocated entries.........: %d\n", number_alloc_list);
-	printf("Maximum memory allocated..........: %zu\n", max_mem_allocated);
-	printf("Number of bad entries.............: %d\n", badptr);
-	printf("Number of buffer overrun..........: %d\n\n", overrun);
+	fprintf(log_op, "\n\n---[ Keepalived memory dump summary for (%s) ]---\n", banner);
+	fprintf(log_op, "Total number of bytes not freed...: %d\n", sum);
+	fprintf(log_op, "Number of entries not freed.......: %d\n", n);
+	fprintf(log_op, "Maximum allocated entries.........: %d\n", number_alloc_list);
+	fprintf(log_op, "Maximum memory allocated..........: %zu\n", max_mem_allocated);
+	fprintf(log_op, "Number of bad entries.............: %d\n", badptr);
+	fprintf(log_op, "Number of buffer overrun..........: %d\n\n", overrun);
 
 	if (sum || n || badptr || overrun)
-		printf("=> Program seems to have some memory problem !!!\n\n");
+		fprintf(log_op, "=> Program seems to have some memory problem !!!\n\n");
 	else
-		printf("=> Program seems to be memory allocation safe...\n\n");
+		fprintf(log_op, "=> Program seems to be memory allocation safe...\n\n");
 }
 
 void *
@@ -325,7 +344,7 @@ keepalived_realloc(void *buffer, unsigned long size, char *file, char *function,
 	long check;
 
 	if (buffer == NULL) {
-		printf("realloc %p %s, %3d %s\n", buffer, file, line, function);
+		fprintf(log_op, "realloc %p %s, %3d %s\n", buffer, file, line, function);
 		i = number_alloc_list++;
 
 		assert(number_alloc_list < MAX_ALLOC_LIST);
@@ -349,7 +368,7 @@ keepalived_realloc(void *buffer, unsigned long size, char *file, char *function,
 
 	/* not found */
 	if (i == number_alloc_list) {
-		printf("realloc ERROR no matching zalloc %p \n", buffer);
+		fprintf(log_op, "realloc ERROR no matching zalloc %p \n", buffer);
 		number_alloc_list++;
 
 		assert(number_alloc_list < MAX_ALLOC_LIST);
@@ -376,12 +395,11 @@ keepalived_realloc(void *buffer, unsigned long size, char *file, char *function,
 	*(long *) ((char *) buf + size) = check;
 	alloc_list[i].csum = check;
 
-	if (__test_bit(LOG_CONSOLE_BIT, &debug))
-		printf("realloc [%3d:%3d] %p, %4ld %s %d %s -> %p %4ld %s %d %s\n",
-		       i, number_alloc_list, alloc_list[i].ptr,
-		       alloc_list[i].size, file, line, function, buf, size,
-		       alloc_list[i].file, alloc_list[i].line,
-		       alloc_list[i].func);
+	fprintf(log_op, "realloc [%3d:%3d] %p, %4ld %s %d %s -> %p %4ld %s %d %s\n",
+	       i, number_alloc_list, alloc_list[i].ptr,
+	       alloc_list[i].size, file, line, function, buf, size,
+	       alloc_list[i].file, alloc_list[i].line,
+	       alloc_list[i].func);
 
 	alloc_list[i].ptr = buf;
 	alloc_list[i].size = size;
@@ -392,4 +410,37 @@ keepalived_realloc(void *buffer, unsigned long size, char *file, char *function,
 	return buf;
 }
 
+void
+mem_log_init(const char* prog_name)
+{
+	size_t log_name_len;
+	char *log_name;
+
+	if (__test_bit(LOG_CONSOLE_BIT, &debug)) {
+		log_op = stderr;
+		return;
+	}
+
+	if (log_op)
+		fclose(log_op);
+
+	log_name_len = 5 + strlen(prog_name) + 5 + 5 + 4 + 1;	/* "/tmp/" + prog_name + "_mem." + PID + ".log" + '\0" */
+	log_name = malloc(log_name_len);
+	if (!log_name) {
+		log_message(LOG_INFO, "Unable to malloc log file name");
+		log_op = stderr;
+		return;
+	}
+
+	snprintf(log_name, log_name_len, "/tmp/%s_mem.%d.log", prog_name, getpid());
+	log_op = fopen(log_name, "a");
+	if (log_op == NULL) {
+		log_message(LOG_INFO, "Unable to open %s for appending", log_name);
+		log_op = stderr;
+	}
+	else
+		fprintf(log_op, "\n");
+
+	free(log_name);
+}
 #endif

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -43,7 +43,7 @@ extern void *zalloc(unsigned long size);
 #define REALLOC(b,n) ( keepalived_realloc((b), (n), \
 		      (__FILE__), (char *)(__FUNCTION__), (__LINE__)) )
 
-extern unsigned long mem_allocated;
+extern size_t mem_allocated;
 
 /* Memory debug prototypes defs */
 extern void *keepalived_malloc(unsigned long, char *, char *, int);

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -27,9 +27,6 @@
 /* system includes */
 #include <stdlib.h>
 
-/* extern types */
-extern void *zalloc(unsigned long size);
-
 /* Local defines */
 #ifdef _MEM_CHECK_
 
@@ -53,6 +50,8 @@ extern void keepalived_free_final(char *);
 extern void mem_log_init(const char *);
 
 #else
+
+extern void *zalloc(unsigned long size);
 
 #define MALLOC(n)    (zalloc(n))
 #define FREE(p)      (free(p), (p) = NULL)

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -25,20 +25,13 @@
 #define _MEMORY_H
 
 /* system includes */
-#include <stdio.h>
-#include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
 
 /* extern types */
-extern void *xalloc(unsigned long size);
 extern void *zalloc(unsigned long size);
 
-/* Global alloc macro */
-#define ALLOC(n) (xalloc(n))
-
 /* Local defines */
-#ifdef _DEBUG_
+#ifdef _MEM_CHECK_
 
 #define MAX_ALLOC_LIST 2048
 
@@ -57,6 +50,7 @@ extern void *keepalived_malloc(unsigned long, char *, char *, int);
 extern int keepalived_free(void *, char *, char *, int);
 extern void *keepalived_realloc(void *, unsigned long, char *, char *, int);
 extern void keepalived_free_final(char *);
+extern void mem_log_init(const char *);
 
 #else
 

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdbool.h>
 #include "parser.h"
 #include "memory.h"
 #include "logger.h"
@@ -390,21 +391,24 @@ check_include(char *buf)
 int
 read_line(char *buf, int size)
 {
-	int ch;
+	size_t len ;
+	bool eof = false;
 
 	do {
-		int count = 0;
-		memset(buf, 0, size);
-		while ((ch = fgetc(current_stream)) != EOF && (int) ch != '\n'
-			   && (int) ch != '\r') {
-			if (count < size)
-				buf[count] = (int) ch;
-			else
-				break;
-			count++;
+		if (fgets(buf, size, current_stream)) {
+			for (len = strlen(buf) - 1; len >= 0; len--) {
+				if (buf[len] != '\r' && buf[len] != '\n')
+					break;
+				buf[len] = '\0';
+			}
+		}
+		else
+		{
+			eof = true;
+			buf[0] = '\0';
 		}
 	} while (check_include(buf) == 1);
-	return (ch == EOF) ? 0 : 1;
+	return (eof) ? 0 : 1;
 }
 
 vector_t *

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -542,10 +542,10 @@ process_stream(vector_t *keywords_vec, int need_bob)
 	current_keywords = keywords_vec;
 	int bob_needed = 0;
 
-	buf = zalloc(MAXBUF);
+	buf = MALLOC(MAXBUF);
 	while (read_line(buf, MAXBUF)) {
 		strvec = alloc_strvec(buf);
-		memset(buf,0, MAXBUF);
+		memset(buf, 0, MAXBUF);
 
 		if (!strvec)
 			continue;
@@ -627,7 +627,7 @@ process_stream(vector_t *keywords_vec, int need_bob)
 	}
 
 	current_keywords = prev_keywords;
-	free(buf);
+	FREE(buf);
 	return;
 }
 

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -137,10 +137,13 @@ dump_keywords(vector_t *keydump, int level, FILE *fp)
 
 	if (!level) {
 		sprintf(file_name, "/tmp/keywords.%d", getpid());
+		snprintf(file_name, sizeof(file_name), "/tmp/keywords.%d", getpid());
 		fp = fopen(file_name, "w");
 		if (!fp)
 			return;
 	}
+
+	vector_dump(fp, keywords);
 
 	for (i = 0; i < vector_size(keydump); i++) {
 		keyword_vec = vector_slot(keydump, i);
@@ -638,7 +641,6 @@ init_data(const char *conf_file, vector_t * (*init_keywords) (void))
 
 #if DUMP_KEYWORDS
 	/* Dump configuration */
-	vector_dump(keywords);
 	dump_keywords(keywords, 0, NULL);
 #endif
 

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -221,6 +221,7 @@ thread_cleanup_master(thread_master_t * m)
 	thread_destroy_list(m, m->read);
 	thread_destroy_list(m, m->write);
 	thread_destroy_list(m, m->timer);
+	thread_destroy_list(m, m->child);
 	thread_destroy_list(m, m->event);
 	thread_destroy_list(m, m->ready);
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -33,7 +33,7 @@ unsigned long debug = 0;
 
 /* Display a buffer into a HEXA formated output */
 void
-dump_buffer(char *buff, int count)
+dump_buffer(char *buff, int count, FILE* fp)
 {
 	int i, j, c;
 	int printnext = 1;
@@ -46,28 +46,28 @@ dump_buffer(char *buff, int count)
 	for (i = 0; i < c; i++) {
 		if (printnext) {
 			printnext--;
-			printf("%.4x ", i & 0xffff);
+			fprintf(fp, "%.4x ", i & 0xffff);
 		}
 		if (i < count)
-			printf("%3.2x", buff[i] & 0xff);
+			fprintf(fp, "%3.2x", buff[i] & 0xff);
 		else
-			printf("   ");
+			fprintf(fp, "   ");
 		if (!((i + 1) % 8)) {
 			if ((i + 1) % 16)
-				printf(" -");
+				fprintf(fp, " -");
 			else {
-				printf("   ");
+				fprintf(fp, "   ");
 				for (j = i - 15; j <= i; j++)
 					if (j < count) {
 						if ((buff[j] & 0xff) >= 0x20
 						    && (buff[j] & 0xff) <= 0x7e)
-							printf("%c",
+							fprintf(fp, "%c",
 							       buff[j] & 0xff);
 						else
-							printf(".");
+							fprintf(fp, ".");
 					} else
-						printf(" ");
-				printf("\n");
+						fprintf(fp, " ");
+				fprintf(fp, "\n");
 				printnext = 1;
 			}
 		}

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -49,7 +49,7 @@
 extern unsigned long debug;
 
 /* Prototypes defs */
-extern void dump_buffer(char *, int);
+extern void dump_buffer(char *, int, FILE *);
 extern u_short in_csum(u_short *, int, int, int *);
 extern char *inet_ntop2(uint32_t);
 extern uint8_t inet_stor(const char *);

--- a/lib/vector.c
+++ b/lib/vector.c
@@ -255,15 +255,15 @@ vector_free(vector_t *v)
 
 /* dump vector slots */
 void
-vector_dump(vector_t *v)
+vector_dump(FILE *fp, vector_t *v)
 {
 	unsigned int i;
 
-	printf("Vector Size : %d, active %d\n", v->allocated, v->active);
+	fprintf(fp, "Vector Size : %d, active %d\n", v->allocated, v->active);
 
 	for (i = 0; i < v->allocated; i++) {
 		if (v->slot[i] != NULL) {
-			printf("  Slot [%d]: %p\n", i, vector_slot(v, i));
+			fprintf(fp, "  Slot [%d]: %p\n", i, vector_slot(v, i));
 		}
 	}
 }

--- a/lib/vector.h
+++ b/lib/vector.h
@@ -23,6 +23,8 @@
 #ifndef _VECTOR_H
 #define _VECTOR_H
 
+#include <stdio.h>
+
 /* vector definition */
 typedef struct _vector {
 	unsigned int	active;
@@ -49,7 +51,7 @@ extern void vector_set_slot(vector_t *, void *);
 extern void vector_unset(vector_t *, unsigned int);
 extern unsigned int vector_count(vector_t *);
 extern void vector_free(vector_t *);
-extern void vector_dump(vector_t *);
+extern void vector_dump(FILE *fp, vector_t *);
 extern void free_strvec(vector_t *);
 
 #endif


### PR DESCRIPTION
This resolves a segfault reported in issue #365, caused by referencing memory that has been freed and re-alloc'd.

I believe there is still a further cause of a segfault, in thread_child_handler(), but it seems to occur less frequently that the segfault which is fixed here. See issue #365 for further details.