### PR TITLE
Resolve a segfault when reloading keepalived

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -210,8 +210,7 @@ reload_check_thread(thread_t * thread)
 #ifdef _WITH_VRRP_
 	kernel_netlink_close();
 #endif
-	thread_destroy_master(master);
-	master = thread_make_master();
+	thread_cleanup_master(master);
 	free_global_data(global_data);
 	free_checkers_queue();
 #ifdef _WITH_VRRP_
@@ -306,7 +305,7 @@ start_check_child(void)
 
 	/* Create the new master thread */
 	signal_handler_destroy();
-	thread_destroy_master(master);
+	thread_destroy_master(master);	/* This destroys any residual settings from the parent */
 	master = thread_make_master();
 
 	/* change to / dir */

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -325,16 +325,16 @@ parse_cmdline(int argc, char **argv)
 		{"core-dump",         no_argument,       0, 'm'},
 		{"core-dump-pattern", optional_argument, 0, 'M'},
 #ifdef _MEM_CHECK_LOG_
-		{"mem-check-log",     no_argument,       0, 'm'},
+		{"mem-check-log",     no_argument,       0, 'L'},
 #endif
 		{"version",           no_argument,       0, 'v'},
 		{"help",              no_argument,       0, 'h'},
 		{0, 0, 0, 0}
 	};
 
-	while ((c = getopt_long(argc, argv, "vhlndVIDRS:f:PCp:c:r:mM"
+	while ((c = getopt_long(argc, argv, "vhlndVIDRS:f:PCp:c:r:mML"
 #ifdef _WITH_SNMP_
-								   "xA:"
+					    "xA:"
 #endif
 									, long_options, NULL)) != EOF) {
 		switch (c) {

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -145,7 +145,6 @@ typedef struct _vrrp_t {
 	sa_family_t		family;			/* AF_INET|AF_INET6 */
 	char			*iname;			/* Instance Name */
 	vrrp_sgroup_t		*sync;			/* Sync group we belong to */
-	char			base_iface[IFNAMSIZ];	/* base interface name */
 	vrrp_stats		*stats;			/* Statistics */
 	interface_t		*ifp;			/* Interface we belong to */
 	int			dont_track_primary;	/* If set ignores ifp faults */

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -214,7 +214,7 @@ thread_destroy_list(thread_master_t * m, thread_list_t thread_list)
 }
 
 /* Cleanup master */
-static void
+void
 thread_cleanup_master(thread_master_t * m)
 {
 	/* Unuse current thread lists */
@@ -232,6 +232,8 @@ thread_cleanup_master(thread_master_t * m)
 
 	/* Clean garbage */
 	thread_clean_unuse(m);
+
+	memset(m, 0, sizeof(*m));
 }
 
 /* Stop thread scheduler. */

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -106,6 +106,7 @@ extern thread_master_t *master;
 extern void report_child_status(int, pid_t, const char *);
 extern thread_master_t *thread_make_master(void);
 extern thread_t *thread_add_terminate_event(thread_master_t *);
+extern void thread_cleanup_master(thread_master_t *);
 extern void thread_destroy_master(thread_master_t *);
 extern thread_t *thread_add_read(thread_master_t *, int (*func) (thread_t *), void *, int, long);
 extern thread_t *thread_add_write(thread_master_t *, int (*func) (thread_t *), void *, int, long);


### PR DESCRIPTION
This resolves the second cause of a segfault reported in issue #365, caused by referencing memory that has since been freed and re-alloc'd.

This should resolve issue #365.
