### PR TITLE
Add configuration option to flush LVS configuration

### DIFF
--- a/doc/KEEPALIVED-MIB
+++ b/doc/KEEPALIVED-MIB
@@ -22,15 +22,17 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201606030000Z"
+     LAST-UPDATED "201606290000Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
-     REVISION-UPDATED "201606030000Z"
+     REVISION "201606290000Z"
+     DESCRIPTION "add lvs_flush"
+     REVISION "201606030000Z"
      DESCRIPTION "update comment for vrrpInstancePreemptDelay"
-     REVISION-UPDATED "201605221540Z"
+     REVISION "201605221540Z"
      DESCRIPTION "smtpServerPort added"
      REVISION "201510270000Z"
      DESCRIPTION "routerId added to traps variables"
@@ -179,6 +181,14 @@ linkBeat OBJECT-TYPE
         change while polling(2) means that the status of the link is
         checked periodically."
     ::= { global 5 }
+
+lvsFlush OBJECT-TYPE
+    SYNTAX INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicate whether LVS config is flushed at startup."
+    ::= { global 6 }
 
 -- ----------------------------------------------------------------------
 -- VRRP part
@@ -2108,7 +2118,8 @@ globalGroup OBJECT-GROUP
     emailAddress,
     smtpServerPort,
     trapEnable,
-    linkBeat
+    linkBeat,
+    lvsFlush
     }
     STATUS current
     DESCRIPTION

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -50,6 +50,7 @@ global_defs {				# Block identification
     lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE>	[<SYNC_ID>]
 					   # Binding interface, vrrp instance and optional
 					   #  syncid (0 to 255) for lvs syncd
+    lvs_flush				   # flush any existing LVS configuration at startup
     vrrp_garp_master_delay <INTEGER>	   # delay in seconds for second set of gratuitous ARP
 					   #  messages after MASTER state transition, default 5
     vrrp_garp_master_repeat <INTEGER>	   # how many gratuitous ARP messages after MASTER

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -58,6 +58,7 @@ and
  lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE> [<SYNC_ID>]
                               # Binding interface, vrrp instance and optional
                               #  syncid for lvs syncd
+ lvs_flush                    # flush any existing LVS configuration at startup
 
  # delay for second set of gratuitous ARPs after transition to MASTER
  vrrp_garp_master_delay 10    # seconds, default 5, 0 for no second set

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -95,10 +95,6 @@ start_check(void)
 		return;
 	}
 
-	/* Remove any entries left over from previous invocation */
-	if (!reload)
-		ipvs_flush_cmd();
-
 	init_checkers_queue();
 #ifdef _WITH_VRRP_
 	init_interface_queue();
@@ -119,6 +115,10 @@ start_check(void)
 #ifdef _DEBUG_
 	log_message(LOG_INFO, "Configuration is using : %lu Bytes", mem_allocated);
 #endif
+
+	/* Remove any entries left over from previous invocation */
+	if (!reload && global_data->lvs_flush)
+		ipvs_flush_cmd();
 
 #ifdef _WITH_SNMP_CHECKER_
 	if (!reload && global_data->enable_snmp_checker)

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -247,6 +247,7 @@ dump_global_data(data_t * data)
 		log_message(LOG_INFO, " LVS syncd syncid = %d"
 				    , data->lvs_syncd_syncid);
 	}
+	log_message(LOG_INFO, "LVS flush = %s", data->lvs_flush ? "true" : "false");
 	if (data->vrrp_mcast_group4.ss_family) {
 		log_message(LOG_INFO, " VRRP IPv4 mcast group = %s"
 				    , inet_sockaddrtos(&data->vrrp_mcast_group4));

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -133,6 +133,11 @@ lvs_syncd_handler(vector_t *strvec)
 	}
 }
 static void
+lvs_flush_handler(vector_t *strvec)
+{
+	global_data->lvs_flush = true;
+}
+static void
 vrrp_mcast_group4_handler(vector_t *strvec)
 {
 	struct sockaddr_storage *mcast = &global_data->vrrp_mcast_group4;
@@ -446,6 +451,7 @@ global_init_keywords(void)
 	install_keyword("smtp_connect_timeout", &smtpto_handler);
 	install_keyword("notification_email", &email_handler);
 	install_keyword("lvs_sync_daemon", &lvs_syncd_handler);
+	install_keyword("lvs_flush", &lvs_flush_handler);
 	install_keyword("vrrp_mcast_group4", &vrrp_mcast_group4_handler);
 	install_keyword("vrrp_mcast_group6", &vrrp_mcast_group6_handler);
 	install_keyword("vrrp_garp_master_delay", &vrrp_garp_delay_handler);

--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -96,6 +96,7 @@ snmp_header_list_table(struct variable *vp, oid *name, size_t *length,
 #define SNMP_MAIL_EMAILADDRESS 7
 #define SNMP_TRAPS 8
 #define SNMP_LINKBEAT 9
+#define SNMP_LVSFLUSH 10
 
 static u_char*
 snmp_scalar(struct variable *vp, oid *name, size_t *length,
@@ -142,6 +143,9 @@ snmp_scalar(struct variable *vp, oid *name, size_t *length,
 	case SNMP_LINKBEAT:
 		long_ret = global_data->linkbeat_use_polling?2:1;
 		return (u_char *)&long_ret;
+	case SNMP_LVSFLUSH:
+		long_ret = global_data->lvs_flush?1:2;
+		return (u_char *)&long_ret;
 	default:
 		break;
 	}
@@ -186,6 +190,8 @@ static struct variable8 global_vars[] = {
 	{SNMP_TRAPS, ASN_INTEGER, RONLY, snmp_scalar, 1, {4}},
 	/* linkBeat */
 	{SNMP_LINKBEAT, ASN_INTEGER, RONLY, snmp_scalar, 1, {5}},
+	/* lvsFlush */
+	{SNMP_LVSFLUSH, ASN_INTEGER, RONLY, snmp_scalar, 1, {6}},
 };
 
 static int

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -68,7 +68,8 @@ typedef struct _data {
 	char				*lvs_syncd_if;		/* handle LVS sync daemon state using this */
 	vrrp_t				*lvs_syncd_vrrp;	/* instance FSM & running on specific interface */
 	int				lvs_syncd_syncid;	/* => eth0 for example. */
-	char				*lvs_syncd_vrrp_name; /* Only used during configuration */
+	char				*lvs_syncd_vrrp_name;	/* Only used during configuration */
+	bool				lvs_flush;		/* flush any residual LVS config at startup */
 	int				vrrp_garp_delay;
 	timeval_t			vrrp_garp_refresh;
 	int				vrrp_garp_rep;


### PR DESCRIPTION
This will resolve issue #363 when a second instance of keepalived running was removing and LVS config setup by an currently running instance of keepalived.