### PR TITLE
fix healthchecker reload when some healthchecks are failed

### DIFF
--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -667,6 +667,22 @@ clear_diff_rs(virtual_server_t * old_vs, list new_rs_list)
 			if (new_rs->alive) {
 				/* clear failed_checkers list */
 				free_list_elements(new_rs->failed_checkers);
+			} else {
+				/*
+				 * if not alive, we must copy the failed checker list
+				 * If we do not, the new RS is in a state where it’s reported
+				 * as down with no check failed. As a result, the server will never
+				 * be put up back when it’s alive again in check_tcp.c#83 because
+				 * of the check that put a rs up only if it was not previously up
+				 * based on the failed_checkers list
+				 */
+				element hc_e;
+				list hc_l = rs->failed_checkers;
+				list new_hc_l = new_rs->failed_checkers;
+				for (hc_e = LIST_HEAD(hc_l); hc_e; ELEMENT_NEXT(hc_e)) {
+					list_add(new_hc_l, ELEMENT_DATA(hc_e));
+					ELEMENT_DATA(hc_e) = NULL;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hi,

Some background: have a VS with some RS. One or more RS has it’s health-check failing. In my case, I’m using TCP checks, one of the RS is down, so TCP handshake is failing.

Now reload the configuration. In `clear_diff_rs function`, the RS state is reported: `new_rs->alive = rs->alive;`. But if the RS is failing, the list of checks failing is not copied.

This is a problem, because in checkers, the failed checker of the RS is put back up only if it was previously recorded as down. See [svr_checker_up](https://github.com/acassen/keepalived/blob/master/keepalived/check/ipwrapper.c#L463) and [tcp_epilog](https://github.com/casta/keepalived/blob/master/keepalived/check/check_tcp.c#L118) for example.

So the consequence for my previous case: server is recorded as failed, but without any checks failing. So it’s never put back up, and definitively lost until next keepalived cold restart.

My PR propose to copy the failed_checkers structure along with the alive status across configuration reload so that we remain in a consistent failure state after reload. Notice that I set the data element pointer to NULL on the old structure, so that it’s not destroyed at the end of the reload, and avoiding an unneeded allocation.

Thanks !