### PR TITLE
Remove VIPs on reload if no longer in configuration

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -93,7 +93,7 @@ global_defs {				# Block identification
 					   #   the following keywords are available
 					   # Note: keepalived, checker and rfc support can be
 					   #   individually enabled/disabled
-    snmp_socket <ADDRESS>:<PORT>	   # specify socket to use for connecting to SNMP master agent (default 127.0.0.1:161)
+    snmp_socket <PROTOCOL>:<ADDRESS>[:<PORT>] # specify socket to use for connecting to SNMP master agent (default unix:/var/agentx/master)
     enable_snmp_keepalived		   # enable SNMP handling of vrrp element of KEEPALIVED MIB
     enable_snmp_checker			   # enable SNMP handling of checker element of KEEPALIVED MIB
     enable_snmp_rfc			   # enable SNMP handling of RFC2787 and RFC6527 VRRP MIBs

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -143,7 +143,7 @@ and
 
  # If Keepalived has been build with SNMP support, the following keywords are available
  # Note: Keepalived, checker and RFC support can be individually enabled/disabled
- snmp_socket 1.2.3.4:161      # specify socket to use for connecting to SNMP master agent (default 127.0.0.1:161)
+ snmp_socket udp:1.2.3.4:705  # specify socket to use for connecting to SNMP master agent (default unix:/var/agentx/master)
  enable_snmp_keepalived       # enable SNMP handling of vrrp element of KEEPALIVED MIB
  enable_snmp_checker          # enable SNMP handling of checker element of KEEPALIVED MIB
  enable_snmp_rfc              # enable SNMP handling of RFC2787 and RFC6527 VRRP MIBs

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -84,6 +84,7 @@ static void
 set_vrrp_defaults(data_t * data)
 {
 	data->vrrp_garp_rep = VRRP_GARP_REP;
+	data->vrrp_garp_refresh.tv_sec = VRRP_GARP_REFRESH;
 	data->vrrp_garp_refresh_rep = VRRP_GARP_REFRESH_REP;
 	data->vrrp_garp_delay = VRRP_GARP_DELAY;
 	data->vrrp_garp_lower_prio_delay = -1;

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -453,6 +453,10 @@ main(int argc, char **argv)
 
 	openlog(PROG, LOG_PID | ((__test_bit(LOG_CONSOLE_BIT, &debug)) ? LOG_CONS : 0)
 		    , log_facility);
+
+	if (__test_bit(LOG_CONSOLE_BIT, &debug))
+		enable_console_log();
+
 #ifdef GIT_COMMIT
 	log_message(LOG_INFO, "Starting %s, git commit %s", VERSION_STRING, GIT_COMMIT);
 #else
@@ -472,9 +476,6 @@ main(int argc, char **argv)
 		report_stopped = false;
 		goto end;
 	}
-
-	if (__test_bit(LOG_CONSOLE_BIT, &debug))
-		enable_console_log();
 
 	/* daemonize process */
 	if (!__test_bit(DONT_FORK_BIT, &debug))

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -83,6 +83,7 @@ typedef struct {
 #define VRRP_ADVER_DFL		1		/* advert. interval (in sec) -- rfc2338.5.3.7 */
 #define VRRP_GARP_DELAY		(5 * TIMER_HZ)	/* Default delay to launch gratuitous arp */
 #define VRRP_GARP_REP		5		/* Default repeat value for MASTER state gratuitous arp */
+#define VRRP_GARP_REFRESH	0		/* Default interval for refresh gratuitous arp (0 = none) */
 #define VRRP_GARP_REFRESH_REP	1		/* Default repeat value for refresh gratuitous arp */
 
 /*

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2500,7 +2500,7 @@ clear_diff_vrrp_vip(vrrp_t *old_vrrp, vrrp_t *vrrp)
 #endif
 	struct ipt_handle *h = NULL;
 
-	if (!old_vrrp->iptable_rules_set)
+	if (!old_vrrp->vipset)
 		return;
 
 #ifdef _HAVE_LIBIPTC_

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -480,6 +480,7 @@ vrrp_garp_refresh_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
 	vrrp->garp_refresh.tv_sec = atoi(vector_slot(strvec, 1));
+	vrrp->garp_refresh.tv_usec = 0;
 }
 static void
 vrrp_garp_rep_handler(vector_t *strvec)


### PR DESCRIPTION
When keepalived was reloading a configuration, and VIPs were removed and accept mode was set on the VRRP instance, the removed VIPs were not deleted. This commit resolves the issue, and should resolve issue #382.

Logging startup and "already running" messages will help understand problems of keepalived running in a container - see issue #383.