### PR TITLE
Add internet network control support for IPv6

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1041,7 +1041,7 @@ vrrp_alloc_send_buffer(vrrp_t * vrrp)
 	vrrp->send_buffer = MALLOC(VRRP_SEND_BUFFER_SIZE(vrrp));
 }
 
-/* send VRRP advertissement */
+/* send VRRP advertisement */
 int
 vrrp_send_adv(vrrp_t * vrrp, int prio)
 {
@@ -1691,7 +1691,12 @@ open_vrrp_send_socket(sa_family_t family, int proto, int idx, int unicast)
 	}
 
 	if_setsockopt_priority(&fd);
-	if (fd < 0)
+
+    /* set tos to internet network control */
+	int tos = 0xc0; // 192, which translates to DCSP value 48, or cs6
+	setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, &tos, sizeof(tos));
+
+    if (fd < 0)
 		return -1;
 
 	return fd;


### PR DESCRIPTION
VRRP IPv6 packets should be prioritised over user packets, just like for IPv4