### PR TITLE
Add all ip rules/routes options, and minor fixes

### DIFF
--- a/configure
+++ b/configure
@@ -656,6 +656,15 @@ USE_LIBIPTC
 IPV4_DEVCONF
 LINUX_NET_IF_H_COLLISION
 IF_H_LINK_H_COLLISION
+FRA_TUN_ID
+FRA_SUPPRESS_IFGROUP
+FRA_SUPPRESS_PREFIXLEN
+FRA_OIFNAME
+RTA_VIA
+RTA_PREF
+RTA_NEWDST
+RTA_EXPIRES
+RTA_ENCAP
 USE_NL3
 EGREP
 GREP
@@ -4208,6 +4217,55 @@ done
 
 fi
 
+for flag in RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF RTA_VIA FRA_OIFNAME FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID; do
+  eval ${flag}="_WITHOUT_${flag}_"
+  if test "${IPVS_USE_NL}" = "LIBIPVS_USE_NL"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $flag" >&5
+$as_echo_n "checking for $flag... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+        #include <linux/rtnetlink.h>
+        #include <sys/socket.h>
+        #include <linux/fib_rules.h>
+
+int
+main ()
+{
+
+	int flag = ${flag};
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+	eval ${flag}_SUPPORT="yes"
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext;
+    eval SUPPORT=\$${flag}_SUPPORT
+    if test "${SUPPORT}" = "yes"; then
+      eval ${flag}="_HAVE_${flag}_"
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    fi
+  fi
+done
+
+
+
+
+
+
+
+
+
+
 IF_H_LINK_H_COLLISION="_WITHOUT_IF_H_LINK_H_COLLISION_"
 if test "${USE_NL3}" = "_HAVE_LIBNL3_"; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for linux/if.h and netlink/route/link.h namespace collision" >&5
@@ -4717,6 +4775,7 @@ $as_echo_n "checking for FIB routing support... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+    #include <sys/socket.h>
     #include <linux/fib_rules.h>
     int type;
 
@@ -5487,7 +5546,7 @@ fi
 
 
 
-APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${IPVS_SYNCD_ATTRIBUTES} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} -D${MEM_CHECK} -D${MEM_CHECK_LOG} -D${PIPE2_SUPPORT} ${DFLAGS}"
+APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${IPVS_SYNCD_ATTRIBUTES} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} -D${MEM_CHECK} -D${MEM_CHECK_LOG} -D${PIPE2_SUPPORT} -D${RTA_ENCAP} -D${RTA_EXPIRES} -D${RTA_NEWDST} -D${RTA_PREF} -D${RTA_VIA} -D${FRA_OIFNAME} -D${FRA_SUPPRESS_PREFIXLEN} -D${FRA_SUPPRESS_IFGROUP} -D${FRA_TUN_ID} ${DFLAGS}"
 BUILD_OPTS=`echo ${APP_DEFS} | sed -e 's/ "$//' -e 's/.*"//' -e 's/-D//g' -e 's/_ / /g' -e 's/ _/ /g' -e 's/^_//' -e 's/_$//'`
 
 

--- a/configure
+++ b/configure
@@ -735,6 +735,7 @@ enable_snmp_rfcv2
 enable_snmp_rfcv3
 enable_sha1
 enable_vrrp_auth
+enable_routes
 enable_libiptc
 enable_libipset
 enable_mem_check
@@ -1370,6 +1371,7 @@ Optional Features:
   --enable-snmp-rfcv3     compile with SNMP RFC6257 (VRRPv3) support
   --enable-sha1           compile with SHA1 support
   --disable-vrrp-auth     compile without VRRP authentication
+  --disable-routes        compile without ip rules/routes
   --disable-libiptc       compile without libiptc
   --disable-libipset      compile without libipset
   --enable-mem-check      compile with memory alloc checking
@@ -3357,6 +3359,11 @@ if test "${enable_vrrp_auth+set}" = set; then :
   enableval=$enable_vrrp_auth;
 fi
 
+# Check whether --enable-routes was given.
+if test "${enable_routes+set}" = set; then :
+  enableval=$enable_routes;
+fi
+
 # Check whether --enable-libiptc was given.
 if test "${enable_libiptc+set}" = set; then :
   enableval=$enable_libiptc;
@@ -4769,21 +4776,24 @@ $as_echo "no" >&6; }
 
 
 
-# Introduced in Linux 2.6.19
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for FIB routing support" >&5
+FIB_ROUTING_SUPPORT="_WITHOUT_FIB_ROUTING_"
+if test ${VRRP_SUPPORT} = "_WITH_VRRP_"; then
+    if test "${enable_routes}" != "no"; then
+    # Introduced in Linux 2.6.19
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for FIB routing support" >&5
 $as_echo_n "checking for FIB routing support... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-    #include <sys/socket.h>
-    #include <linux/fib_rules.h>
-    int type;
+        #include <sys/socket.h>
+        #include <linux/fib_rules.h>
+        int type;
 
 int
 main ()
 {
 
-    type = FRA_SRC;
+        type = FRA_SRC;
 
   ;
   return 0;
@@ -4791,20 +4801,19 @@ main ()
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
 
-    FIB_ROUTING_SUPPORT=yes
+        FIB_ROUTING_SUPPORT="_HAVE_FIB_ROUTING_"
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext;
-
-  if test "$FIB_ROUTING_SUPPORT" = "yes"; then
-    FIB_ROUTING_SUPPORT="_HAVE_FIB_ROUTING_"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-  else
-    FIB_ROUTING_SUPPORT="_WITHOUT_FIB_ROUTING_"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
   fi
+fi
 
 
 
@@ -6775,6 +6784,11 @@ if test "${VRRP_SUPPORT}" = "_WITH_VRRP_"; then
     echo "Use VRRP authentication  : Yes"
   else
     echo "Use VRRP authentication  : No"
+  fi
+  if test ${FIB_ROUTING_SUPPORT} = "_HAVE_FIB_ROUTING_"; then
+    echo "With ip rules/routes     : Yes"
+  else
+    echo "With ip rules/routes     : No"
   fi
 else
   echo "Use VRRP Framework       : No"

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,38 @@ if test "$USE_NL3" != "_WITHOUT_LIBNL_"; then
     !!! Please install libnfnetlink headers.              !!!]))
 fi
 
+for flag in RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF RTA_VIA FRA_OIFNAME FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID; do
+  eval ${flag}="_WITHOUT_${flag}_"
+  if test "${IPVS_USE_NL}" = "LIBIPVS_USE_NL"; then
+    AC_MSG_CHECKING([for $flag])
+    AC_TRY_COMPILE([
+        #include <linux/rtnetlink.h>
+        #include <sys/socket.h>
+        #include <linux/fib_rules.h>
+      ], [
+	int flag = ${flag};
+      ], [
+	eval ${flag}_SUPPORT="yes"
+	], []);
+    eval SUPPORT=\$${flag}_SUPPORT
+    if test "${SUPPORT}" = "yes"; then
+      eval ${flag}="_HAVE_${flag}_"
+      AC_MSG_RESULT([yes])
+    else
+      AC_MSG_RESULT([no])
+    fi
+  fi
+done
+AC_SUBST(RTA_ENCAP)
+AC_SUBST(RTA_EXPIRES)
+AC_SUBST(RTA_NEWDST)
+AC_SUBST(RTA_PREF)
+AC_SUBST(RTA_VIA)
+AC_SUBST(FRA_OIFNAME)
+AC_SUBST(FRA_SUPPRESS_PREFIXLEN)
+AC_SUBST(FRA_SUPPRESS_IFGROUP)
+AC_SUBST(FRA_TUN_ID)
+
 dnl ----[Check if have linux/if.h and netlink/route/link.h namespace collision]----
 IF_H_LINK_H_COLLISION="_WITHOUT_IF_H_LINK_H_COLLISION_"
 if test "${USE_NL3}" = "_HAVE_LIBNL3_"; then
@@ -411,6 +443,7 @@ dnl ----[ Checks for FIB routing support ]----
 # Introduced in Linux 2.6.19
 AC_MSG_CHECKING([for FIB routing support])
 AC_TRY_COMPILE([
+    #include <sys/socket.h>
     #include <linux/fib_rules.h>
     int type;
   ], [
@@ -655,7 +688,7 @@ AC_CHECK_FUNCS(gettimeofday select socket strerror strtol uname)
 AC_CHECK_FUNC([pipe2], [PIPE2_SUPPORT=_HAVE_PIPE2_], [PIPE2_SUPPORT=_WITHOUT_PIPE2_])
 AC_SUBST([PIPE2_SUPPORT])
 
-APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${IPVS_SYNCD_ATTRIBUTES} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} -D${MEM_CHECK} -D${MEM_CHECK_LOG} -D${PIPE2_SUPPORT} ${DFLAGS}"
+APP_DEFS="-D${KERN} -D${IPVS_SUPPORT} -D${IPVS_SYNCD} -D${IPVS_SYNCD_ATTRIBUTES} -D${VRRP_SUPPORT} -D${VRRP_VMAC} -D${ADDR_GEN_MODE} -D${SNMP_SUPPORT} -D${SNMP_KEEPALIVED_SUPPORT} -D${SNMP_CHECKER_SUPPORT} -D${SNMP_RFC_SUPPORT} -D${SNMP_RFCV2_SUPPORT} -D${SNMP_RFCV3_SUPPORT} -D${IPVS_USE_NL} -D${USE_NL3} -D${VRRP_AUTH_SUPPORT} -D${SO_MARK_SUPPORT} -D${USE_LIBIPTC} -D${USE_LIBIPSET} -D${IPV4_DEVCONF} -D${IF_H_LINK_H_COLLISION} -D${LINUX_NET_IF_H_COLLISION} -D${SOCK_NONBLOCK_SUPPORT} -D${SOCK_CLOEXEC_SUPPORT} -D${FIB_ROUTING_SUPPORT} -D${MEM_CHECK} -D${MEM_CHECK_LOG} -D${PIPE2_SUPPORT} -D${RTA_ENCAP} -D${RTA_EXPIRES} -D${RTA_NEWDST} -D${RTA_PREF} -D${RTA_VIA} -D${FRA_OIFNAME} -D${FRA_SUPPRESS_PREFIXLEN} -D${FRA_SUPPRESS_IFGROUP} -D${FRA_TUN_ID} ${DFLAGS}"
 BUILD_OPTS=`echo ${APP_DEFS} | sed -e 's/ "$//' -e 's/.*"//' -e 's/-D//g' -e 's/_ / /g' -e 's/ _/ /g' -e 's/^_//' -e 's/_$//'`
 AC_SUBST(APP_DEFS)
 AC_SUBST(BUILD_OPTS)

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,8 @@ AC_ARG_ENABLE(sha1,
   [  --enable-sha1           compile with SHA1 support])
 AC_ARG_ENABLE(vrrp-auth,
   [  --disable-vrrp-auth     compile without VRRP authentication])
+AC_ARG_ENABLE(routes,
+  [  --disable-routes        compile without ip rules/routes])
 AC_ARG_ENABLE(libiptc,
   [  --disable-libiptc       compile without libiptc])
 AC_ARG_ENABLE(libipset,
@@ -439,26 +441,26 @@ AC_TRY_COMPILE([
 
 AC_SUBST(SOCK_CLOEXEC_SUPPORT)
 
-dnl ----[ Checks for FIB routing support ]----
-# Introduced in Linux 2.6.19
-AC_MSG_CHECKING([for FIB routing support])
-AC_TRY_COMPILE([
-    #include <sys/socket.h>
-    #include <linux/fib_rules.h>
-    int type;
-  ], [
-    type = FRA_SRC;
-  ], [
-    FIB_ROUTING_SUPPORT=yes
-  ], []);
-
-  if test "$FIB_ROUTING_SUPPORT" = "yes"; then
-    FIB_ROUTING_SUPPORT="_HAVE_FIB_ROUTING_"
-    AC_MSG_RESULT([yes])
-  else
-    FIB_ROUTING_SUPPORT="_WITHOUT_FIB_ROUTING_"
-    AC_MSG_RESULT([no])
+FIB_ROUTING_SUPPORT="_WITHOUT_FIB_ROUTING_"
+if test ${VRRP_SUPPORT} = "_WITH_VRRP_"; then
+  dnl ----[ Checks for FIB routing support ]----
+  if test "${enable_routes}" != "no"; then
+    # Introduced in Linux 2.6.19
+    AC_MSG_CHECKING([for FIB routing support])
+    AC_TRY_COMPILE([
+        #include <sys/socket.h>
+        #include <linux/fib_rules.h>
+        int type;
+      ], [
+        type = FRA_SRC;
+      ], [
+        FIB_ROUTING_SUPPORT="_HAVE_FIB_ROUTING_"
+        AC_MSG_RESULT([yes])
+      ], [
+        AC_MSG_RESULT([no])
+      ]);
   fi
+fi
 
 AC_SUBST(FIB_ROUTING_SUPPORT)
 
@@ -758,6 +760,11 @@ if test "${VRRP_SUPPORT}" = "_WITH_VRRP_"; then
     echo "Use VRRP authentication  : Yes"
   else
     echo "Use VRRP authentication  : No"
+  fi
+  if test ${FIB_ROUTING_SUPPORT} = "_HAVE_FIB_ROUTING_"; then
+    echo "With ip rules/routes     : Yes"
+  else
+    echo "With ip rules/routes     : No"
   fi
 else
   echo "Use VRRP Framework       : No"

--- a/doc/KEEPALIVED-MIB
+++ b/doc/KEEPALIVED-MIB
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201607021200Z"
+     LAST-UPDATED "201607030000Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201607030000Z"
+     DESCRIPTION "change vrrpRuleIndex to unsigned"
      REVISION "201607021200Z"
      DESCRIPTION "add lvs timeout parameters"
      REVISION "201607020000Z"
@@ -1011,7 +1013,7 @@ vrrpRuleEntry OBJECT-TYPE
     ::= { vrrpRuleTable 1 }
 
 VrrpRuleEntry ::= SEQUENCE {
-    vrrpRuleIndex Integer32,
+    vrrpRuleIndex Unsigned32,
     vrrpRuleDirection DisplayString,
     vrrpRuleAddressType InetAddressType,
     vrrpRuleAddress InetAddress,
@@ -1021,7 +1023,7 @@ VrrpRuleEntry ::= SEQUENCE {
 }
 
 vrrpRuleIndex OBJECT-TYPE
-    SYNTAX Integer32 (1..2147483647)
+    SYNTAX Unsigned32 (1..4294967295)
     MAX-ACCESS not-accessible
     STATUS current
     DESCRIPTION

--- a/doc/KEEPALIVED-MIB
+++ b/doc/KEEPALIVED-MIB
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201607030000Z"
+     LAST-UPDATED "201607100000Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201607100000Z"
+     DESCRIPTION "enhanced virtual rules and routes"
      REVISION "201607030000Z"
      DESCRIPTION "change vrrpRuleIndex to unsigned"
      REVISION "201607021200Z"
@@ -64,6 +66,52 @@ VrrpState ::= TEXTUAL-CONVENTION
     fault(3),
     unknown(4)
     }
+
+RouteType ::= TEXTUAL-CONVENTION
+    STATUS	current
+    DESCRIPTION
+	"Type of route"
+    SYNTAX	INTEGER { unicast(1),
+			  ecmp(2),
+		          blackhole(3),
+		          anycast(4),
+		          multicast(5),
+		          broadcast(6),
+		          unreachable(7),
+		          prohibit(8),
+			  throw(9),
+		          nat(10),
+		          xresolve(11) }
+
+RuleAction ::= TEXTUAL-CONVENTION
+    STATUS	current
+    DESCRIPTION
+	"Action of rule"
+    SYNTAX	INTEGER { table(1),
+			  goto(2),
+			  nop(3),
+		          blackhole(6),
+		          unreachable(7),
+		          prohibit(8) }
+
+Realm ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS	current
+    DESCRIPTION
+	"Route realm."
+    SYNTAX	Unsigned32 (1..65535)
+
+PrefType ::= TEXTUAL-CONVENTION
+    STATUS	current
+    DESCRIPTION
+	"Preference type of route"
+    SYNTAX	INTEGER { low(1), medium(2), high(3) }
+
+EncapType ::= TEXTUAL-CONVENTION
+    STATUS	current
+    DESCRIPTION
+	"Encapsulation type of route"
+    SYNTAX INTEGER { mpls(1), ip(2), ila(3), ip6(4) }
 
 global          OBJECT IDENTIFIER ::= { keepalived 1 }
 vrrp            OBJECT IDENTIFIER ::= { keepalived 2 }
@@ -876,7 +924,47 @@ VrrpRouteEntry ::= SEQUENCE {
     vrrpRouteIfIndex InterfaceIndex,
     vrrpRouteIfName DisplayString,
     vrrpRouteRoutingTable Unsigned32,
-    vrrpRouteStatus INTEGER
+    vrrpRouteStatus INTEGER,
+    vrrpRouteFromAddress InetAddress,
+    vrrpRouteFromAddressMask InetAddressPrefixLength,
+    vrrpRouteTos Unsigned32,
+    vrrpRouteProtocol INTEGER,
+    vrrpRouteECN TruthValue,
+    vrrpRouteQuickAck TruthValue,
+    vrrpRouteExpires Integer32,
+    vrrpRouteMTU Unsigned32,
+    vrrpRouteMTULock TruthValue,
+    vrrpRouteHopLimit Unsigned32,
+    vrrpRouteAdvmss Unsigned32,
+    vrrpRouteAdvmssLock TruthValue,
+    vrrpRouteRTT Unsigned32,
+    vrrpRouteRTTLock TruthValue,
+    vrrpRouteRTTvar Unsigned32,
+    vrrpRouteRTTvarLock TruthValue,
+    vrrpRouteReordering Unsigned32,
+    vrrpRouteReorderingLock TruthValue,
+    vrrpRouteWindow Unsigned32,
+    vrrpRouteCwnd Unsigned32,
+    vrrpRouteCwndLock TruthValue,
+    vrrpRouteSSthresh Unsigned32,
+    vrrpRouteSSthreshLock TruthValue,
+    vrrpRouteRTOMin Unsigned32,
+    vrrpRouteRTOMinLock TruthValue,
+    vrrpRouteInitCwnd Unsigned32,
+    vrrpRouteInitRwnd Unsigned32,
+    vrrpRouteCongCtl DisplayString,
+    vrrpRoutePref PrefType,
+    vrrpRouteRealmDst Realm,
+    vrrpRouteRealmSrc Realm,
+    vrrpRouteEncapType EncapType,
+    vrrpRouteEncapMplsLabels DisplayString,
+    vrrpRouteEncapId Counter64,
+    vrrpRouteEncapDstAddress InetAddress,
+    vrrpRouteEncapSrcAddress InetAddress,
+    vrrpRouteEncapTOS Unsigned32,
+    vrrpRouteEncapTTL Unsigned32,
+    vrrpRouteEncapFlags Unsigned32,
+    vrrpRouteEncapIlaLocator Counter64
 }
 
 vrrpRouteIndex OBJECT-TYPE
@@ -952,7 +1040,7 @@ vrrpRouteScope OBJECT-TYPE
     ::= { vrrpRouteEntry 9 }
 
 vrrpRouteType OBJECT-TYPE
-    SYNTAX INTEGER { normal(1), ecmp(2), blackhole(3) }
+    SYNTAX RouteType
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
@@ -991,6 +1079,514 @@ vrrpRouteStatus OBJECT-TYPE
         "Is this route set in the kernel?"
     ::= { vrrpRouteEntry 14 }
 
+vrrpRouteFromAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Source address to use for the route."
+    ::= { vrrpRouteEntry 15 }
+
+vrrpRouteFromAddressMask OBJECT-TYPE
+    SYNTAX InetAddressPrefixLength
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Source address mask."
+    ::= { vrrpRouteEntry 16 }
+
+vrrpRouteTos OBJECT-TYPE
+    SYNTAX Unsigned32 (0..255)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Route TOS value to match."
+    ::= { vrrpRouteEntry 17 }
+
+vrrpRouteProtocol OBJECT-TYPE
+    SYNTAX INTEGER { unspec(1), redirect(2), kernel(3), boot(4), static(5), gated(9), ra(10), mrt(11),
+		      zebra(12), bird(13), dnrouted(14), xorp(15), ntk(16), dhcp(17) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Route protocol identifier"
+    ::= { vrrpRouteEntry 18 }
+
+vrrpRouteECN OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Explicit congestion notification enabled on route."
+    ::= { vrrpRouteEntry 19 }
+
+vrrpRouteQuickAck OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Quick ack enabled on route."
+    ::= { vrrpRouteEntry 20 }
+
+vrrpRouteExpires OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Lifetime of route."
+    ::= { vrrpRouteEntry 21 }
+
+vrrpRouteMTU OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "MTU for route."
+    ::= { vrrpRouteEntry 22 }
+
+vrrpRouteMTULock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is MTU locked?"
+    ::= { vrrpRouteEntry 23 }
+
+vrrpRouteHopLimit OBJECT-TYPE
+    SYNTAX Unsigned32 (1..256)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Hoplimit for route."
+    ::= { vrrpRouteEntry 24 }
+
+vrrpRouteAdvmss OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Advertised MSS for route."
+    ::= { vrrpRouteEntry 25 }
+
+vrrpRouteAdvmssLock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is advertised MSS locked?"
+    ::= { vrrpRouteEntry 26 }
+
+vrrpRouteRTT OBJECT-TYPE
+    SYNTAX Unsigned32 (1..536870)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Retransmission timer in msec for route."
+    ::= { vrrpRouteEntry 27 }
+
+vrrpRouteRTTLock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is retransmission timer locked?"
+    ::= { vrrpRouteEntry 28 }
+
+vrrpRouteRTTvar OBJECT-TYPE
+    SYNTAX Unsigned32 (1..1073741)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Retransmission timer var in msec for route."
+    ::= { vrrpRouteEntry 29 }
+
+vrrpRouteRTTvarLock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is retransmission timer var locked?"
+    ::= { vrrpRouteEntry 30 }
+
+vrrpRouteReordering OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Reordeering for route."
+    ::= { vrrpRouteEntry 31 }
+
+vrrpRouteReorderingLock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is reordering value locked?"
+    ::= { vrrpRouteEntry 32 }
+
+vrrpRouteWindow OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Window for route."
+    ::= { vrrpRouteEntry 33 }
+
+vrrpRouteCwnd OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Congestion window for route."
+    ::= { vrrpRouteEntry 34 }
+
+vrrpRouteCwndLock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is congestion window value locked?"
+    ::= { vrrpRouteEntry 35 }
+
+vrrpRouteSSthresh OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "SS threshold window for route."
+    ::= { vrrpRouteEntry 36 }
+
+vrrpRouteSSthreshLock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is SS threshold value locked?"
+    ::= { vrrpRouteEntry 37 }
+
+vrrpRouteRTOMin OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Minimum RTO value (ms) for route."
+    ::= { vrrpRouteEntry 38 }
+
+vrrpRouteRTOMinLock OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Is minimum RTO value value locked?"
+    ::= { vrrpRouteEntry 39 }
+
+vrrpRouteInitCwnd OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Initial congestion window for route."
+    ::= { vrrpRouteEntry 40 }
+
+vrrpRouteInitRwnd OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Initian R window for route."
+    ::= { vrrpRouteEntry 41 }
+
+vrrpRouteCongCtl OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Congestion control algorithm for route."
+    ::= { vrrpRouteEntry 42 }
+
+vrrpRoutePref OBJECT-TYPE
+    SYNTAX PrefType
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Preference type for IPv6 route"
+    ::= { vrrpRouteEntry 43 }
+
+vrrpRouteRealmDst OBJECT-TYPE
+    SYNTAX Realm
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Realms for route."
+    ::= { vrrpRouteEntry 44 }
+
+vrrpRouteRealmSrc OBJECT-TYPE
+    SYNTAX Realm
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Realms for route."
+    ::= { vrrpRouteEntry 45 }
+
+vrrpRouteEncapType OBJECT-TYPE
+    SYNTAX EncapType
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Encapsulation type."
+    ::= { vrrpRouteEntry 46 }
+
+vrrpRouteEncapMplsLabels OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "MPLS labels for MPLS encapsulation."
+    ::= { vrrpRouteEntry 47 }
+
+vrrpRouteEncapId OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Tunnel ID for IP/IPv6 tunnels."
+    ::= { vrrpRouteEntry 48 }
+
+vrrpRouteEncapDstAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Destination address for IP/IPv6 encapsulation."
+    ::= { vrrpRouteEntry 49 }
+
+vrrpRouteEncapSrcAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Source address for IP/IPv6 encapsulation."
+    ::= { vrrpRouteEntry 50 }
+
+vrrpRouteEncapTOS OBJECT-TYPE
+    SYNTAX Unsigned32 (0..255)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Route next hop TOS/dsfield for IP/IPv6 encapsulation."
+    ::= { vrrpRouteEntry 51 }
+
+vrrpRouteEncapTTL OBJECT-TYPE
+    SYNTAX Unsigned32 (1..255)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Next hop time to live/hopcount for IP/IPv6 encapsulation."
+    ::= { vrrpRouteEntry 52 }
+
+vrrpRouteEncapFlags OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Flags for this IP/IPv6 encapsulation."
+    ::= { vrrpRouteEntry 53 }
+
+vrrpRouteEncapIlaLocator OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "ILA locator for this encapsulation."
+    ::= { vrrpRouteEntry 54 }
+
+-- Route next hops
+-- see vrrp_iproute.h
+
+vrrpRouteNextHopTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF VrrpRouteNextHopEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Table of next hops for static and virtual routes."
+    ::= { vrrp 11 }
+
+vrrpRouteNextHopEntry OBJECT-TYPE
+    SYNTAX VrrpRouteNextHopEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Information describing a route next hop. This can be for a static
+         route or a virtual route. In case of a static route, the
+         VRRP instance index is 0."
+    INDEX { vrrpInstanceIndex, vrrpRouteIndex, vrrpRouteNextHopIndex }
+    ::= { vrrpRouteNextHopTable 1 }
+
+VrrpRouteNextHopEntry ::= SEQUENCE {
+    vrrpRouteNextHopIndex Integer32,
+    vrrpRouteNextHopAddressType InetAddressType,
+    vrrpRouteNextHopAddress InetAddress,
+    vrrpRouteNextHopIfIndex InterfaceIndex,
+    vrrpRouteNextHopIfName DisplayString,
+    vrrpRouteNextHopWeight Unsigned32,
+    vrrpRouteNextHopOnlink TruthValue,
+    vrrpRouteNextHopRealmDst Realm,
+    vrrpRouteNextHopRealmSrc Realm,
+    vrrpRouteNextHopEncapType EncapType,
+    vrrpRouteNextHopEncapMplsLabels DisplayString,
+    vrrpRouteNextHopEncapId Counter64,
+    vrrpRouteNextHopEncapDstAddress InetAddress,
+    vrrpRouteNextHopEncapSrcAddress InetAddress,
+    vrrpRouteNextHopEncapTOS Unsigned32,
+    vrrpRouteNextHopEncapTTL Unsigned32,
+    vrrpRouteNextHopEncapFlags Unsigned32,
+    vrrpRouteNextHopEncapIlaLocator Counter64
+}
+
+vrrpRouteNextHopIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Route next hop index."
+    ::= { vrrpRouteNextHopEntry 1 }
+
+vrrpRouteNextHopAddressType OBJECT-TYPE
+    SYNTAX InetAddressType
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Route next hop internet address type."
+    ::= { vrrpRouteNextHopEntry 2 }
+
+vrrpRouteNextHopAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Route next hop address."
+    ::= { vrrpRouteNextHopEntry 3 }
+
+vrrpRouteNextHopIfIndex OBJECT-TYPE
+    SYNTAX InterfaceIndex
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Interface for this next hop."
+    ::= { vrrpRouteNextHopEntry 4 }
+
+vrrpRouteNextHopIfName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Name of the interface for this next hop."
+    ::= { vrrpRouteNextHopEntry 5 }
+
+vrrpRouteNextHopWeight OBJECT-TYPE
+    SYNTAX Unsigned32 (1..256)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Route next hop weight."
+    ::= { vrrpRouteNextHopEntry 6 }
+
+vrrpRouteNextHopOnlink OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Next hop address is specified to be onlink."
+    ::= { vrrpRouteNextHopEntry 7 }
+
+vrrpRouteNextHopRealmDst OBJECT-TYPE
+    SYNTAX Realm
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Destination realm for this next hop."
+    ::= { vrrpRouteNextHopEntry 8 }
+
+vrrpRouteNextHopRealmSrc OBJECT-TYPE
+    SYNTAX Realm
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Source realms for this next hop."
+    ::= { vrrpRouteNextHopEntry 9 }
+
+vrrpRouteNextHopEncapType OBJECT-TYPE
+    SYNTAX EncapType
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Encapsulation type."
+    ::= { vrrpRouteNextHopEntry 10 }
+
+vrrpRouteNextHopEncapMplsLabels OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "MPLS labels for MPLS encapsulation."
+    ::= { vrrpRouteNextHopEntry 11 }
+
+vrrpRouteNextHopEncapId OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Tunnel ID for IP/IPv6 tunnels."
+    ::= { vrrpRouteNextHopEntry 12 }
+
+vrrpRouteNextHopEncapDstAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Destination address for IP/IPv6 encapsulation."
+    ::= { vrrpRouteNextHopEntry 13 }
+
+vrrpRouteNextHopEncapSrcAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Source address for IP/IPv6 encapsulation."
+    ::= { vrrpRouteNextHopEntry 14 }
+
+vrrpRouteNextHopEncapTOS OBJECT-TYPE
+    SYNTAX Unsigned32 (0..255)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Route next hop TOS/dsfield for IP/IPv6 encapsulation."
+    ::= { vrrpRouteNextHopEntry 15 }
+
+vrrpRouteNextHopEncapTTL OBJECT-TYPE
+    SYNTAX Unsigned32 (1..255)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Next hop time to live/hopcount for IP/IPv6 encapsulation."
+    ::= { vrrpRouteNextHopEntry 16 }
+
+vrrpRouteNextHopEncapFlags OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Flags for this IP/IPv6 encapsulation."
+    ::= { vrrpRouteNextHopEntry 17 }
+
+vrrpRouteNextHopEncapIlaLocator OBJECT-TYPE
+    SYNTAX Counter64
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "ILA locator for this encapsulation."
+    ::= { vrrpRouteNextHopEntry 18 }
+
 -- Rules
 -- see vrrp_iprule.h
 
@@ -1019,7 +1615,29 @@ VrrpRuleEntry ::= SEQUENCE {
     vrrpRuleAddress InetAddress,
     vrrpRuleAddressMask InetAddressPrefixLength,
     vrrpRuleRoutingTable Unsigned32,
-    vrrpRuleStatus INTEGER
+    vrrpRuleStatus INTEGER,
+    vrrpRuleInvert TruthValue,
+    vrrpRuleDestinationAddressType InetAddressType,
+    vrrpRuleDestinationAddress InetAddress,
+    vrrpRuleDestinationAddressMask InetAddressPrefixLength,
+    vrrpRuleSourceAddressType InetAddressType,
+    vrrpRuleSourceAddress InetAddress,
+    vrrpRuleSourceAddressMask InetAddressPrefixLength,
+    vrrpRuleTos Unsigned32,
+    vrrpRuleFwmark Unsigned32,
+    vrrpRuleFwmask Unsigned32,
+    vrrpRuleRealmDst Realm,
+    vrrpRuleRealmSrc Realm,
+    vrrpRuleInInterface DisplayString,
+    vrrpRuleOutInterface DisplayString,
+    vrrpRuleTarget Unsigned32,
+    vrrpRuleAction RuleAction,
+    vrrpRuleTableNo Unsigned32,
+    vrrpRulePreference Unsigned32,
+    vrrpRuleSuppressPrefixLen Unsigned32,
+    vrrpRuleSuppressGroup DisplayString,
+    vrrpRuleTunnelIdHigh Unsigned32,
+    vrrpRuleTunnelIdLow Unsigned32
 }
 
 vrrpRuleIndex OBJECT-TYPE
@@ -1033,7 +1651,7 @@ vrrpRuleIndex OBJECT-TYPE
 vrrpRuleDirection OBJECT-TYPE
     SYNTAX DisplayString
     MAX-ACCESS read-only
-    STATUS current
+    STATUS obsolete
     DESCRIPTION
         "Traffic direction for this rule."
     ::= { vrrpRuleEntry 2 }
@@ -1041,7 +1659,7 @@ vrrpRuleDirection OBJECT-TYPE
 vrrpRuleAddressType OBJECT-TYPE
     SYNTAX InetAddressType
     MAX-ACCESS read-only
-    STATUS current
+    STATUS obsolete
     DESCRIPTION
         "Rule type of internet address."
     ::= { vrrpRuleEntry 3 }
@@ -1049,7 +1667,7 @@ vrrpRuleAddressType OBJECT-TYPE
 vrrpRuleAddress OBJECT-TYPE
     SYNTAX InetAddress
     MAX-ACCESS read-only
-    STATUS current
+    STATUS obsolete
     DESCRIPTION
         "Rule network address."
     ::= { vrrpRuleEntry 4 }
@@ -1057,7 +1675,7 @@ vrrpRuleAddress OBJECT-TYPE
 vrrpRuleAddressMask OBJECT-TYPE
     SYNTAX InetAddressPrefixLength
     MAX-ACCESS read-only
-    STATUS current
+    STATUS obsolete
     DESCRIPTION
         "Rule network mask."
     ::= { vrrpRuleEntry 5 }
@@ -1077,6 +1695,182 @@ vrrpRuleStatus OBJECT-TYPE
     DESCRIPTION
         "Is this rule set in the kernel?"
     ::= { vrrpRuleEntry 7 }
+
+vrrpRuleInvert OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Invert rule matching sense."
+    ::= { vrrpRuleEntry 8 }
+
+vrrpRuleDestinationAddressType OBJECT-TYPE
+    SYNTAX InetAddressType
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Family of rule destination internet address."
+    ::= { vrrpRuleEntry 9 }
+
+vrrpRuleDestinationAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule destination network address."
+    ::= { vrrpRuleEntry 10 }
+
+vrrpRuleDestinationAddressMask OBJECT-TYPE
+    SYNTAX InetAddressPrefixLength
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule destination address network mask."
+    ::= { vrrpRuleEntry 11 }
+
+vrrpRuleSourceAddressType OBJECT-TYPE
+    SYNTAX InetAddressType
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Family of rule source internet address."
+    ::= { vrrpRuleEntry 12 }
+
+vrrpRuleSourceAddress OBJECT-TYPE
+    SYNTAX InetAddress
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule source network address."
+    ::= { vrrpRuleEntry 13 }
+
+vrrpRuleSourceAddressMask OBJECT-TYPE
+    SYNTAX InetAddressPrefixLength
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule source address network mask."
+    ::= { vrrpRuleEntry 14 }
+
+vrrpRuleTos OBJECT-TYPE
+    SYNTAX Unsigned32 (0..255)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule TOS value to match."
+    ::= { vrrpRuleEntry 15 }
+
+vrrpRuleFwmark OBJECT-TYPE
+    SYNTAX Unsigned32 (0..4294967295)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule fwmark value to match."
+    ::= { vrrpRuleEntry 16 }
+
+vrrpRuleFwmask OBJECT-TYPE
+    SYNTAX Unsigned32 (0..4294967295)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule fwmask value to match the fwmark."
+    ::= { vrrpRuleEntry 17 }
+
+vrrpRuleRealmDst OBJECT-TYPE
+    SYNTAX Realm
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Destination realm to select if the rule matched."
+    ::= { vrrpRuleEntry 18 }
+
+vrrpRuleRealmSrc OBJECT-TYPE
+    SYNTAX Realm
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Source realm to select if the rule matched."
+    ::= { vrrpRuleEntry 19 }
+
+vrrpRuleInInterface OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule incoming interface to match."
+    ::= { vrrpRuleEntry 20 }
+
+vrrpRuleOutInterface OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule outgoing interface to match."
+    ::= { vrrpRuleEntry 21 }
+
+vrrpRuleTarget OBJECT-TYPE
+    SYNTAX Unsigned32 (0..4294967295)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule goto target."
+    ::= { vrrpRuleEntry 22 }
+
+vrrpRuleAction OBJECT-TYPE
+    SYNTAX RuleAction
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule type."
+    ::= { vrrpRuleEntry 23 }
+
+vrrpRuleTableNo OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Routing table."
+    ::= { vrrpRuleEntry 24 }
+
+vrrpRulePreference OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Routing table."
+    ::= { vrrpRuleEntry 25 }
+
+vrrpRuleSuppressPrefixLen OBJECT-TYPE
+    SYNTAX Unsigned32 (0..128)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule suppress match prefix length."
+    ::= { vrrpRuleEntry 26 }
+
+vrrpRuleSuppressGroup OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule suppress match interface group."
+    ::= { vrrpRuleEntry 27 }
+
+vrrpRuleTunnelIdHigh OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule tunnel-id low 32 bits."
+    ::= { vrrpRuleEntry 28 }
+
+vrrpRuleTunnelIdLow OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Rule tunnel-id high 32 bits."
+    ::= { vrrpRuleEntry 29 }
 
 -- VRRP scripts
 -- see vrrp_track.h
@@ -2327,12 +3121,86 @@ vrrpInstanceGroup OBJECT-GROUP
     vrrpRouteIfName,
     vrrpRouteRoutingTable,
     vrrpRouteStatus,
-    vrrpRuleDirection,
-    vrrpRuleAddressType,
-    vrrpRuleAddress,
-    vrrpRuleAddressMask,
+    vrrpRouteFromAddress,
+    vrrpRouteFromAddressMask,
+    vrrpRouteTos,
+    vrrpRouteProtocol,
+    vrrpRouteECN,
+    vrrpRouteQuickAck,
+    vrrpRouteExpires,
+    vrrpRouteMTU,
+    vrrpRouteMTULock,
+    vrrpRouteHopLimit,
+    vrrpRouteAdvmss,
+    vrrpRouteAdvmssLock,
+    vrrpRouteRTT,
+    vrrpRouteRTTLock,
+    vrrpRouteRTTvar,
+    vrrpRouteRTTvarLock,
+    vrrpRouteReordering,
+    vrrpRouteReorderingLock,
+    vrrpRouteWindow,
+    vrrpRouteCwnd,
+    vrrpRouteCwndLock,
+    vrrpRouteSSthresh,
+    vrrpRouteSSthreshLock,
+    vrrpRouteRTOMin,
+    vrrpRouteRTOMinLock,
+    vrrpRouteInitCwnd,
+    vrrpRouteInitRwnd,
+    vrrpRouteCongCtl,
+    vrrpRoutePref,
+    vrrpRouteRealmDst,
+    vrrpRouteRealmSrc,
+    vrrpRouteEncapType,
+    vrrpRouteEncapMplsLabels,
+    vrrpRouteEncapId,
+    vrrpRouteEncapDstAddress,
+    vrrpRouteEncapSrcAddress,
+    vrrpRouteEncapTOS,
+    vrrpRouteEncapTTL,
+    vrrpRouteEncapFlags,
+    vrrpRouteEncapIlaLocator,
+    vrrpRouteNextHopAddressType,
+    vrrpRouteNextHopAddress,
+    vrrpRouteNextHopIfIndex,
+    vrrpRouteNextHopIfName,
+    vrrpRouteNextHopWeight,
+    vrrpRouteNextHopOnlink,
+    vrrpRouteNextHopRealmDst,
+    vrrpRouteNextHopRealmSrc,
+    vrrpRouteNextHopEncapMplsLabels,
+    vrrpRouteNextHopEncapId,
+    vrrpRouteNextHopEncapDstAddress,
+    vrrpRouteNextHopEncapSrcAddress,
+    vrrpRouteNextHopEncapTOS,
+    vrrpRouteNextHopEncapTTL,
+    vrrpRouteNextHopEncapFlags,
+    vrrpRouteNextHopEncapIlaLocator,
     vrrpRuleRoutingTable,
-    vrrpRuleStatus
+    vrrpRuleStatus,
+    vrrpRuleInvert,
+    vrrpRuleDestinationAddressType,
+    vrrpRuleDestinationAddress,
+    vrrpRuleDestinationAddressMask,
+    vrrpRuleSourceAddressType,
+    vrrpRuleSourceAddress,
+    vrrpRuleSourceAddressMask,
+    vrrpRuleTos,
+    vrrpRuleFwmark,
+    vrrpRuleFwmask,
+    vrrpRuleRealmDst,
+    vrrpRuleRealmSrc,
+    vrrpRuleInInterface,
+    vrrpRuleOutInterface,
+    vrrpRuleTarget,
+    vrrpRuleAction,
+    vrrpRuleTableNo,
+    vrrpRulePreference,
+    vrrpRuleSuppressPrefixLen,
+    vrrpRuleSuppressGroup,
+    vrrpRuleTunnelIdHigh,
+    vrrpRuleTunnelIdLow
     }
     STATUS current
     DESCRIPTION
@@ -2374,6 +3242,17 @@ vrrpLvsSyncGroup OBJECT-GROUP
 	"The deprecated LVS sync daemon configuration
 	 objects associated with a VRRP instance."
     ::= { vrrpGroups 5 }
+
+vrrpObsoleteInstanceGroup OBJECT-GROUP
+    OBJECTS {
+    vrrpRuleDirection,
+    vrrpRuleAddressType,
+    vrrpRuleAddress,
+    vrrpRuleAddressMask }
+    STATUS obsolete
+    DESCRIPTION
+        "Obsolete group for VRRP instances."
+    ::= { vrrpGroups 6 }
 
 checkGroups OBJECT IDENTIFIER ::= { groups 3 }
 

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -16,9 +16,11 @@ in you configuration file use this char.
 
 1. Globals configurations
 
-This block is divided in 2 sub-block :
+This block is divided in 4 sub-blocks :
 
 	* Global definitions
+	* Static addresses
+	* Static rules
 	* Static routes
 
 	1.1. Global definitions
@@ -126,24 +128,24 @@ SCOPE can take the following values :
 	* nowhere
 	* global
 
-	1.3. Static routes
+	1.3 Static rules
+
+static_rules {							# block identification
+								# The syntax is that same as for ip rule add, without "ip rule add" with the addition of tunnel-id option, e.g.
+	from 192.168.28.0/24 to 192.168.29.0/26 table small iif p33p1 oif wlan0 tos 22 fwmark 24/12 preference 39 realms 30/20 goto 40
+	to 1:2:3:4:5:6:7:0/112 from 7:6:5:4:3:2::/96 table 6908
+}
+
+	1.4. Static routes
 
 	The configuration block looks like :
 
 static_routes {							# block identification
-    src <IP ADDRESS> [to] <IP ADDRESS>/<MASK> via|gw <IP ADDRESS> dev <STRING> scope <SCOPE> table <TABLE-ID> # to is optional
-    src <IP ADDRESS> [to] <IP ADDRESS>/<MASK> via|gw <IP ADDRESS> dev <STRING> scope <SCOPE> table <TABLE-ID> # to is optional
-    src <IP ADDRESS> [to] <IP ADDRESS>/<MASK> via|gw <IP ADDRESS> or <IP ADDRESS> dev <STRING> scope <SCOPE> table <TABLE-ID> # will use multipath route
-    blackhole <IP ADDRESS>[/<MASK>]
-    ...
+								# The syntax is the same as ip route add, without "ip route add" e.g.
+	192.168.100.0/24 table 6909 nexthop via 192.168.101.1 dev wlan0 onlink weight 1 nexthop via 192.168.101.2 dev wlan0 onlink weight 2
+	192.168.200.0/24 dev p33p1.2 table 6909 tos 0x04 protocol bird scope link priority 12 mtu 1000 hoplimit 100 advmss 101 rtt 102 rttvar 103 reordering 104 window 105 cwnd 106 ssthresh lock 107 realms PQA/0x14 rto_min 108 initcwnd 109 initrwnd 110 features ecn
+	2001:470:69e9:1:2::4 dev p33p1.2 table 6909 tos 0x04 protocol bird scope link priority 12 mtu 1000 hoplimit 100 advmss 101 rtt 102 rttvar 103 reordering 104 window 105 cwnd 106 ssthresh lock 107 rto_min 108 initcwnd 109 initrwnd 110 features ecn
 }
-
-SCOPE can take the following values :
-	* site
-	* link
-	* host
-	* nowhere
-	* global
 
 2. VRRP configuration
 
@@ -313,14 +315,10 @@ vrrp_instance <STRING> {		# VRRP instance declaration
         ...
     }
     virtual_routes {			# VRRP virtual routes
-    	src <IP ADDRESS> [to] <IP ADDRESS>/<MASK> via|gw <IP ADDRESS> dev <STRING> scope <SCOPE> table <TABLE-ID> metric <METRIC> # to is optional
-    	src <IP ADDRESS> [to] <IP ADDRESS>/<MASK> via|gw <IP ADDRESS> dev <STRING> scope <SCOPE> table <TABLE-ID> metric <METRIC> # to is optional
-    	src <IP ADDRESS> [to] <IP ADDRESS>/<MASK> via|gw <IP ADDRESS> or <IP ADDRESS> dev <STRING> scope <SCOPE> table <TABLE-ID> # will use multipath route
-        ...
-	blackhole <IP ADDRESS>[/<MASK>]
+					# The syntax is the same as static_routes
     }
     virtual_rules {			# VRRP virtual rules
-	from|to <IP ADDRESS>/<MASK> table <TABLE-ID>
+					# The syntax is the same as static_rules
     }
 
     nopreempt					# Override VRRP RFC preemption default

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -167,8 +167,9 @@ Keepalived can configure static addresses, routes, and rules. These addresses ar
 moved by vrrpd, they stay on the machine.
 If you already have IPs and routes on your machines and
 your machines can ping each other, you don't need this section.
+The syntax for rules and routes is that same as for ip rule add/ip route add.
 .PP
-The syntax is the same as for virtual addresses and virtual routes.
+The syntax is the same for virtual addresses and virtual routes.
 .PP
  static_ipaddress
  {
@@ -179,6 +180,9 @@ The syntax is the same as for virtual addresses and virtual routes.
  static_routes
  {
  192.168.2.0/24 via 192.168.1.100 dev eth0
+ 192.168.100.0/24 table 6909 nexthop via 192.168.101.1 dev wlan0 onlink weight 1 nexthop via 192.168.101.2 dev wlan0 onlink weight 2
+ 192.168.200.0/24 dev p33p1.2 table 6909 tos 0x04 protocol bird scope link priority 12 mtu 1000 hoplimit 100 advmss 101 rtt 102 rttvar 103 reordering 104 window 105 cwnd 106 ssthresh lock 107 realms PQA/0x14 rto_min 108 initcwnd 109 initrwnd 110 features ecn
+ 2001:470:69e9:1:2::4 dev p33p1.2 table 6909 tos 0x04 protocol bird scope link priority 12 mtu 1000 hoplimit 100 advmss 101 rtt 102 rttvar 103 reordering 104 window 105 cwnd 106 ssthresh lock 107 rto_min 108 initcwnd 109 initrwnd 110 features ecn
  ...
  }
 .PP
@@ -186,6 +190,8 @@ The syntax is the same as for virtual addresses and virtual routes.
  {
  from 192.168.2.0/24 table 1
  to 192.168.2.0/24 table 1
+ from 192.168.28.0/24 to 192.168.29.0/26 table small iif p33p1 oif wlan0 tos 22 fwmark 24/12 preference 39 realms 30/20 goto 40
+ to 1:2:3:4:5:6:7:0/112 from 7:6:5:4:3:2::/96 table 6908
  ...
  }
 .PP
@@ -414,7 +420,8 @@ which will transition together on any state change.
      <IPADDR>/<MASK> brd <IPADDR> dev <STRING> scope <SCOPE>
         ...
     }
-    # routes add|del when changing to MASTER, to BACKUP
+    # routes add|del when changing to MASTER, to BACKUP.
+    # See static_routes for more details
     virtual_routes {
         # src <IPADDR> [to] <IPADDR>/<MASK> via|gw <IPADDR> [or <IPADDR>] dev <STRING> scope <SCOPE> table <TABLE>
         src 192.168.100.1 to 192.168.109.0/24 via 192.168.200.254 dev eth1
@@ -427,6 +434,7 @@ which will transition together on any state change.
     }
 
     # rules add|del when changing to MASTER, to BACKUP
+    # See static_rules for more details
     virtual_rules {
         from 192.168.2.0/24 table 1
         to 192.168.2.0/24 table 1

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -49,17 +49,17 @@ string_to_number(const char *s, int min, int max)
 	char *end;
 
 	number = (int) strtol(s, &end, 10);
-	if (*end == '\0' && end != s) {
-		/*
-		 * We parsed a number, let's see if we want this.
-		 * If max <= min then ignore ranges
-		 */
-		if (max <= min || (min <= number && number <= max))
-			return number;
-		else
-			return -1;
-	} else
+	if (*end || end == s)
 		return -1;
+
+	/*
+	 * We parsed a number, let's see if we want this.
+	 * If max <= min then ignore ranges
+	 */
+	if (max <= min || (min <= number && number <= max))
+		return number;
+
+	return -1;
 }
 
 static int

--- a/keepalived/include/ipvswrapper.h
+++ b/keepalived/include/ipvswrapper.h
@@ -33,7 +33,7 @@
 #include <stdbool.h>
 
 #include <net/if.h>
-#include <netinet/ip_icmp.h>
+//#include <netinet/ip_icmp.h>
 #include <netinet/udp.h>
 #include <netinet/tcp.h>
 #include <sys/wait.h>

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -171,7 +171,7 @@ extern int if_setsockopt_mcast_all(sa_family_t, int *);
 extern int if_setsockopt_mcast_loop(sa_family_t, int *);
 extern int if_setsockopt_mcast_hops(sa_family_t, int *);
 extern int if_setsockopt_mcast_if(sa_family_t, int *, interface_t *);
-extern int if_setsockopt_priority(int *);
+extern int if_setsockopt_priority(int *, int);
 extern int if_setsockopt_rcvbuf(int *, int);
 
 #endif

--- a/keepalived/include/vrrp_ip_rule_route_parser.h
+++ b/keepalived/include/vrrp_ip_rule_route_parser.h
@@ -1,0 +1,44 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        iprule and iproute parser
+ *
+ * Author:      Quentin Armitage, <quentin@armitage.org.uk>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2016 Quentin Armitage, <quentin@armitage.org.uk>
+ */
+
+#ifndef _VRRP_IP_RULE_ROUTE_PARSER_H
+#define _VRRP_IP_RULE_ROUTE_PARSER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <linux/rtnetlink.h>
+#ifdef _HAVE_RTA_ENCAP_
+#include "vrrp_iproute.h"
+#endif
+
+extern bool get_realms(uint32_t *, char *);
+extern bool get_u8(uint8_t *, const char *, uint8_t, const char*);
+extern bool get_u32(uint32_t *, const char *, uint32_t, const char*);
+extern bool get_u16(uint16_t *, const char *, uint16_t, const char*);
+extern bool get_u64(uint64_t *, const char *, uint64_t, const char*);
+extern bool get_time_rtt(uint32_t *, const char *, bool *);
+extern bool get_addr64(uint64_t *, const char *);
+#ifdef _HAVE_RTA_ENCAP_
+extern bool parse_mpls_address(const char *, encap_mpls_t *);
+#endif
+
+#endif

--- a/keepalived/include/vrrp_ipaddress.h
+++ b/keepalived/include/vrrp_ipaddress.h
@@ -86,7 +86,7 @@ typedef struct _ip_address {
 			 (X)->ifa.ifa_scope         == (Y)->ifa.ifa_scope		&& \
 			 string_equal((X)->label, (Y)->label))
 
-#define IP_ISEQ(X,Y)    (((X) && (Y)) ? ((IP_FAMILY(X) == IP_FAMILY(Y)) ? (IP_IS6(X) ? IP6_ISEQ(X, Y) : IP4_ISEQ(X, Y)) : 0) : (((!(X) && (Y))||((X) && !(Y))) ? 0 : 1))
+#define IP_ISEQ(X,Y)    (!(X) && !(Y) ? true : !(X) != !(Y) ? false : (IP_FAMILY(X) != IP_FAMILY(Y) ? false : IP_IS6(X) ? IP6_ISEQ(X, Y) : IP4_ISEQ(X, Y)))
 
 struct ipt_handle;	// AAGH - TODO
 

--- a/keepalived/include/vrrp_netlink.h
+++ b/keepalived/include/vrrp_netlink.h
@@ -64,16 +64,29 @@ typedef struct _nl_handle {
 #endif
 #endif
 
+#define htonll(x) ((1==htonl(1)) ? (x) : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32))
+
+#define RTA_TAIL(rta)	((struct rtattr *) (((void *) (rta)) + RTA_ALIGN((rta)->rta_len)))
+
 /* Global vars exported */
 extern nl_handle_t nl_cmd;	/* Command channel */
 extern int netlink_error_ignore; /* If we get this error, ignore it */
 
 /* prototypes */
-extern int addattr32(struct nlmsghdr *, int, int, uint32_t);
-extern int addattr_l(struct nlmsghdr *, int, int, void *, int);
-extern int rta_addattr_l(struct rtattr *, int, int, const void *, int);
-extern const char *netlink_scope_n2a(int);
-extern int netlink_scope_a2n(char *);
+extern int addattr_l(struct nlmsghdr *, size_t, int, void *, size_t);
+extern int addattr8(struct nlmsghdr *, size_t, int, uint8_t);
+extern int addattr32(struct nlmsghdr *, size_t, int, uint32_t);
+extern int addattr64(struct nlmsghdr *, size_t, int, uint64_t);
+extern int addattr_l2(struct nlmsghdr *, size_t, int, void *, size_t, void *, size_t);
+extern int addraw_l(struct nlmsghdr *, size_t, const void *, size_t);
+extern size_t rta_addattr_l(struct rtattr *, size_t, int, const void *, size_t);
+extern size_t rta_addattr_l2(struct rtattr *, size_t, int, const void *, size_t, const void*, size_t);
+extern size_t rta_addattr64(struct rtattr *, size_t, int, uint64_t);
+extern size_t rta_addattr32(struct rtattr *, size_t, int, uint32_t);
+extern size_t rta_addattr16(struct rtattr *, size_t, int, uint16_t);
+extern size_t rta_addattr8(struct rtattr *, size_t, int, uint8_t);
+extern struct rtattr *rta_nest(struct rtattr *, size_t, int);
+extern size_t rta_nest_end(struct rtattr *, struct rtattr *);
 extern int netlink_talk(nl_handle_t *, struct nlmsghdr *);
 extern int netlink_interface_lookup(void);
 extern void kernel_netlink_init(void);

--- a/keepalived/vrrp/Makefile.in
+++ b/keepalived/vrrp/Makefile.in
@@ -20,7 +20,7 @@ COMPILE	 = $(CC) $(CFLAGS) @APP_DEFS@
 OBJS =	vrrp_daemon.o vrrp_print.o vrrp_data.o vrrp_parser.o \
 	vrrp.o vrrp_notify.o vrrp_scheduler.o vrrp_sync.o vrrp_index.o \
 	vrrp_netlink.o vrrp_arp.o vrrp_if.o vrrp_track.o vrrp_ipaddress.o \
-	vrrp_ndisc.o vrrp_if_config.o
+	vrrp_ndisc.o vrrp_if_config.o vrrp_ip_rule_route_parser.o
 
 ifeq ($(VRRP_VMAC_FLAG),_HAVE_VRRP_VMAC_)
   OBJS += vrrp_vmac.o
@@ -104,10 +104,11 @@ vrrp_ipaddress.o: vrrp_ipaddress.c ../include/vrrp_ipaddress.h ../include/vrrp_n
   ../../lib/bitops.h ../include/vrrp_iptables.h
 vrrp_iproute.o: vrrp_iproute.c ../include/vrrp_iproute.h ../include/vrrp_netlink.h \
   ../include/vrrp_if.h  ../include/vrrp_data.h ../../lib/memory.h ../../lib/utils.h \
-  ../../lib/rttables.h
+  ../../lib/rttables.h ../include/vrrp_ip_rule_route_parser.h
 vrrp_iprule.o: vrrp_iprule.c ../include/vrrp_iprule.h ../include/vrrp_netlink.h \
   ../include/vrrp_if.h  ../include/vrrp_data.h ../../lib/memory.h ../../lib/utils.h \
-  ../../lib/rttables.h
+  ../../lib/rttables.h ../include/vrrp_ip_rule_route_parser.h
+vrrp_ip_rule_route_parser.o: ../include/vrrp_ip_rule_route_parser.h
 vrrp_ipsecah.o: vrrp_ipsecah.c ../include/vrrp_ipsecah.h
 vrrp_ndisc.o: vrrp_ndisc.c ../include/vrrp_ndisc.h ../include/vrrp_ipaddress.h \
   ../../lib/utils.h ../../lib/memory.h ../include/vrrp_if_config.h ../include/vrrp_scheduler.h

--- a/keepalived/vrrp/Makefile.in
+++ b/keepalived/vrrp/Makefile.in
@@ -20,7 +20,7 @@ COMPILE	 = $(CC) $(CFLAGS) @APP_DEFS@
 OBJS =	vrrp_daemon.o vrrp_print.o vrrp_data.o vrrp_parser.o \
 	vrrp.o vrrp_notify.o vrrp_scheduler.o vrrp_sync.o vrrp_index.o \
 	vrrp_netlink.o vrrp_arp.o vrrp_if.o vrrp_track.o vrrp_ipaddress.o \
-	vrrp_ndisc.o vrrp_if_config.o vrrp_ip_rule_route_parser.o
+	vrrp_ndisc.o vrrp_if_config.o
 
 ifeq ($(VRRP_VMAC_FLAG),_HAVE_VRRP_VMAC_)
   OBJS += vrrp_vmac.o
@@ -31,7 +31,7 @@ ifeq ($(VRRP_AUTH_FLAG),_WITH_VRRP_AUTH_)
 endif
 
 ifeq ($(FIB_ROUTING_FLAG),_HAVE_FIB_ROUTING_)
-  OBJS += vrrp_iproute.o vrrp_iprule.o
+  OBJS += vrrp_iproute.o vrrp_iprule.o vrrp_ip_rule_route_parser.o
 endif
 
 ifeq ($(LIBIPTC_FLAG),_HAVE_LIBIPTC_)

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1685,13 +1685,9 @@ open_vrrp_send_socket(sa_family_t family, int proto, int idx, int unicast)
 		if_setsockopt_mcast_loop(family, &fd);
 	}
 
-	if_setsockopt_priority(&fd);
+	if_setsockopt_priority(&fd, family);
 
-    /* set tos to internet network control */
-	int tos = 0xc0; // 192, which translates to DCSP value 48, or cs6
-	setsockopt(fd, IPPROTO_IPV6, IPV6_TCLASS, &tos, sizeof(tos));
-
-    if (fd < 0)
+	if (fd < 0)
 		return -1;
 
 	return fd;

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -43,6 +43,7 @@
 #include "signals.h"
 #include "process.h"
 #include "bitops.h"
+#include "rttables.h"
 #ifdef _WITH_LVS_
   #include "ipvswrapper.h"
 #endif
@@ -260,6 +261,8 @@ start_vrrp(void)
 		ifl = get_if_list();
 		if (!LIST_ISEMPTY(ifl))
 			dump_list(ifl);
+
+		clear_rt_names();
 	}
 
 	/* Initialize linkbeat */
@@ -325,7 +328,6 @@ reload_vrrp_thread(thread_t * thread)
 	kernel_netlink_close();
 	thread_cleanup_master(master);
 #ifdef _HAVE_IPVS_SYNCD_
-	/* TODO - Note: this didn't work if we found ipvs_syndc on vrrp before on old_vrrp */
 	if (global_data->lvs_syncd.ifname)
 		ipvs_syncd_cmd(IPVS_STOPDAEMON, &global_data->lvs_syncd,
 		       (global_data->lvs_syncd.vrrp->state == VRRP_STATE_MAST) ? IPVS_MASTER:

--- a/keepalived/vrrp/vrrp_ip_rule_route_parser.c
+++ b/keepalived/vrrp/vrrp_ip_rule_route_parser.c
@@ -1,0 +1,296 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        iprule and iproute parser
+ *
+ * Author:      Chris Riley, <kernelchris@gmail.com>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2015 Chris Riley, <kernelchris@gmail.com>
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <math.h>
+#include <arpa/inet.h>
+
+#include "logger.h"
+#include "vrrp_ip_rule_route_parser.h"
+#include "rttables.h"
+#ifdef _HAVE_RTA_ENCAP_
+#include "vrrp_iproute.h"
+#endif
+
+bool
+get_realms(uint32_t *realms, char *str)
+{
+	uint32_t val, val1;
+	char *end;
+
+	if ((end = strchr(str,'/')))
+		*end = '\0';
+
+	if (!find_rttables_realms(str, &val))
+		goto err;
+
+	if (end) {
+		if (!find_rttables_realms(end + 1, &val1))
+			goto err;
+
+		val <<= 16;
+		val |= val1;
+
+		*end = '/';
+	}
+
+	*realms = val;
+
+	return false;
+
+err:
+	if (end)
+		*end = '/';
+	return true;
+}
+
+
+bool
+get_u8(uint8_t *val, const char *str, uint8_t max, const char* errmsg)
+{
+	char *end;
+	unsigned long t_val;
+
+	t_val = strtoul(str, &end, 0);
+	if (*end == '\0' && t_val <= max) {
+		*val = t_val;
+		return false;
+	}
+
+	log_message(LOG_INFO, errmsg, str);
+	return true;
+}
+
+bool
+get_u16(uint16_t *val, const char *str, uint16_t max, const char* errmsg)
+{
+	char *end;
+	unsigned long t_val;
+
+	/* strtoul can do "nasty" things with -ve unsigneds */
+	if (str[0] == '-')
+		return true;
+
+	t_val = strtoul(str, &end, 0);
+	if (*end == '\0' && t_val <= max) {
+		*val = t_val;
+		return false;
+	}
+
+	log_message(LOG_INFO, errmsg, str);
+	return true;
+}
+
+bool
+get_u32(uint32_t *val, const char *str, uint32_t max, const char* errmsg)
+{
+	char *end;
+	unsigned long t_val;
+
+	/* strtoul can do "nasty" things with -ve unsigneds */
+	if (str[0] == '-')
+		return true;
+
+	t_val = strtoul(str, &end, 0);
+	if (*end == '\0' && t_val <= max) {
+		*val = t_val;
+		return false;
+	}
+
+	log_message(LOG_INFO, errmsg, str);
+	return true;
+}
+
+bool
+get_u64(uint64_t *val, const char *str, uint64_t max, const char* errmsg)
+{
+	char *end;
+	unsigned long long t_val;
+
+	/* strtoull can do "nasty" things with -ve unsigneds */
+	if (str[0] == '-')
+		return true;
+
+	t_val = strtoull(str, &end, 0);
+	if (*end == '\0' && t_val <= max) {
+		*val = t_val;
+		return false;
+	}
+
+	log_message(LOG_INFO, errmsg, str);
+	return true;
+}
+
+bool
+get_time_rtt(uint32_t *val, const char *str, bool *raw)
+{
+	double t;
+	unsigned long res;
+	char *end;
+
+	errno = 0;
+	if (strchr(str, '.') ||
+	    (strpbrk(str,"Ee" ) && !strpbrk(str, "xX"))) {
+		t = strtod(str, &end);
+		if (t <= 0.0)
+			return true;
+
+		/* no digits? */
+		if (end == str)
+			return true;
+
+		/* overflow */
+		if (t == HUGE_VAL && errno == ERANGE)
+			return true;
+
+		if (t >=UINT_MAX)
+			return -1;
+	} else {
+		/* strtoul does "nasty" things with negative numbers */
+		if (str[0] == '-')
+			return -1;
+
+		res = strtoul(str, &end, 0);
+
+		/* no digits? */
+		if (end == str)
+			return true;
+
+		/* overflow */
+		if (res == ULONG_MAX && errno == ERANGE)
+			return true;
+
+		if (res >= UINT_MAX)
+			return -1;
+
+		t = (double)res;
+	}
+
+	if (*end) {
+		*raw = false;
+                if (!strcasecmp(end, "s") ||
+		    !strcasecmp(end, "sec") ||
+                    !strcasecmp(end, "secs")) {
+			if (t >= UINT_MAX / 1000)
+				return -1;
+                        t *= 1000;
+		}
+                else if (strcasecmp(end, "ms") &&
+			 strcasecmp(end, "msec") &&
+                         strcasecmp(end, "msecs"))
+                        return true;
+        }
+	else
+		*raw = true;
+
+	*val = t;
+	if (*val < t)
+		(*val)++;
+	
+        return false;
+}
+
+bool
+get_addr64(uint64_t *ap, const char *cp)
+{
+	int i;
+
+	union {
+		uint16_t v16[4];
+		uint64_t v64;
+	} val;
+
+	val.v64 = 0;
+	for (i = 0; i < 4; i++) {
+		unsigned long n;
+		char *endp;
+
+		n = strtoul(cp, &endp, 16);
+		if (n > 0xffff)
+			return true;	/* bogus network value */
+
+		if (endp == cp) /* no digits */
+			return true;
+
+		val.v16[i] = htons(n);
+
+		if (*endp == '\0') {
+			if (i != 3)	/* address too short */
+				return true;
+			break;
+		}
+
+		if (i == 3 || *endp != ':')
+			return true;	/* extra characters */
+		cp = endp + 1;
+	}
+
+	*ap = val.v64;
+
+	return false;
+}
+
+#ifdef _HAVE_RTA_ENCAP_
+bool
+parse_mpls_address(const char *str, encap_mpls_t *mpls)
+{
+	char *endp;
+	unsigned count;
+	unsigned long label;
+
+	mpls->num_labels = 0;
+
+	for (count = 0; count < MAX_MPLS_LABELS; count++) {
+		if (str[0] == '-')
+			return true;
+
+		label = strtoul(str, &endp, 0);
+
+		/* Fail when the label value is out of range */
+		if (label > UINT32_MAX)
+			return true;
+		if (label & ~(MPLS_LS_LABEL_MASK >> MPLS_LS_LABEL_SHIFT))
+			return true;
+
+		if (endp == str) /* no digits */
+			return true;
+
+		mpls->addr[count].entry = htonl(label << MPLS_LS_LABEL_SHIFT);
+		if (*endp == '\0') {
+			mpls->addr[count].entry |= htonl(1 << MPLS_LS_S_SHIFT);
+			mpls->num_labels = count + 1;
+			return false;
+		}
+
+		/* Bad character in the address */
+		if (*endp != '/')
+			return true;
+
+		str = endp + 1;
+	}
+	/* The address was too long */
+	return true;
+}
+#endif

--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -32,6 +32,7 @@
 #include "utils.h"
 #include "bitops.h"
 #include "global_data.h"
+#include "rttables.h"
 
 
 #define INFINITY_LIFE_TIME      0xFFFFFFFF
@@ -326,7 +327,7 @@ dump_ipaddress(void *if_data)
 			    , ipaddr->ifa.ifa_prefixlen
 			    , broadcast
 			    , IF_NAME(ipaddr->ifp)
-			    , netlink_scope_n2a(ipaddr->ifa.ifa_scope)
+			    , get_rttables_scope(ipaddr->ifa.ifa_scope)
 			    , ipaddr->label ? " label " : ""
 			    , ipaddr->label ? ipaddr->label : "");
 }
@@ -396,7 +397,7 @@ alloc_ipaddress(list ip_list, vector_t *strvec, interface_t *ifp)
 	interface_t *ifp_local;
 	char *str;
 	unsigned int i = 0, addr_idx = 0;
-	int scope;
+	uint32_t scope;
 	int param_avail;
 
 	new = (ip_address_t *) MALLOC(sizeof(ip_address_t));
@@ -439,7 +440,7 @@ alloc_ipaddress(list ip_list, vector_t *strvec, interface_t *ifp)
 			new->ifa.ifa_index = IF_INDEX(ifp_local);
 			new->ifp = ifp_local;
 		} else if (!strcmp(str, "scope")) {
-			scope = netlink_scope_a2n(vector_slot(strvec, ++i));
+			find_rttables_scope(vector_slot(strvec, ++i), &scope);
 			if (scope == -1)
 				log_message(LOG_INFO, "Invalid scope '%s' specified for %s - ignoring", FMT_STR_VSLOT(strvec,i), FMT_STR_VSLOT(strvec, addr_idx));
 			else

--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -30,6 +30,21 @@
 #include "memory.h"
 #include "utils.h"
 #include "rttables.h"
+#include "vrrp_ip_rule_route_parser.h"
+
+#include <linux/icmpv6.h>
+#include <inttypes.h>
+#ifdef _HAVE_RTA_ENCAP_
+#include <linux/lwtunnel.h>
+#include <linux/mpls_iptunnel.h>
+#include <linux/ila.h>
+#endif
+
+/* Buffer sizes for netlink messages. Increase if needed. */
+#define	RTM_SIZE		1024
+#define	RTA_SIZE		1024
+#define	ENCAP_RTA_SIZE		 128
+#define NEXTHOP_RTA_SIZE	1024
 
 /* Utility functions */
 static int
@@ -41,13 +56,43 @@ add_addr2req(struct nlmsghdr *n, int maxlen, int type, ip_address_t *ip_address)
 	if (!ip_address)
 		return -1;
 
-	addr = (IP_IS6(ip_address)) ? (void *) &ip_address->u.sin6_addr :
-				     (void *) &ip_address->u.sin.sin_addr;
-	alen = (IP_IS6(ip_address)) ? sizeof(ip_address->u.sin6_addr) :
-				     sizeof(ip_address->u.sin.sin_addr);
+	if (IP_IS6(ip_address)) {
+		addr = (void *) &ip_address->u.sin6_addr;
+		alen = sizeof(ip_address->u.sin6_addr);
+	}
+	else
+	{
+	     addr = (void *) &ip_address->u.sin.sin_addr;
+	     alen = sizeof(ip_address->u.sin.sin_addr);
+	}
 
 	return addattr_l(n, maxlen, type, addr, alen);
 }
+
+#ifdef _HAVE_RTA_VIA_
+static int
+add_addr_fam2req(struct nlmsghdr *n, int maxlen, int type, ip_address_t *ip_address)
+{
+	void *addr;
+	int alen;
+	uint16_t family;
+
+	if (!ip_address)
+		return -1;
+
+	if (IP_IS6(ip_address)) {
+		addr = (void *)&ip_address->u.sin6_addr;
+		alen = sizeof(ip_address->u.sin6_addr);
+	}
+	else {
+		addr = (void *)&ip_address->u.sin.sin_addr;
+		alen = sizeof(ip_address->u.sin.sin_addr);
+	}
+	family = ip_address->ifa.ifa_family;
+
+	return addattr_l2(n, maxlen, type, &family, sizeof(family), addr, alen);
+}
+#endif
 
 static int
 add_addr2rta(struct rtattr *rta, int maxlen, int type, ip_address_t *ip_address)
@@ -58,12 +103,177 @@ add_addr2rta(struct rtattr *rta, int maxlen, int type, ip_address_t *ip_address)
 	if (!ip_address)
 		return -1;
 
-	addr = (IP_IS6(ip_address)) ? (void *) &ip_address->u.sin6_addr :
-				     (void *) &ip_address->u.sin.sin_addr;
-	alen = (IP_IS6(ip_address)) ? sizeof(ip_address->u.sin6_addr) :
-				     sizeof(ip_address->u.sin.sin_addr);
+	if (IP_IS6(ip_address)) {
+		addr = (void *)&ip_address->u.sin6_addr;
+		alen = sizeof(ip_address->u.sin6_addr);
+	}
+	else {
+		addr = (void *)&ip_address->u.sin.sin_addr;
+		alen = sizeof(ip_address->u.sin.sin_addr);
+	}
 
 	return rta_addattr_l(rta, maxlen, type, addr, alen);
+}
+
+#ifdef _HAVE_RTA_VIA_
+static int
+add_addrfam2rta(struct rtattr *rta, int maxlen, int type, ip_address_t *ip_address)
+{
+	void *addr;
+	int alen;
+	uint16_t family;
+
+	if (!ip_address)
+		return -1;
+
+	if (IP_IS6(ip_address)) {
+		addr = (void *)&ip_address->u.sin6_addr;
+		alen = sizeof(ip_address->u.sin6_addr);
+	}
+	else {
+		addr = (void *)&ip_address->u.sin.sin_addr;
+		alen = sizeof(ip_address->u.sin.sin_addr);
+	}
+	family = ip_address->ifa.ifa_family;
+
+	return rta_addattr_l2(rta, maxlen, type, &family, sizeof(family), addr, alen);
+}
+#endif
+
+#ifdef _HAVE_RTA_ENCAP_
+static void
+add_encap_mpls(struct rtattr *rta, size_t len, const encap_t *encap)
+{
+	rta_addattr_l(rta, len, MPLS_IPTUNNEL_DST, &encap->mpls.addr, encap->mpls.num_labels * sizeof(encap->mpls.addr[0]));
+}
+
+static void
+add_encap_ip(struct rtattr *rta, size_t len, const encap_t *encap)
+{
+	if (encap->flags & IPROUTE_BIT_ENCAP_ID)
+		rta_addattr64(rta, len, LWTUNNEL_IP_ID, htonll(encap->ip.id));
+	if (encap->ip.dst)
+		rta_addattr_l(rta, len, LWTUNNEL_IP_DST, &encap->ip.dst->u.sin.sin_addr.s_addr, sizeof(encap->ip.dst->u.sin.sin_addr.s_addr));
+	if (encap->ip.src)
+		rta_addattr_l(rta, len, LWTUNNEL_IP_SRC, &encap->ip.src->u.sin.sin_addr.s_addr, sizeof(encap->ip.src->u.sin.sin_addr.s_addr));
+	if (encap->flags & IPROUTE_BIT_ENCAP_DSFIELD)
+		rta_addattr8(rta, len, LWTUNNEL_IP_TOS, encap->ip.tos);
+	if (encap->flags & IPROUTE_BIT_ENCAP_HOPLIMIT)
+		rta_addattr8(rta, len, LWTUNNEL_IP_TTL, encap->ip.ttl);
+	if (encap->flags & IPROUTE_BIT_ENCAP_FLAGS)
+		rta_addattr16(rta, len, LWTUNNEL_IP_FLAGS, encap->ip.flags);
+}
+
+static void
+add_encap_ila(struct rtattr *rta, size_t len, const encap_t *encap)
+{
+	rta_addattr64(rta, len, ILA_ATTR_LOCATOR, encap->ila.locator);
+}
+
+static void
+add_encap_ip6(struct rtattr *rta, size_t len, const encap_t *encap)
+{
+	if (encap->flags & IPROUTE_BIT_ENCAP_ID)
+		rta_addattr64(rta, len, LWTUNNEL_IP6_ID, htonll(encap->ip6.id));
+	if (encap->ip6.dst)
+		rta_addattr_l(rta, len, LWTUNNEL_IP6_DST, &encap->ip6.dst->u.sin6_addr, sizeof(encap->ip6.dst->u.sin6_addr));
+	if (encap->ip6.src)
+		rta_addattr_l(rta, len, LWTUNNEL_IP6_SRC, &encap->ip6.src->u.sin6_addr, sizeof(encap->ip6.src->u.sin6_addr));
+	if (encap->flags & IPROUTE_BIT_ENCAP_DSFIELD)
+		rta_addattr8(rta, len, LWTUNNEL_IP6_TC, encap->ip6.tc);
+	if (encap->flags & IPROUTE_BIT_ENCAP_HOPLIMIT)
+		rta_addattr8(rta, len, LWTUNNEL_IP6_HOPLIMIT, encap->ip6.hoplimit);
+	if (encap->flags & IPROUTE_BIT_ENCAP_FLAGS)
+		rta_addattr16(rta, len, LWTUNNEL_IP6_FLAGS, encap->ip6.flags);
+}
+
+static bool
+add_encap(struct rtattr *rta, size_t len, encap_t *encap)
+{
+	struct rtattr *nest;
+
+	nest = rta_nest(rta, len, RTA_ENCAP);
+	switch (encap->type) {
+	case LWTUNNEL_ENCAP_MPLS:
+		add_encap_mpls(rta, len, encap);
+		break;
+	case LWTUNNEL_ENCAP_IP:
+		add_encap_ip(rta, len, encap);
+		break;
+	case LWTUNNEL_ENCAP_ILA:
+		add_encap_ila(rta, len, encap);
+		break;
+	case LWTUNNEL_ENCAP_IP6:
+		add_encap_ip6(rta, len, encap);
+		break;
+	default:
+		log_message(LOG_INFO, "unknown encap type %d", encap->type);
+		break;
+	}
+	rta_nest_end(rta, nest);
+
+	rta_addattr16(rta, len, RTA_ENCAP_TYPE, encap->type);
+
+	return true;
+}
+#endif
+
+static void
+add_nexthop(nexthop_t *nh, struct nlmsghdr *nlh, struct rtmsg *rtm, struct rtattr *rta, size_t len, struct rtnexthop *rtnh)
+{
+	if (nh->addr) {
+		if (rtm->rtm_family == nh->addr->ifa.ifa_family)
+			rtnh->rtnh_len += add_addr2rta(rta, len, RTA_GATEWAY, nh->addr);
+#ifdef _HAVE_RTA_VIA_
+		else
+			rtnh->rtnh_len += add_addrfam2rta(rta, len, RTA_VIA, nh->addr);
+#endif
+	}
+	if (nh->ifp)
+		rtnh->rtnh_ifindex = nh->ifp->ifindex;
+
+	if (nh->mask |= IPROUTE_BIT_WEIGHT)
+		rtnh->rtnh_hops = nh->weight;
+
+	rtnh->rtnh_flags = nh->flags;
+
+	if (nh->realms)
+		rtnh->rtnh_len += rta_addattr32(rta, len, RTA_FLOW, nh->realms);
+
+#ifdef _HAVE_RTA_ENCAP_
+	if (nh->encap.type != LWTUNNEL_ENCAP_NONE) {
+		int len = rta->rta_len;
+		add_encap(rta, len, &nh->encap);
+		rtnh->rtnh_len += rta->rta_len - len;
+	}
+#endif
+}
+
+static void
+add_nexthops(ip_route_t *route, struct nlmsghdr *nlh, struct rtmsg *rtm)
+{
+	char buf[ENCAP_RTA_SIZE];
+	struct rtattr *rta = (void *)buf;
+	struct rtnexthop *rtnh;
+	nexthop_t *nh;
+	element e;
+
+	rta->rta_type = RTA_MULTIPATH;
+	rta->rta_len = RTA_LENGTH(0);
+	rtnh = RTA_DATA(rta);
+
+	for (e = LIST_HEAD(route->nhs); e; ELEMENT_NEXT(e)) {
+		nh = ELEMENT_DATA(e);
+
+		memset(rtnh, 0, sizeof(*rtnh));
+		rtnh->rtnh_len = sizeof(*rtnh);
+		rta->rta_len += rtnh->rtnh_len;
+		add_nexthop(nh, nlh, rtm, rta, sizeof(buf), rtnh);
+		rtnh = RTNH_NEXT(rtnh);
+	}
+
+	if (rta->rta_len > RTA_LENGTH(0))
+		addattr_l(nlh, sizeof(buf), RTA_MULTIPATH, RTA_DATA(rta), RTA_PAYLOAD(rta));
 }
 
 /* Add/Delete IP route to/from a specific interface */
@@ -74,71 +284,212 @@ netlink_route(ip_route_t *iproute, int cmd)
 	struct {
 		struct nlmsghdr n;
 		struct rtmsg r;
-		char buf[1024];
+		char buf[RTM_SIZE];
 	} req;
-
-	char buf[1024];
+	char buf[RTA_SIZE];
 	struct rtattr *rta = (void*)buf;
-	struct rtnexthop *rtnh;
 
 	memset(&req, 0, sizeof (req));
 
 	req.n.nlmsg_len   = NLMSG_LENGTH(sizeof(struct rtmsg));
-	req.n.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE;
-	req.n.nlmsg_type  = cmd ? RTM_NEWROUTE : RTM_DELROUTE;
-	req.r.rtm_family  = (iproute->dst) ? IP_FAMILY(iproute->dst) :
-			    (iproute->src) ? IP_FAMILY(iproute->src) :
-			    AF_INET;
+	if (cmd == IPROUTE_DEL) {
+		req.n.nlmsg_flags = NLM_F_REQUEST;
+		req.n.nlmsg_type  = RTM_DELROUTE;
+	}
+	else {
+		req.n.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE;
+		if (cmd == IPROUTE_REPLACE)
+			req.n.nlmsg_flags |= NLM_F_REPLACE;
+		req.n.nlmsg_type  = RTM_NEWROUTE;
+	}
+
+	rta->rta_type = RTA_METRICS;
+	rta->rta_len = RTA_LENGTH(0);
+
+	req.r.rtm_family = iproute->family;
 	if (iproute->table < 256)
-		req.r.rtm_table   = iproute->table ? iproute->table : RT_TABLE_MAIN;
+		req.r.rtm_table = iproute->table;
 	else {
 		req.r.rtm_table = RT_TABLE_UNSPEC;
 		addattr32(&req.n, sizeof(req), RTA_TABLE, iproute->table);
 	}
-	req.r.rtm_scope   = RT_SCOPE_NOWHERE;
 
-	if (cmd == IPROUTE_ADD) {
-		req.r.rtm_protocol = RTPROT_BOOT;
-		req.r.rtm_scope = iproute->scope;
-		req.r.rtm_type = RTN_UNICAST;
+	if (cmd == IPROUTE_DEL) {
+		req.r.rtm_scope = RT_SCOPE_NOWHERE;
+		if (iproute->mask & IPROUTE_BIT_TYPE)
+			req.r.rtm_type = iproute->type;
 	}
-	if (iproute->blackhole)
-		req.r.rtm_type = RTN_BLACKHOLE;
+	else {
+		req.r.rtm_protocol = RTPROT_BOOT;
+		req.r.rtm_scope = RT_SCOPE_UNIVERSE;
+		req.r.rtm_type = iproute->type;
+	}
 
-	/* Set routing entry */
+	if (iproute->mask & IPROUTE_BIT_PROTOCOL)
+		req.r.rtm_protocol = iproute->protocol;
+
+	if (iproute->mask & IPROUTE_BIT_SCOPE)
+		req.r.rtm_scope = iproute->scope;
+
 	if (iproute->dst) {
-		req.r.rtm_dst_len = iproute->dmask;
+		req.r.rtm_dst_len = iproute->dst->ifa.ifa_prefixlen;
 		add_addr2req(&req.n, sizeof(req), RTA_DST, iproute->dst);
 	}
-	if ((!iproute->blackhole) && (!iproute->gw2))
-		add_addr2req(&req.n, sizeof(req), RTA_GATEWAY, iproute->gw);
-	if (iproute->gw && iproute->gw2) {
-		rta->rta_type = RTA_MULTIPATH;
-		rta->rta_len = RTA_LENGTH(0);
-		rtnh = RTA_DATA(rta);
-#define MULTIPATH_ADD_GW(x) \
-	memset(rtnh, 0, sizeof(*rtnh)); \
-	rtnh->rtnh_len = sizeof(*rtnh); \
-	if (iproute->index) rtnh->rtnh_ifindex = iproute->index; \
-	rta->rta_len += rtnh->rtnh_len;	\
-	add_addr2rta(rta, 1024, RTA_GATEWAY, x); \
-	rtnh->rtnh_len += sizeof(struct rtattr) + IP_SIZE(x); \
-	rtnh = RTNH_NEXT(rtnh);
-		MULTIPATH_ADD_GW(iproute->gw);
-		MULTIPATH_ADD_GW(iproute->gw2);
-		addattr_l(&req.n, sizeof(req), RTA_MULTIPATH, RTA_DATA(rta), RTA_PAYLOAD(rta));
+
+	if (iproute->src) {
+		req.r.rtm_src_len = iproute->src->ifa.ifa_prefixlen;
+		add_addr2req(&req.n, sizeof(req), RTA_SRC, iproute->src);
 	}
-	if ((iproute->index) && (!iproute->gw2))
-		addattr32(&req.n, sizeof(req), RTA_OIF, iproute->index);
-	if (iproute->src)
-		add_addr2req(&req.n, sizeof(req), RTA_PREFSRC, iproute->src);
-	if (iproute->metric)
+
+	if (iproute->pref_src)
+		add_addr2req(&req.n, sizeof(req), RTA_PREFSRC, iproute->pref_src);
+
+//#ifdef _HAVE_RTA_NEWDST_
+//	if (iproute->as_to)
+//		add_addr2req(&req.n, sizeof(req), RTA_NEWDST, iproute->as_to);
+//#endif
+
+	if (iproute->via) {
+		if (iproute->via->ifa.ifa_family == iproute->family)
+			add_addr2req(&req.n, sizeof(req), RTA_GATEWAY, iproute->via);
+#ifdef _HAVE_RTA_VIA_
+		else
+			add_addr_fam2req(&req.n, sizeof(req), RTA_VIA, iproute->via);
+#endif
+	}
+
+#ifdef _HAVE_RTA_ENCAP_
+	if (iproute->encap.type != LWTUNNEL_ENCAP_NONE) {
+		char encap_buf[ENCAP_RTA_SIZE];
+		struct rtattr *encap_rta = (void *)encap_buf;
+
+		encap_rta->rta_type = RTA_ENCAP;
+		encap_rta->rta_len = RTA_LENGTH(0);
+		add_encap(encap_rta, sizeof(encap_buf), &iproute->encap);
+
+		if (encap_rta->rta_len > RTA_LENGTH(0))
+			addraw_l(&req.n, sizeof(encap_buf), RTA_DATA(encap_rta), RTA_PAYLOAD(encap_rta));
+	}
+#endif
+
+	if (iproute->mask & IPROUTE_BIT_DSFIELD)
+		req.r.rtm_tos = iproute->tos;
+	
+	if (iproute->oif)
+		addattr32(&req.n, sizeof(req), RTA_OIF, iproute->oif->ifindex);
+
+	if (iproute->mask & IPROUTE_BIT_METRIC)
 		addattr32(&req.n, sizeof(req), RTA_PRIORITY, iproute->metric);
+
+	req.r.rtm_flags = iproute->flags;
+
+	if (iproute->realms)
+		addattr32(&req.n, sizeof(req), RTA_FLOW, iproute->realms);
+
+#ifdef _HAVE_RTA_EXPIRES_
+	if (iproute->mask & IPROUTE_BIT_EXPIRES)
+		addattr32(&req.n, sizeof(req), RTA_EXPIRES, iproute->expires);
+#endif
+
+#ifdef RTAX_CC_ALGO
+	if (iproute->congctl)
+		rta_addattr_l(rta, sizeof(buf), RTAX_CC_ALGO, iproute->congctl, strlen(iproute->congctl));
+#endif
+
+	if (iproute->mask & IPROUTE_BIT_RTT)
+		rta_addattr32(rta, sizeof(buf), RTAX_RTT, iproute->rtt);
+
+	if (iproute->mask & IPROUTE_BIT_RTTVAR)
+		rta_addattr32(rta, sizeof(buf), RTAX_RTTVAR, iproute->rttvar);
+
+	if (iproute->mask & IPROUTE_BIT_RTO_MIN)
+		rta_addattr32(rta, sizeof(buf), RTAX_RTO_MIN, iproute->rto_min);
+
+#ifdef RTAX_FEATURES
+	if (iproute->features)
+		rta_addattr32(rta, sizeof(buf), RTAX_FEATURES, iproute->features);
+#endif
+
+	if (iproute->mask & IPROUTE_BIT_MTU)
+		rta_addattr32(rta, sizeof(buf), RTAX_MTU, iproute->mtu);
+
+	if (iproute->mask & IPROUTE_BIT_WINDOW)
+		rta_addattr32(rta, sizeof(buf), RTAX_WINDOW, iproute->window);
+
+	if (iproute->mask & IPROUTE_BIT_SSTHRESH)
+		rta_addattr32(rta, sizeof(buf), RTAX_SSTHRESH, iproute->ssthresh);
+
+	if (iproute->mask & IPROUTE_BIT_CWND)
+		rta_addattr32(rta, sizeof(buf), RTAX_CWND, iproute->cwnd);
+
+	if (iproute->mask & IPROUTE_BIT_ADVMSS)
+		rta_addattr32(rta, sizeof(buf), RTAX_ADVMSS, iproute->advmss);
+
+	if (iproute->mask & IPROUTE_BIT_REORDERING)
+		rta_addattr32(rta, sizeof(buf), RTAX_REORDERING, iproute->reordering);
+
+	if (iproute->mask & IPROUTE_BIT_HOPLIMIT)
+		rta_addattr32(rta, sizeof(buf), RTAX_HOPLIMIT, iproute->hoplimit);
+
+	if (iproute->mask & IPROUTE_BIT_INITCWND)
+		rta_addattr32(rta, sizeof(buf), RTAX_INITCWND, iproute->initcwnd);
+
+#ifdef RTAX_INITRWND
+	if (iproute->mask & IPROUTE_BIT_INITRWND)
+		rta_addattr32(rta, sizeof(buf), RTAX_INITRWND, iproute->initrwnd);
+#endif
+
+#ifdef RTAX_QUICKACK
+	if (iproute->mask & IPROUTE_BIT_QUICKACK)
+		rta_addattr32(rta, sizeof(buf), RTAX_QUICKACK, iproute->quickack);
+#endif
+
+#ifdef _HAVE_RTA_PREF_
+	if (iproute->mask & IPROUTE_BIT_PREF)
+		addattr8(&req.n, sizeof(req), RTA_PREF, iproute->pref);
+#endif
+
+	if (rta->rta_len > RTA_LENGTH(0)) {
+		if (iproute->lock)
+			rta_addattr32(rta, sizeof(buf), RTAX_LOCK, iproute->lock);
+		addattr_l(&req.n, sizeof(req), RTA_METRICS, RTA_DATA(rta), RTA_PAYLOAD(rta));
+	}
+
+	if (!LIST_ISEMPTY(iproute->nhs))
+		add_nexthops(iproute, &req.n, &req.r);
+
+#ifdef DEBUG_NETLINK_MSG
+	size_t i, j;
+	uint8_t *p;
+	char lbuf[3072];
+	char *op = lbuf;
+
+	log_message(LOG_INFO, "rtmsg buffer used %lu, rtattr buffer used %d", req.n.nlmsg_len - NLMSG_LENGTH(sizeof(struct rtmsg)), rta->rta_len);
+
+	op += snprintf(op, sizeof(lbuf) - (op - lbuf), "nlmsghdr %p(%u):", &req.n, req.n.nlmsg_len);
+	for (i = 0, p = (uint8_t*)&req.n; i < sizeof(struct nlmsghdr); i++)
+		op += snprintf(op, sizeof(lbuf) - (op - lbuf), " %2.2hhx", *(p++));
+	log_message(LOG_INFO, "%s\n", lbuf);
+
+	op = lbuf;
+	op += snprintf(op, sizeof(lbuf) - (op - lbuf), "rtmsg %p(%lu):", &req.r, req.n.nlmsg_len - sizeof(struct nlmsghdr));
+	for (i = 0, p = (uint8_t*)&req.r; i < + req.n.nlmsg_len - sizeof(struct nlmsghdr); i++)
+		op += snprintf(op, sizeof(lbuf) - (op - lbuf), " %2.2hhx", *(p++));
+
+	for (j = 0; lbuf + j < op; j+= MAX_LOG_MSG)
+		log_message(LOG_INFO, "%.*\n", MAX_LOG_MSG, lbuf+j);
+#endif
 
 	/* This returns ESRCH if the address of via address doesn't exist */
 	/* ENETDOWN if dev p33p1.40 for example is down */
-	if (netlink_talk(&nl_cmd, &req.n) < 0)
-		status = -1;
+	if (netlink_talk(&nl_cmd, &req.n) < 0) {
+#ifdef _HAVE_RTA_EXPIRES_
+		/* If an expiry was set on the route, it may have disappeared already */
+		if (cmd != IPADDRESS_DEL || !(iproute->mask & IPROUTE_BIT_EXPIRES))
+#endif
+			status = -1;
+	}
+
 	return status;
 }
 
@@ -155,8 +506,7 @@ netlink_rtlist(list rt_list, int cmd)
 
 	for (e = LIST_HEAD(rt_list); e; ELEMENT_NEXT(e)) {
 		iproute = ELEMENT_DATA(e);
-		if ((cmd == IPROUTE_ADD && !iproute->set) ||
-		    (cmd == IPROUTE_DEL && iproute->set)) {
+		if ((cmd == IPROUTE_DEL) == iproute->set) {
 			if (netlink_route(iproute, cmd) > 0)
 				iproute->set = (cmd == IPROUTE_ADD);
 			else
@@ -166,6 +516,37 @@ netlink_rtlist(list rt_list, int cmd)
 }
 
 /* Route dump/allocation */
+#ifdef _HAVE_RTA_ENCAP_
+void
+free_encap(void *rt_data)
+{
+	encap_t *encap = rt_data;
+
+	if (encap->type == LWTUNNEL_ENCAP_IP) {
+		FREE_PTR(encap->ip.dst);
+		FREE_PTR(encap->ip.src);
+	}
+	else if (encap->type == LWTUNNEL_ENCAP_IP6) {
+		FREE_PTR(encap->ip6.dst);
+		FREE_PTR(encap->ip6.src);
+	}
+
+	FREE(rt_data);
+}
+#endif
+
+void
+free_nh(void *rt_data)
+{
+	nexthop_t *nh = rt_data;
+
+	FREE_PTR(nh->addr);
+//#ifdef _HAVE_RTA_NEWDST_
+//	FREE_PTR(nh->as_to);
+//#endif
+	FREE(rt_data);
+}
+
 void
 free_iproute(void *rt_data)
 {
@@ -173,117 +554,1104 @@ free_iproute(void *rt_data)
 
 	FREE_PTR(route->dst);
 	FREE_PTR(route->src);
-	FREE_PTR(route->gw);
-	FREE_PTR(route->gw2);
+	FREE_PTR(route->pref_src);
+	FREE_PTR(route->via);
+	free_list(&route->nhs);
+#ifdef RTAX_CC_ALGO
+	FREE_PTR(route->congctl);
+#endif
 	FREE(rt_data);
 }
+
+#ifdef _HAVE_RTA_ENCAP_
+static size_t
+print_encap_mpls(char *op, size_t len, const encap_t* encap)
+{
+	int i;
+	char *opn = op;
+
+	opn += snprintf(opn, len - (opn - op), " encap mpls");
+	for (i = 0; i < encap->mpls.num_labels; i++)
+		opn += snprintf(opn, len - (opn - op), "%s%x", i ? "/" : " ", ntohl(encap->mpls.addr[i].entry));
+
+	return opn - op;
+}
+
+static size_t
+print_encap_ip(char *op, size_t len, const encap_t* encap)
+{
+	char *opn = op;
+
+	opn += snprintf(opn, len - (opn - op), " encap ip");
+
+	if (encap->flags & IPROUTE_BIT_ENCAP_ID)
+		opn += snprintf(opn, len - (opn - op), " id %" PRIu64, encap->ip.id);
+	if (encap->ip.dst)
+		opn += snprintf(opn, len - (opn - op), " dst %s", ipaddresstos(NULL, encap->ip.dst));
+	if (encap->ip.src)
+		opn += snprintf(opn, len - (opn - op), " src %s", ipaddresstos(NULL, encap->ip.src));
+	if (encap->flags & IPROUTE_BIT_ENCAP_DSFIELD)
+		opn += snprintf(opn, len - (opn - op), " tos %d", encap->ip.tos);
+	if (encap->flags & IPROUTE_BIT_ENCAP_TTL)
+		opn += snprintf(opn, len - (opn - op), " ttl %d", encap->ip.ttl);
+	if (encap->flags & IPROUTE_BIT_ENCAP_FLAGS)
+		opn += snprintf(opn, len - (opn - op), " flags 0x%x", encap->ip.flags);
+
+	return opn - op;
+}
+
+static size_t
+print_encap_ila(char *op, size_t len, const encap_t* encap)
+{
+	return snprintf(op, len, " encap ila %" PRIu64, encap->ila.locator);
+}
+
+static size_t
+print_encap_ip6(char *op, size_t len, const encap_t* encap)
+{
+	char *opn = op;
+
+	opn += snprintf(opn, len - (opn - op), " encap ip6");
+
+	if (encap->flags & IPROUTE_BIT_ENCAP_ID)
+		opn += snprintf(opn, len - (opn - op), " id %" PRIu64, encap->ip6.id);
+	if (encap->ip.dst)
+		opn += snprintf(opn, len - (opn - op), " dst %s", ipaddresstos(NULL, encap->ip6.dst));
+	if (encap->ip.src)
+		opn += snprintf(opn, len - (opn - op), " src %s", ipaddresstos(NULL, encap->ip6.src));
+	if (encap->flags & IPROUTE_BIT_ENCAP_DSFIELD)
+		opn += snprintf(opn, len - (opn - op), " tc %d", encap->ip6.tc);
+	if (encap->flags & IPROUTE_BIT_ENCAP_HOPLIMIT)
+		opn += snprintf(opn, len - (opn - op), " hoplimit %d", encap->ip6.hoplimit);
+	if (encap->flags & IPROUTE_BIT_ENCAP_FLAGS)
+		opn += snprintf(opn, len - (opn - op), " flags 0x%x", encap->ip6.flags);
+
+	return opn - op;
+}
+
+static size_t
+print_encap(char *op, size_t len, const encap_t* encap)
+{
+	switch (encap->type) {
+	case LWTUNNEL_ENCAP_MPLS:
+		return print_encap_mpls(op, len, encap);
+	case LWTUNNEL_ENCAP_IP:
+		return print_encap_ip(op, len, encap);
+	case LWTUNNEL_ENCAP_ILA:
+		return print_encap_ila(op, len, encap);
+	case LWTUNNEL_ENCAP_IP6:
+		return print_encap_ip6(op, len, encap);
+	}
+
+	return snprintf(op, len, "unknown encap type %d", encap->type);
+}
+#endif
+
+void
+format_iproute(ip_route_t *route, char *buf, size_t buf_len)
+{
+	char *op = buf;
+	char *buf_end = buf + buf_len;
+	nexthop_t *nh;
+	element e;
+
+	if (route->type != RTN_UNICAST)
+		op += snprintf(op, buf_end - op, " %s", get_rttables_rtntype(route->type));
+	if (route->dst) {
+		op += snprintf(op, buf_end - op, " %s", ipaddresstos(NULL, route->dst));
+		if ((route->dst->ifa.ifa_family == AF_INET && route->dst->ifa.ifa_prefixlen != 32 ) ||
+		    (route->dst->ifa.ifa_family == AF_INET6 && route->dst->ifa.ifa_prefixlen != 128 ))
+			op += snprintf(op, buf_end - op, "/%u", route->dst->ifa.ifa_prefixlen);
+	}
+	else
+		op += snprintf(op, buf_end - op, " %s", "default");
+
+	if (route->src) {
+		op += snprintf(op, buf_end - op, " from %s", ipaddresstos(NULL, route->src));
+		if ((route->src->ifa.ifa_family == AF_INET && route->src->ifa.ifa_prefixlen != 32 ) ||
+		    (route->src->ifa.ifa_family == AF_INET6 && route->src->ifa.ifa_prefixlen != 128 ))
+			op += snprintf(op, buf_end - op, "/%u", route->src->ifa.ifa_prefixlen);
+	}
+
+//#ifdef _HAVE_RTA_NEWDST_
+//	/* MPLS only */
+//	if (route->as_to)
+//		op += snprintf(op, buf_end - op, " as to %s", ipaddresstos(NULL, route->as_to));
+//#endif
+
+	if (route->pref_src)
+		op += snprintf(op, buf_end - op, " src %s", ipaddresstos(NULL, route->pref_src));
+
+	if (route->mask & IPROUTE_BIT_DSFIELD)
+		op += snprintf(op, buf_end - op, " tos %u", route->tos);
+
+#ifdef _HAVE_RTA_ENCAP_
+	if (route->encap.type != LWTUNNEL_ENCAP_NONE)
+		op += print_encap(op, buf_end - op, &route->encap);
+#endif
+
+	if (route->via)
+		op += snprintf(op, buf_end - op, " via %s %s", route->via->ifa.ifa_family == AF_INET6 ? "inet6" : "inet", ipaddresstos(NULL, route->via));
+
+	if (route->oif)
+		op += snprintf(op, buf_end - op, " dev %s", route->oif->ifname);
+
+	if (route->table != RT_TABLE_MAIN)
+		op += snprintf(op, buf_end - op, " table %u", route->table);
+
+	if (route->mask & IPROUTE_BIT_PROTOCOL)
+		op += snprintf(op, buf_end - op, " proto %u", route->protocol);
+
+	if (route->mask & IPROUTE_BIT_SCOPE)
+		op += snprintf(op, buf_end - op, " scope %u", route->scope);
+
+	if (route->mask & IPROUTE_BIT_METRIC)
+		op += snprintf(op, buf_end - op, " metric %u", route->metric);
+
+	if (route->family == AF_INET && route->flags & RTNH_F_ONLINK)
+		op += snprintf(op, buf_end - op, " %s", "onlink");
+
+	if (route->realms) {
+		if (route->realms & 0xFFFF0000)
+			op += snprintf(op, buf_end - op, " realms %d/", route->realms >> 16);
+		else
+			op += snprintf(op, buf_end - op, " realm ");
+		op += snprintf(op, buf_end - op, "%d", route->realms & 0xFFFF);
+	}
+
+#ifdef _HAVE_RTA_EXPIRES_
+	if (route->mask & IPROUTE_BIT_EXPIRES)
+		op += snprintf(op, buf_end - op, " expires %dsec", route->expires);
+#endif
+
+#ifdef RTAX_CC_ALGO
+	if (route->congctl)
+		op += snprintf(op, buf_end - op, " congctl %s%s", route->congctl, route->lock & (1<<RTAX_CC_ALGO) ? "lock " : "");
+#endif
+
+	if (route->mask & IPROUTE_BIT_RTT) {
+		op += snprintf(op, buf_end - op, " %s%s ", "rtt", route->lock & (1<<RTAX_RTT) ? " lock" : "");
+		if (route->rtt >= 8000)
+			op += snprintf(op, buf_end - op, "%gs", route->rtt / 8000.0);
+		else
+			op += snprintf(op, buf_end - op, "%ums", route->rtt / 8);
+	}
+
+	if (route->mask & IPROUTE_BIT_RTTVAR) {
+		op += snprintf(op, buf_end - op, " %s%s ", "rttvar", route->lock & (1<<RTAX_RTTVAR) ? " lock" : "");
+		if (route->rttvar >= 4000)
+			op += snprintf(op, buf_end - op, "%gs", route->rttvar / 4000.0);
+		else
+			op += snprintf(op, buf_end - op, "%ums", route->rttvar / 4);
+	}
+
+	if (route->mask & IPROUTE_BIT_RTO_MIN) {
+		op += snprintf(op, buf_end - op, " %s%s ", "rto_min", route->lock & (1<<RTAX_RTO_MIN) ? " lock" : "");
+		if (route->rto_min >= 1000)
+			op += snprintf(op, buf_end - op, "%gs", route->rto_min / 1000.0);
+		else
+			op += snprintf(op, buf_end - op, "%ums", route->rto_min);
+	}
+
+#ifdef RTAX_FEATURES
+	if (route->features) {
+		if (route->features & RTAX_FEATURE_ECN)
+			op += snprintf(op, buf_end - op, " %s", "features ecn");
+	}
+#endif
+
+	if (route->mask & IPROUTE_BIT_MTU) {
+		op += snprintf(op, buf_end - op, " mtu %s%u",
+			route->lock & (1<<RTAX_MTU) ? "lock " : "",
+			route->mtu);
+	}
+
+	if (route->mask & IPROUTE_BIT_WINDOW)
+		op += snprintf(op, buf_end - op, " window %u", route->window);
+
+	if (route->mask & IPROUTE_BIT_SSTHRESH) {
+		op += snprintf(op, buf_end - op, " ssthresh %s%u",
+			route->lock & (1<<RTAX_SSTHRESH) ? "lock " : "",
+			route->ssthresh);
+	}
+
+	if (route->mask & IPROUTE_BIT_CWND) {
+		op += snprintf(op, buf_end - op, " cwnd %s%u",
+			route->lock & (1<<RTAX_CWND) ? "lock " : "",
+			route->cwnd);
+	}
+
+	if (route->mask & IPROUTE_BIT_ADVMSS) {
+		op += snprintf(op, buf_end - op, " advmss %s%u",
+			route->lock & (1<<RTAX_ADVMSS) ? "lock " : "",
+			route->advmss);
+	}
+
+	if (route->mask & IPROUTE_BIT_REORDERING) {
+		op += snprintf(op, buf_end - op, " reordering %s%u",
+			route->lock & (1<<RTAX_REORDERING) ? "lock " : "",
+			route->reordering);
+	}
+
+	if (route->mask & IPROUTE_BIT_HOPLIMIT)
+		op += snprintf(op, buf_end - op, " hoplimit %u", route->hoplimit);
+
+	if (route->mask & IPROUTE_BIT_INITCWND)
+		op += snprintf(op, buf_end - op, " initcwnd %u", route->initcwnd);
+
+#ifdef RTAX_INITRWND
+	if (route->mask & IPROUTE_BIT_INITRWND)
+		op += snprintf(op, buf_end - op, " initrwnd %u", route->initrwnd);
+#endif
+
+#ifdef RTAX_QUICKACK
+	if (route->mask & IPROUTE_BIT_QUICKACK)
+		op += snprintf(op, buf_end - op, " quickack %u", route->quickack);
+#endif
+
+#ifdef _HAVE_RTA_PREF_
+	if (route->mask & IPROUTE_BIT_PREF)
+		op += snprintf(op, buf_end - op, " %s %s", "pref",
+			route->pref == ICMPV6_ROUTER_PREF_LOW ? "low" :
+			route->pref == ICMPV6_ROUTER_PREF_MEDIUM ? "medium" :
+			route->pref == ICMPV6_ROUTER_PREF_HIGH ? "high" :
+			"unknown");
+#endif
+
+	if (!LIST_ISEMPTY(route->nhs)) {
+		for (e = LIST_HEAD(route->nhs); e; ELEMENT_NEXT(e)) {
+			nh = ELEMENT_DATA(e);
+
+			op += snprintf(op, buf_end - op, " nexthop");
+
+			if (nh->addr)
+				op += snprintf(op, buf_end - op, " via inet%s %s",
+					nh->addr->ifa.ifa_family == AF_INET ? "" : "6",
+					ipaddresstos(NULL,nh->addr));
+			if (nh->ifp)
+				op += snprintf(op, buf_end - op, " dev %s", nh->ifp->ifname);
+
+			if (nh->mask & IPROUTE_BIT_WEIGHT)
+				op += snprintf(op, buf_end - op, " weight %d", nh->weight + 1);
+
+			if (nh->flags & RTNH_F_ONLINK)
+				op += snprintf(op, buf_end - op, " onlink");
+
+			if (nh->realms) {
+				if (route->realms & 0xFFFF0000)
+					op += snprintf(op, buf_end - op, " realms %d/", nh->realms >> 16);
+				else
+					op += snprintf(op, buf_end - op, " realm ");
+				op += snprintf(op, buf_end - op, "%d", nh->realms & 0xFFFF);
+			}
+#ifdef _HAVE_RTA_ENCAP_
+			if (nh->encap.type != LWTUNNEL_ENCAP_NONE)
+				op += print_encap(op, buf_end - op, &nh->encap);
+#endif
+		}
+	}
+}
+
 void
 dump_iproute(void *rt_data)
 {
 	ip_route_t *route = rt_data;
-	char *log_msg = MALLOC(1024);
-	char *op = log_msg;
+	char *buf = MALLOC(ROUTE_BUF_SIZE);
+	int len;
+	int i;
 
-	if (route->blackhole) {
-		strncat(log_msg, "blackhole ", 30);
-	}
-	if (route->dst)
-		op += snprintf(op, log_msg + 1024 - op, "%s/%d", ipaddresstos(NULL, route->dst), route->dmask);
-	if (route->gw)
-		op += snprintf(op, log_msg + 1024 - op, " gw %s", ipaddresstos(NULL, route->gw));
-	if (route->gw2)
-		op += snprintf(op, log_msg + 1024 - op, " or gw %s", ipaddresstos(NULL, route->gw2));
-	if (route->src)
-		op += snprintf(op, log_msg + 1024 - op, " src %s", ipaddresstos(NULL, route->src));
-	if (route->index)
-		op += snprintf(op, log_msg + 1024 - op, " dev %s",
-			 IF_NAME(if_get_by_ifindex(route->index)));
-	if (route->table)
-		op += snprintf(op, log_msg + 1024 - op, " table %d", route->table);
-	if (route->scope)
-		op += snprintf(op, log_msg + 1024 - op, " scope %s",
-			 netlink_scope_n2a(route->scope));
-	if (route->metric)
-		op += snprintf(op, log_msg + 1024 - op, " metric %d", route->metric);
+	format_iproute(route, buf, ROUTE_BUF_SIZE);
 
-	log_message(LOG_INFO, "     %s", log_msg);
+	for (i = 0, len = strlen(buf); i < len; i += i ? MAX_LOG_MSG - 7 : MAX_LOG_MSG - 5)
+		log_message(LOG_INFO, "%*s%s", i ? 7 : 5, "", buf + i);
 
-	FREE(log_msg);
+	FREE(buf);
 }
+
+#ifdef _HAVE_RTA_ENCAP_
+static int parse_encap_mpls(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
+{
+	char *str;
+
+	encap->type = LWTUNNEL_ENCAP_MPLS;
+
+	if (*i_ptr >= vector_size(strvec)) {
+		log_message(LOG_INFO, "missing address for MPLS encapsulation");
+		return true;
+	}
+
+	str = vector_slot(strvec, (*i_ptr)++);
+	if (parse_mpls_address(str, &encap->mpls)) {
+		log_message(LOG_INFO, "invalid mpls address %s for encapsulation", str);
+		return true;
+	}
+
+	return false;
+}
+
+static int parse_encap_ip(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
+{
+	unsigned int i = *i_ptr;
+	char *str, *str1;
+
+	encap->type = LWTUNNEL_ENCAP_IP;
+
+	while (i + 1 < vector_size(strvec)) {
+		str = vector_slot(strvec, i);
+		str1 = vector_slot(strvec, i + 1);
+
+		if (!strcmp(str, "id")) {
+			if (get_u64(&encap->ip.id, str1, UINT64_MAX, "encap id %s value is invalid"))
+				goto err;
+			encap->flags |= IPROUTE_BIT_ENCAP_ID;
+		} else if (!strcmp(str, "dst")) {
+			if (encap->ip.dst)
+				FREE_PTR(encap->ip.dst);
+			encap->ip.dst = parse_ipaddress(NULL, str1, false);
+			if (!encap->ip.dst) {
+				log_message(LOG_INFO, "Invalid encap ip dst %s", str1);
+				goto err;
+			}
+			if (encap->ip.dst->ifa.ifa_family != AF_INET) {
+				log_message(LOG_INFO, "IPv6 address %s not valid for ip encapsulation", str1);
+				goto err;
+			}
+		} else if (!strcmp(str, "src")) {
+			if (encap->ip.src)
+				FREE_PTR(encap->ip.src);
+			encap->ip.src = parse_ipaddress(NULL, str1, false);
+			if (!encap->ip.src) {
+				log_message(LOG_INFO, "Invalid encap ip src %s", str1);
+				goto err;
+			}
+			if (encap->ip.src->ifa.ifa_family != AF_INET) {
+				log_message(LOG_INFO, "IPv6 address %s not valid for ip encapsulation", str1);
+				goto err;
+			}
+		} else if (!strcmp(str, "tos")) {
+			if (!find_rttables_dsfield(str1, &encap->ip.tos)) {
+				log_message(LOG_INFO, "dsfield %s not valid for ip encapsulation", str1);
+				goto err;
+			}
+			encap->flags |= IPROUTE_BIT_ENCAP_DSFIELD;
+		} else if (!strcmp(str, "ttl")) {
+			if (get_u8(&encap->ip.ttl, str1, UINT8_MAX, "ttl %s is not valid for ip encapsulation"))
+				goto err;
+			encap->flags |= IPROUTE_BIT_ENCAP_TTL;
+		} else if (!strcmp(str, "flags")) {
+			if (get_u16(&encap->ip.flags, str1, UINT16_MAX, "flags %s is not valid for ip encapsulation"))
+				goto err;
+			encap->flags |= IPROUTE_BIT_ENCAP_FLAGS;
+		} else
+			break;
+
+		i += 2;
+	}
+
+	if (!encap->ip.dst && !(encap->flags | IPROUTE_BIT_ENCAP_ID)) {
+		log_message(LOG_INFO, "address or id missing for ip encapsulation");
+		goto err;
+	}
+
+	*i_ptr = i;
+
+	return false;
+
+err:
+	*i_ptr = i;
+
+	FREE_PTR(encap->ip.dst);
+	FREE_PTR(encap->ip.src);
+	return true;
+}
+
+static
+int parse_encap_ila(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
+{
+	char *str;
+
+	encap->type = LWTUNNEL_ENCAP_ILA;
+
+	if (*i_ptr >= vector_size(strvec)) {
+		log_message(LOG_INFO, "missing locator for ILA encapsulation");
+		return true;
+	}
+
+	str = vector_slot(strvec, (*i_ptr)++);
+
+	if (get_addr64(&encap->ila.locator, str)) {
+		log_message(LOG_INFO, "invalid locator %s for ila encapsulation", str);
+		return true;
+	}
+
+	return false;
+}
+
+static
+int parse_encap_ip6(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
+{
+	unsigned int i = *i_ptr;
+	char *str, *str1;
+
+	encap->type = LWTUNNEL_ENCAP_IP6;
+
+	while (i + 1 < vector_size(strvec)) {
+		str = vector_slot(strvec, i);
+		str1 = vector_slot(strvec, i + 1);
+
+		if (!strcmp(str, "id")) {
+			if (get_u64(&encap->ip6.id, str1, UINT64_MAX, "id %s value invalid for IPv6 encapsulation\n"))
+				goto err;
+			encap->flags |= IPROUTE_BIT_ENCAP_ID;
+		} else if (!strcmp(str, "dst")) {
+			if (encap->ip6.dst)
+				FREE_PTR(encap->ip6.dst);
+			encap->ip6.dst = parse_ipaddress(NULL, str1, false);
+			if (!encap->ip6.dst) {
+				log_message(LOG_INFO, "Invalid encap ip6 dst %s", str1);
+				goto err;
+			}
+			if (encap->ip6.dst->ifa.ifa_family != AF_INET6) {
+				log_message(LOG_INFO, "IPv4 address %s not valid for ip6 encapsulation", str1);
+				goto err;
+			}
+		} else if (!strcmp(str, "src")) {
+			if (encap->ip6.src)
+				FREE_PTR(encap->ip6.src);
+			encap->ip6.src = parse_ipaddress(NULL, str1, false);
+			if (!encap->ip6.src) {
+				log_message(LOG_INFO, "Invalid encap ip6 src %s", str1);
+				goto err;
+			}
+			if (encap->ip6.src->ifa.ifa_family != AF_INET6) {
+				log_message(LOG_INFO, "IPv4 address %s not valid for ip6 encapsulation", str1);
+				goto err;
+			}
+		} else if (!strcmp(str, "tc")) {
+			if (!find_rttables_dsfield(str1, &encap->ip6.tc)) {
+				log_message(LOG_INFO, "tc value %s is invalid for ip6 encapsulation", str);
+				goto err;
+			}
+			encap->flags |= IPROUTE_BIT_ENCAP_DSFIELD;
+		} else if (!strcmp(str, "hoplimit")) {
+			if (get_u8(&encap->ip6.hoplimit, str1, UINT8_MAX, "Invalid hoplimit %s specified for ip6 encapsulation"))
+				goto err;
+			encap->flags |= IPROUTE_BIT_ENCAP_HOPLIMIT;
+		} else if (!strcmp(str, "flags")) {
+			if (get_u16(&encap->ip6.flags, str1, UINT16_MAX, "flags %s is not valid for ip6 encapsulation"))
+				goto err;
+			encap->flags |= IPROUTE_BIT_ENCAP_FLAGS;
+		} else
+			break;
+
+		i += 2;
+	}
+
+	if (!encap->ip.dst && !(encap->flags | IPROUTE_BIT_ENCAP_ID)) {
+		log_message(LOG_INFO, "address or id missing for ip6 encapsulation");
+		goto err;
+	}
+
+	*i_ptr = i;
+	return false;
+
+err:
+	*i_ptr = i;
+	FREE_PTR(encap->ip6.dst);
+	FREE_PTR(encap->ip6.src);
+	return true;
+}
+
+static bool
+parse_encap(vector_t *strvec, unsigned int *i, encap_t *encap)
+{
+	char *str;
+
+	if (vector_size(strvec) <= ++*i) {
+		log_message(LOG_INFO, "Missing encap type");
+		return false;
+	}
+
+	str = vector_slot(strvec, (*i)++);
+
+	if (!strcmp(str, "mpls"))
+		parse_encap_mpls(strvec, i, encap);
+	else if (!strcmp(str, "ip"))
+		parse_encap_ip(strvec, i, encap);
+	else if (!strcmp(str, "ip6"))
+		parse_encap_ip6(strvec, i, encap);
+	else if (!strcmp(str, "ila"))
+		parse_encap_ila(strvec, i, encap);
+	else {
+		log_message(LOG_INFO, "Unknown encap type - %s", str);
+		return false;
+	}
+
+	--*i;
+	return true;
+}
+#endif
+
+static void
+parse_nexthops(vector_t *strvec, unsigned int i, ip_route_t *route)
+{
+	int family = AF_UNSPEC;
+	nexthop_t *new;
+	char *str;
+	uint32_t val;
+
+	if (!LIST_EXISTS(route->nhs))
+		route->nhs = alloc_list(free_nh, NULL);
+
+	while (i < vector_size(strvec) && !strcmp("nexthop", vector_slot(strvec, i))) {
+		i++;
+		new = MALLOC(sizeof(nexthop_t));
+
+		while (i < vector_size(strvec)) {
+			str = vector_slot(strvec, i);
+
+			if (!strcmp(str, "via")) {
+				str = vector_slot(strvec, ++i);
+				if (!strcmp(str, "inet")) {
+					family = AF_INET;
+					str = vector_slot(strvec, ++i);
+				}
+				else if (!strcmp(str, "inet6")) {
+					family = AF_INET6;
+					str = vector_slot(strvec, ++i);
+				}
+
+				if (family != AF_UNSPEC) {
+					if (route->family == AF_UNSPEC)
+						route->family = family;
+					else if (route->family != family) {
+						log_message(LOG_INFO, "IPv4/6 mismatch for nexthop");
+						goto err;
+					}
+				}
+
+				new->addr = parse_ipaddress(NULL, str, false);
+				if (!new->addr) {
+					log_message(LOG_INFO, "invalid nexthop address %s", str);
+					goto err;
+				}
+				if (route->family != AF_UNSPEC && new->addr->ifa.ifa_family != route->family) {
+					log_message(LOG_INFO, "Address family mismatch for next hop");
+					goto err;
+				}
+				if (route->family == AF_UNSPEC)
+					route->family = new->addr->ifa.ifa_family;
+			}
+			else if (!strcmp(str, "dev")) {
+				new->ifp = if_get_by_ifname(vector_slot(strvec, ++i));
+				if (!new->ifp) {
+					log_message(LOG_INFO, "VRRP is trying to assign VROUTE to unknown "
+					       "%s interface !!! go out and fix your conf !!!",
+					       FMT_STR_VSLOT(strvec, i));
+					goto err;
+				}
+			}
+			else if (!strcmp(str, "weight")) {
+				if (get_u32(&val, vector_slot(strvec, ++i), 256, "Invalid weight %s specified for route"))
+					goto err;
+				if (!val) {
+					log_message(LOG_INFO, "Invalid weight 0 specified for route");
+					goto err;
+				}
+				new->weight = val - 1;
+				new->mask |= IPROUTE_BIT_WEIGHT;
+			}
+			else if (!strcmp(str, "onlink")) {
+				/* Note: IPv4 only */
+				new->flags |= RTNH_F_ONLINK;
+			}
+			else if (!strcmp(str, "encap")) {	// New in 4.4
+#ifdef _HAVE_RTA_ENCAP_
+				parse_encap(strvec, &i, &new->encap);
+#else
+				log_message(LOG_INFO, "encap not supported by kernel - please remove configuration");
+#endif
+			}
+			else if (!strcmp(str, "realms")) {
+				/* Note: IPv4 only */
+				if (get_realms(&new->realms, vector_slot(strvec, ++i))) {
+					log_message(LOG_INFO, "Invalid realms %s for route", FMT_STR_VSLOT(strvec,i));
+					goto err;
+				}
+				if (route->family == AF_UNSPEC)
+					route->family = AF_INET;
+				else if (route->family != AF_INET) {
+					log_message(LOG_INFO, "realms are only supported for IPv4");
+					goto err;
+				}
+			}
+			else if (!strcmp(str, "as")) {
+				if (!strcmp("to", vector_slot(strvec, ++i)))
+					i++;
+				log_message(LOG_INFO, "'as [to]' (nat) not supported");
+				goto err;
+			}
+			else
+				break;
+
+			i++;
+		}
+		list_add(route->nhs, new);
+		new = NULL;
+	}
+
+	if (i < vector_size(strvec)) {
+		log_message(LOG_INFO, "Route has trailing nonsense after nexthops - %s", FMT_STR_VSLOT(strvec, i));
+		goto err;
+	}
+
+	return;
+
+err:
+	FREE_PTR(new);
+}
+
 void
 alloc_route(list rt_list, vector_t *strvec)
 {
 	ip_route_t *new;
 	interface_t *ifp;
 	char *str;
+	uint32_t val;
+	uint8_t val8;
 	unsigned int i = 0;
-	unsigned int table_id;
+	bool do_nexthop = false;
+	bool raw;
+	ip_address_t *dst;
 
 	new = (ip_route_t *) MALLOC(sizeof(ip_route_t));
+
+	new->table = RT_TABLE_MAIN;
+	new->scope = RT_SCOPE_UNIVERSE;
+	new->type = RTN_UNICAST;
+	new->family = AF_UNSPEC;
 
 	/* FMT parse */
 	while (i < vector_size(strvec)) {
 		str = vector_slot(strvec, i);
 
 		/* cmd parsing */
-		if (!strcmp(str, "blackhole")) {
-			new->blackhole = 1;
-			new->dst = parse_ipaddress(NULL, vector_slot(strvec, ++i), true);
-			new->dmask = new->dst->ifa.ifa_prefixlen;
-		} else if (!strcmp(str, "via") || !strcmp(str, "gw")) {
-			new->gw = parse_ipaddress(NULL, vector_slot(strvec, ++i), false);
-		} else if (!strcmp(str, "or")) {
-			new->gw2 = parse_ipaddress(NULL, vector_slot(strvec, ++i), false);
-		} else if (!strcmp(str, "src")) {
+		if (!strcmp(str, "src")) {
+			if (new->pref_src)
+				FREE(new->pref_src);
+			new->pref_src = parse_ipaddress(NULL, vector_slot(strvec, ++i), false);
+			if (!new->pref_src) {
+				log_message(LOG_INFO, "invalid route src address %s", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			if (new->family == AF_UNSPEC)
+				new->family = new->pref_src->ifa.ifa_family;
+			else if (new->family != new->pref_src->ifa.ifa_family) {
+				log_message(LOG_INFO, "Cannot mix IPv4 and IPv6 addresses for route");
+				goto err;
+			}
+		}
+		else if (!strcmp(str, "as")) {
+			if (!strcmp("to", vector_slot(strvec, ++i)))
+				i++;
+#ifdef _HAVE_RTA_NEWDST_
+			log_message(LOG_INFO, "\"as to\" for MPLS only - ignoring");
+#else
+			log_message(LOG_INFO, "'as [to]' not supported by kernel");
+#endif
+		}
+		else if (!strcmp(str, "via") || !strcmp(str, "gw")) {
+			int family;
+
+			/* "gw" maintained for backward keepalived compatibility */
+			if (str[0] == 'g')	/* "gw" */
+				log_message(LOG_INFO, "\"gw\" for routes is deprecated. Please use \"via\"");
+
+			str = vector_slot(strvec, ++i);
+			if (!strcmp(str, "inet")) {
+				family = AF_INET;
+				str = vector_slot(strvec, ++i);
+			}
+			if (!strcmp(str, "inet6")) {
+				family = AF_INET6;
+				str = vector_slot(strvec, ++i);
+			}
+			else
+				family = new->family;
+
+			if (new->family == AF_UNSPEC)
+				new->family = family;
+			else if (new->family != family) {
+				log_message(LOG_INFO, "Cannot mix IPv4 and IPv6 addresses for route");
+				goto err;
+			}
+
+			if (new->via)
+				FREE(new->via);
+			new->via = parse_ipaddress(NULL, str, false);
+			if (!new->via) {
+				log_message(LOG_INFO, "invalid route via address %s", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			if (new->family == AF_UNSPEC)
+				new->family = new->via->ifa.ifa_family;
+			else if (new->family != new->via->ifa.ifa_family) {
+				log_message(LOG_INFO, "Cannot mix IPv4 and IPv6 addresses for route");
+				goto err;
+			}
+		}
+		else if (!strcmp(str, "from")) {
+			if (new->src)
+				FREE(new->src);
 			new->src = parse_ipaddress(NULL, vector_slot(strvec, ++i), false);
-		} else if (!strcmp(str, "dev") || !strcmp(str, "oif")) {
+			if (!new->src) {
+				log_message(LOG_INFO, "invalid route from address %s", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			if (new->src->ifa.ifa_family != AF_INET6) {
+				log_message(LOG_INFO, "route from address only supported with IPv6 (%s)", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			if (new->family == AF_UNSPEC)
+				new->family = new->src->ifa.ifa_family;
+			else if (new->family != new->src->ifa.ifa_family) {
+				log_message(LOG_INFO, "Cannot mix IPv4 and IPv6 addresses for route");
+				goto err;
+			}
+		}
+		else if (!strcmp(str, "tos") || !strcmp(str,"dsfield")) {
+			/* Note: IPv4 only */
+			if (!find_rttables_dsfield(vector_slot(strvec, ++i), &val)) {
+				log_message(LOG_INFO, "TOS value %s is invalid", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+
+			new->tos = val;
+			new->mask |= IPROUTE_BIT_DSFIELD;
+		}
+		else if (!strcmp(str, "table")) {
+			if (!find_rttables_table(vector_slot(strvec, ++i), &val)) {
+				log_message(LOG_INFO, "Routing table %s not found for route", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			new->table = val;
+		}
+		else if (!strcmp(str, "protocol")) {
+			if (!find_rttables_proto(vector_slot(strvec, ++i), &val)) {
+				log_message(LOG_INFO, "Protocol %s not found or invalid for route", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			new->protocol = val;
+			new->mask |= IPROUTE_BIT_PROTOCOL;
+		}
+		else if (!strcmp(str, "scope")) {
+			/* Note: IPv4 only */
+			if (!find_rttables_scope(vector_slot(strvec, ++i), &val)) {
+				log_message(LOG_INFO, "Scope %s not found or invalid for route", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			new->scope = val;
+			new->mask |= IPROUTE_BIT_SCOPE;
+		}
+		else if (!strcmp(str, "metric") ||
+			 !strcmp(str, "priority") ||
+			 !strcmp(str, "preference")) {
+			if (get_u32(&new->metric, vector_slot(strvec, ++i), UINT32_MAX, "Invalid MTU %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_METRIC;
+		}
+		else if (!strcmp(str, "dev") || !strcmp(str, "oif")) {
 			ifp = if_get_by_ifname(vector_slot(strvec, ++i));
 			if (!ifp) {
 				log_message(LOG_INFO, "VRRP is trying to assign VROUTE to unknown "
 				       "%s interface !!! go out and fix your conf !!!",
-				       (char *)vector_slot(strvec, i));
-				FREE(new);
-				return;
+				       FMT_STR_VSLOT(strvec, i));
+				goto err;
 			}
-			new->index = IF_INDEX(ifp);
-		} else if (!strcmp(str, "table")) {
-			if (!find_rttables_table(vector_slot(strvec, ++i), &table_id))
-				log_message(LOG_INFO, "Routing table %s not found for route"
-						    , (char *)vector_slot(strvec, i));
+			new->oif = ifp;
+		}
+		else if (!strcmp(str, "onlink")) {
+			/* Note: IPv4 only */
+			new->flags |= RTNH_F_ONLINK;
+		}
+		else if (!strcmp(str, "encap")) {	// New in 4.4
+#ifdef _HAVE_RTA_ENCAP_
+			parse_encap(strvec, &i, &new->encap);
+#else
+			log_message(LOG_INFO, "encap not supported by kernel - please remove configuration");
+#endif
+		}
+		else if (!strcmp(str, "expires")) {	// New in 4.4
+			i++;
+#ifdef _HAVE_RTA_EXPIRES_
+			if (new->family == AF_INET) {
+				log_message(LOG_INFO, "expires is only valid for IPv6");
+				goto err;
+			}
+			new->family = AF_INET6;
+			if (get_u32(&new->expires, vector_slot(strvec, i), UINT32_MAX, "Invalid expires time %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_EXPIRES;
+#else
+			log_message(LOG_INFO, "expires not supported by kernel");
+#endif
+		}
+		else if (!strcmp(str, "mtu")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_MTU;
+				i++;
+			}
+			if (get_u32(&new->mtu, vector_slot(strvec, i), UINT32_MAX, "Invalid MTU %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_MTU;
+		}
+		else if (!strcmp(str, "hoplimit")) {
+			if (get_u32(&val, vector_slot(strvec, ++i), 255, "Invalid hoplimit %s specified for route"))
+				goto err;
+			new->hoplimit = val;
+			new->mask |= IPROUTE_BIT_HOPLIMIT;
+		}
+		else if (!strcmp(str, "advmss")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_ADVMSS;
+				i++;
+			}
+			if (get_u32(&new->advmss, vector_slot(strvec, i), UINT32_MAX, "Invalid advmss %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_ADVMSS;
+		}
+		else if (!strcmp(str, "rtt")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_RTT;
+				i++;
+			}
+			if (get_time_rtt(&new->rtt, vector_slot(strvec, i), &raw) ||
+			    (!raw && new->rtt >= UINT32_MAX / 8)) {
+				log_message(LOG_INFO, "Invalid rtt %s for route", FMT_STR_VSLOT(strvec,i));
+				goto err;
+			}
+			if (raw)
+				new->rtt *= 8;
+			new->mask |= IPROUTE_BIT_RTT;
+		}
+		else if (!strcmp(str, "rttvar")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_RTTVAR;
+				i++;
+			}
+			if (get_time_rtt(&new->rttvar, vector_slot(strvec, i), &raw) ||
+			    (!raw && new->rtt >= UINT32_MAX / 4)) {
+				log_message(LOG_INFO, "Invalid rttvar %s for route", FMT_STR_VSLOT(strvec,i));
+				goto err;
+			}
+			if (raw)
+				new->rttvar *= 4;
+			new->mask |= IPROUTE_BIT_RTTVAR;
+		}
+		else if (!strcmp(str, "reordering")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_REORDERING;
+				i++;
+			}
+			if (get_u32(&new->reordering, vector_slot(strvec, i), UINT32_MAX, "Invalid reordering value %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_REORDERING;
+		}
+		else if (!strcmp(str, "window")) {
+			if (get_u32(&new->window, vector_slot(strvec, ++i), UINT32_MAX, "Invalid window value %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_WINDOW;
+		}
+		else if (!strcmp(str, "cwnd")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_CWND;
+				i++;
+			}
+			if (get_u32(&new->cwnd, vector_slot(strvec, i), UINT32_MAX, "Invalid cwnd value %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_CWND;
+		}
+		else if (!strcmp(str, "ssthresh")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_SSTHRESH;
+				i++;
+			}
+			if (get_u32(&new->ssthresh, vector_slot(strvec, i), UINT32_MAX, "Invalid ssthresh value %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_SSTHRESH;
+		}
+		else if (!strcmp(str, "realms")) {
+			if (get_realms(&new->realms, vector_slot(strvec, ++i))) {
+				log_message(LOG_INFO, "Invalid realms %s for route", FMT_STR_VSLOT(strvec,i));
+				goto err;
+			}
+			if (new->family == AF_INET6) {
+				log_message(LOG_INFO, "realms are only valid for IPv4");
+				goto err;
+			}
+			new->family = AF_INET;
+		}
+		else if (!strcmp(str, "rto_min")) {
+			if (!strcmp(vector_slot(strvec, ++i), "lock")) {
+				new->lock |= 1 << RTAX_RTO_MIN;
+				i++;
+			}
+			if (get_time_rtt(&new->rto_min, vector_slot(strvec, i), &raw)) {
+				log_message(LOG_INFO, "Invalid rto_min value %s specified for route", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			new->mask |= IPROUTE_BIT_RTO_MIN;
+		}
+		else if (!strcmp(str, "initcwnd")) {
+			if (get_u32(&new->initcwnd, vector_slot(strvec, ++i), UINT32_MAX, "Invalid initcwnd value %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_INITCWND;
+		}
+		else if (!strcmp(str, "initrwnd")) {
+			i++;
+#ifdef RTAX_INITRWND
+			if (get_u32(&new->initrwnd, vector_slot(strvec, i), UINT32_MAX, "Invalid initrwnd value %s specified for route"))
+				goto err;
+			new->mask |= IPROUTE_BIT_INITRWND;
+#else
+			log_message(LOG_INFO, "initrwnd for route not supported by kernel");
+#endif
+		}
+		else if (!strcmp(str, "features")) {
+			i++;
+#ifdef RTAX_FEATURES
+			if (!strcmp("ecn", vector_slot(strvec, i)))
+				new->features |= RTAX_FEATURE_ECN;
 			else
-				new->table = table_id;
-		} else if (!strcmp(str, "metric")) {
-			new->metric = atoi(vector_slot(strvec, ++i));
-		} else if (!strcmp(str, "scope")) {
-			new->scope = netlink_scope_a2n(vector_slot(strvec, ++i));
-		} else {
-			if (!strcmp(str, "to")) i++;
-
-			new->dst = parse_ipaddress(NULL, vector_slot(strvec, i), true);
-			if (new->dst) {
-				new->dmask = new->dst->ifa.ifa_prefixlen;
+				log_message(LOG_INFO, "feature %s not supported", FMT_STR_VSLOT(strvec,i));
+#else
+			log_message(LOG_INFO, "features for route not supported by kernel");
+#endif
+		}
+		else if (!strcmp(str, "quickack")) {
+			i++;
+#ifdef RTAX_QUICKACK
+			if (get_u32(&val, vector_slot(strvec, i), 1, "Invalid quickack value %s specified for route"))
+				goto err;
+			new->quickack = val;
+			new->mask |= IPROUTE_BIT_QUICKACK;
+#else
+			log_message(LOG_INFO, "quickack for route not supported by kernel");
+#endif
+		}
+		else if (!strcmp(str, "congctl")) {
+			i++;
+#ifdef RTAX_CC_ALGO
+			if (!strcmp(vector_slot(strvec, i), "lock")) {
+				new->lock |= 1 << RTAX_CC_ALGO;
+				i++;
 			}
+			str = vector_slot(strvec, i);
+			new->congctl = malloc(strlen(str) + 1);
+			strcpy(new->congctl, str); 
+#else
+			log_message(LOG_INFO, "congctl for route not supported by kernel");
+#endif
+		}
+		else if (!strcmp(str, "pref")) {
+			i++;
+#ifdef _HAVE_RTA_PREF_
+			if (new->family == AF_INET) {
+				log_message(LOG_INFO, "pref is only valid for IPv6");
+				goto err;
+			}
+			new->family = AF_INET6;
+			str = vector_slot(strvec, i);
+			if (!strcmp(str, "low"))
+				new->pref = ICMPV6_ROUTER_PREF_LOW;
+			else if (!strcmp(str, "medium"))
+				new->pref = ICMPV6_ROUTER_PREF_MEDIUM;
+			else if (!strcmp(str, "high"))
+				new->pref = ICMPV6_ROUTER_PREF_HIGH;
+			else if (!get_u32(&val, str, UINT8_MAX, "Invalid pref value %s specified for route"))
+				new->pref = val;
+			else
+				goto err;
+			new->mask |= IPROUTE_BIT_PREF;
+#else
+			log_message(LOG_INFO, "pref not supported by kernel");
+#endif
+		}
+		/* Maintained for backward compatibility */
+		else if (!strcmp(str, "or")) {
+			log_message(LOG_INFO, "\"or\" for routes is deprecated. Please use \"nexthop\"");
+
+			if (new->nhs) {
+				log_message(LOG_INFO, "\"or\" route already specified - ignoring subsequent");
+				i += 2;
+				continue;
+			}
+
+			new->nhs = alloc_list(free_nh, NULL);
+
+			/* Transfer the via address to the first nexthop */
+			nexthop_t *nh = MALLOC(sizeof(nexthop_t));
+			nh->addr = new->via;
+			new->via = NULL;
+			list_add(new->nhs, nh);
+
+			/* Now handle the "or" address */
+			nh = MALLOC(sizeof(nexthop_t));
+			nh->addr = parse_ipaddress(NULL, vector_slot(strvec, ++i), false);
+			if (!nh->addr) {
+				log_message(LOG_INFO, "Invalid \"or\" address %s", FMT_STR_VSLOT(strvec, i));
+				FREE(nh);
+				goto err;
+			}
+			list_add(new->nhs, nh);
+		}
+		else if (!strcmp(str, "nexthop")) {
+			if (new->nhs)
+				log_message(LOG_INFO, "Cannot specify nexthops with \"or\" route");
+			else
+				do_nexthop = true;
+			break;
+		}
+		else {
+			if (!strcmp(str, "to"))
+				i++;
+
+			if (find_rttables_rtntype(str, &val8)) {
+				new->type = val8;
+				new->mask |= IPROUTE_BIT_TYPE;
+				i++;
+			}
+			if (new->dst)
+				FREE(new->dst);
+			dst = parse_ipaddress(NULL, vector_slot(strvec, i), true);
+			if (!dst) {
+				log_message(LOG_INFO, "unknown route keyword %s", FMT_STR_VSLOT(strvec, i));
+				goto err;
+			}
+			if (new->family == AF_UNSPEC)
+				new->family = dst->ifa.ifa_family;
+			else if (new->family != dst->ifa.ifa_family) {
+				log_message(LOG_INFO, "Cannot mix IPv4 and IPv6 addresses for route");
+				goto err;
+			}
+			new->dst = dst;
 		}
 		i++;
 	}
 
-	if (new->blackhole && new->gw) {
-		log_message(LOG_INFO, "route: blackhole and gw are incompatible");
+	if (do_nexthop)
+		parse_nexthops(strvec, i, new);
+	else if (i < vector_size(strvec)) {
+		log_message(LOG_INFO, "Route has trailing nonsense - %s", FMT_STR_VSLOT(strvec, i));
 		goto err;
 	}
-	if (new->gw2 && !new->gw) {
-		log_message(LOG_INFO, "route: or route requires first route");
-		goto err;
-	}
-
-	if (!new->table)
-		new->table = RT_TABLE_MAIN;
 
 	list_add(rt_list, new);
+
 	return;
 
 err:
-	FREE(new);
+	free_iproute(new);
 }
 
 /* Try to find a route in a list */
@@ -295,7 +1663,14 @@ route_exist(list l, ip_route_t *iproute)
 
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		ipr = ELEMENT_DATA(e);
-		if (ROUTE_ISEQ(ipr, iproute)) {
+
+		/* The kernel's key to a route is (to, tos, preference, table) */
+		if (IP_ISEQ(ipr->dst, iproute->dst) &&
+		    ipr->dst->ifa.ifa_prefixlen == iproute->dst->ifa.ifa_prefixlen &&
+		    (!((ipr->mask ^ iproute->mask) & IPROUTE_BIT_METRIC)) &&
+		    (!(ipr->mask & IPROUTE_BIT_METRIC) ||
+		     ipr->metric == iproute->metric) &&
+		    ipr->table == iproute->table) {
 			ipr->set = iproute->set;
 			return 1;
 		}
@@ -314,7 +1689,7 @@ clear_diff_routes(list l, list n)
 	if (LIST_ISEMPTY(l))
 		return;
 
-	/* All Static routes removed */
+	/* All routes removed */
 	if (LIST_ISEMPTY(n)) {
 		log_message(LOG_INFO, "Removing a VirtualRoute block");
 		netlink_rtlist(l, IPROUTE_DEL);
@@ -323,10 +1698,18 @@ clear_diff_routes(list l, list n)
 
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		iproute = ELEMENT_DATA(e);
-		if (!route_exist(n, iproute) && iproute->set) {
-			log_message(LOG_INFO, "ip route %s/%d ... , no longer exist"
-					    , ipaddresstos(NULL, iproute->dst), iproute->dmask);
-			netlink_route(iproute, IPROUTE_DEL);
+		if (iproute->set) {
+			if (!route_exist(n, iproute)) {
+				log_message(LOG_INFO, "ip route %s/%d ... , no longer exist"
+						    , ipaddresstos(NULL, iproute->dst), iproute->dst->ifa.ifa_prefixlen);
+				netlink_route(iproute, IPROUTE_DEL);
+			}
+			else {
+				/* There are too many route options to compare to see if the
+				 * routes are the same or not, so just replace the existing route
+				 * with the new one. */
+				netlink_route(iproute, IPROUTE_REPLACE);
+			}
 		}
 	}
 }

--- a/keepalived/vrrp/vrrp_print.c
+++ b/keepalived/vrrp/vrrp_print.c
@@ -30,10 +30,12 @@
 #include "vrrp_iprule.h"
 #endif
 #include "vrrp_netlink.h"
+#include "rttables.h"
 #include "logger.h"
 
 #include <time.h>
 #include <errno.h>
+#include <inttypes.h>
 
 static void
 vrrp_print_list(FILE *file, list l, void (*fptr)(FILE*, void*))
@@ -124,7 +126,7 @@ address_print(FILE *file, void *data)
 		, broadcast
 		, IF_NAME(ipaddr->ifp)
 		, IP_IS4(ipaddr) ? " scope " : ""
-		, IP_IS4(ipaddr) ? netlink_scope_n2a(ipaddr->ifa.ifa_scope) : ""
+		, IP_IS4(ipaddr) ? get_rttables_scope(ipaddr->ifa.ifa_scope) : ""
 		, ipaddr->label ? " label " : ""
 		, ipaddr->label ? ipaddr->label : "");
 }
@@ -134,46 +136,27 @@ static void
 route_print(FILE *file, void *data)
 {
 	ip_route_t *route = data;
+	char *buf = MALLOC(ROUTE_BUF_SIZE);
 
-	fprintf(file, "     ");
+	format_iproute(route, buf, ROUTE_BUF_SIZE);
 
-	if (route->blackhole)
-		fprintf(file, "blackhole ");
-	if (route->dst)
-		fprintf(file, "%s/%d", ipaddresstos(NULL, route->dst), route->dmask);
-	if (route->gw)
-		fprintf(file, " gw %s", ipaddresstos(NULL, route->gw));
-	if (route->gw2)
-		fprintf(file, " or gw %s", ipaddresstos(NULL, route->gw2));
-	if (route->src)
-		fprintf(file, " src %s", ipaddresstos(NULL, route->src));
-	if (route->index)
-		fprintf(file, " dev %s", IF_NAME(if_get_by_ifindex(route->index)));
-	if (route->table)
-		fprintf(file, " table %d", route->table);
-	if (route->scope)
-		fprintf(file, " scope %s", netlink_scope_n2a(route->scope));
-	if (route->metric)
-		fprintf(file, " metric %d", route->metric);
+	fprintf(file, "     %s\n", buf);
 
-	fprintf(file, "\n");
+	FREE(buf);
+
 }
 
 static void
 rule_print(FILE *file, void *data)
 {
 	ip_rule_t *rule = data;
+	char *buf = MALLOC(RULE_BUF_SIZE);
 
-	fprintf(file, "     ");
+	format_iprule(rule, buf, RULE_BUF_SIZE);
 
-	if (rule->dir)
-		fprintf(file, "%s ", (rule->dir == VRRP_RULE_FROM) ? "from" : "to");
-	if (rule->addr)
-		fprintf(file, "%s", ipaddresstos(NULL, rule->addr));
-	if (rule->table)
-		fprintf(file, " table %d", rule->table);
+	fprintf(file, "    %s\n", buf);
 
-	fprintf(file, "\n");
+	FREE(buf);
 }
 #endif
 
@@ -379,13 +362,10 @@ vrrp_print_data(void)
 		vrrp_print_list(file, vrrp_data->vrrp_sync_group, &vgroup_print);
 	}
 	fclose(file);
+
+	clear_rt_names();
 }
 
-#if __WORDSIZE == 64
-#define u64	"%lu"
-#else	/* __WORDSIZE == 32 */
-#define u64	"%llu"
-#endif
 void
 vrrp_print_stats(void)
 {
@@ -406,19 +386,19 @@ vrrp_print_stats(void)
 		vrrp = ELEMENT_DATA(e);
 		fprintf(file, "VRRP Instance: %s\n", vrrp->iname);
 		fprintf(file, "  Advertisements:\n");
-		fprintf(file, "    Received: " u64 "\n", vrrp->stats->advert_rcvd);
+		fprintf(file, "    Received: %" PRIu64 "\n", vrrp->stats->advert_rcvd);
 		fprintf(file, "    Sent: %d\n", vrrp->stats->advert_sent);
 		fprintf(file, "  Became master: %d\n", vrrp->stats->become_master);
 		fprintf(file, "  Released master: %d\n",
 			vrrp->stats->release_master);
 		fprintf(file, "  Packet Errors:\n");
-		fprintf(file, "    Length: " u64 "\n", vrrp->stats->packet_len_err);
-		fprintf(file, "    TTL: " u64 "\n", vrrp->stats->ip_ttl_err);
-		fprintf(file, "    Invalid Type: " u64 "\n",
+		fprintf(file, "    Length: %" PRIu64 "\n", vrrp->stats->packet_len_err);
+		fprintf(file, "    TTL: %" PRIu64 "\n", vrrp->stats->ip_ttl_err);
+		fprintf(file, "    Invalid Type: %" PRIu64 "\n",
 			vrrp->stats->invalid_type_rcvd);
-		fprintf(file, "    Advertisement Interval: " u64 "\n",
+		fprintf(file, "    Advertisement Interval: %" PRIu64 "\n",
 			vrrp->stats->advert_interval_err);
-		fprintf(file, "    Address List: " u64 "\n",
+		fprintf(file, "    Address List: %" PRIu64 "\n",
 			vrrp->stats->addr_list_err);
 		fprintf(file, "  Authentication Errors:\n");
 		fprintf(file, "    Invalid Type: %d\n",
@@ -428,8 +408,8 @@ vrrp_print_stats(void)
 		fprintf(file, "    Failure: %d\n",
 			vrrp->stats->auth_failure);
 		fprintf(file, "  Priority Zero:\n");
-		fprintf(file, "    Received: " u64 "\n", vrrp->stats->pri_zero_rcvd);
-		fprintf(file, "    Sent: " u64 "\n", vrrp->stats->pri_zero_sent);
+		fprintf(file, "    Received: %" PRIu64 "\n", vrrp->stats->pri_zero_rcvd);
+		fprintf(file, "    Sent: %" PRIu64 "\n", vrrp->stats->pri_zero_sent);
 	}
 	fclose(file);
 }

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -48,6 +48,7 @@
 #ifdef _WITH_SNMP_
 #include "vrrp_snmp.h"
 #endif
+#include <netinet/ip.h>
 
 /* global vars */
 timeval_t garp_next_time;

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -35,7 +35,7 @@ enable_console_log(void)
 void
 vlog_message(const int facility, const char* format, va_list args)
 {
-	char buf[256];
+	char buf[MAX_LOG_MSG+1];
 
 	vsnprintf(buf, sizeof(buf), format, args);
 

--- a/lib/logger.h
+++ b/lib/logger.h
@@ -26,6 +26,8 @@
 #include <stdarg.h>
 #include <syslog.h>
 
+#define	MAX_LOG_MSG	255
+
 void enable_console_log(void);
 void vlog_message(const int facility, const char* format, va_list args);
 void log_message(int priority, const char* format, ...)

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -62,6 +62,11 @@ extern void *zalloc(unsigned long size);
 #endif
 
 /* Common defines */
-#define FREE_PTR(P) if((P)) FREE((P));
+static inline void
+FREE_PTR(void *p)
+{
+	if (p)
+		FREE(p);
+}
 
 #endif

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -43,9 +43,11 @@
 extern size_t mem_allocated;
 
 /* Memory debug prototypes defs */
-extern void *keepalived_malloc(unsigned long, char *, char *, int);
+extern void *keepalived_malloc(size_t, char *, char *, int)
+		__attribute__((alloc_size(1))) __attribute__((malloc));
 extern int keepalived_free(void *, char *, char *, int);
-extern void *keepalived_realloc(void *, unsigned long, char *, char *, int);
+extern void *keepalived_realloc(void *, size_t, char *, char *, int)
+		__attribute__((alloc_size(2)));
 extern void keepalived_free_final(char *);
 extern void mem_log_init(const char *);
 

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -652,5 +652,5 @@ init_data(const char *conf_file, vector_t * (*init_keywords) (void))
 	current_keywords = keywords;
 	read_conf_file(conf_file);
 	free_keywords(keywords);
-	clear_rttables();
+	clear_rt_names();
 }

--- a/lib/rttables.c
+++ b/lib/rttables.c
@@ -23,6 +23,10 @@
 #include <stdbool.h>
 #include <errno.h>
 
+#include <linux/socket.h>
+#include <sys/socket.h>
+#include <linux/rtnetlink.h>
+
 #include "vector.h"
 #include "list.h"
 #include "memory.h"
@@ -30,8 +34,14 @@
 #include "parser.h"
 #include "rttables.h"
 
-#define RT_TABLES_FILE	"/etc/iproute2/rt_tables"
-#define	MAX_RT_TABLES_BUF	128
+#define IPROUTE2_DIR	"/etc/iproute2/"
+
+#define RT_TABLES_FILE	IPROUTE2_DIR "rt_tables"
+#define	RT_DSFIELD_FILE IPROUTE2_DIR "rt_dsfield"
+#define	RT_REALMS_FILE	IPROUTE2_DIR "rt_realms"
+#define	RT_SCOPES_FILE	IPROUTE2_DIR "rt_scopes"
+#define	RT_PROTOS_FILE	IPROUTE2_DIR "rt_protos"
+#define	RT_GROUPS_FILE	IPROUTE2_DIR "group"
 
 struct rt_entry {
 	unsigned int id;
@@ -39,7 +49,70 @@ struct rt_entry {
 } ;
 typedef struct rt_entry rt_entry_t;
 
-static list rt_list;
+static rt_entry_t rtntypes[] = {
+	{ RTN_LOCAL, "local"},
+	{ RTN_NAT, "nat"},
+	{ RTN_BROADCAST, "broadcast"},
+	{ RTN_BROADCAST, "brd"},
+	{ RTN_ANYCAST, "anycast"},
+	{ RTN_MULTICAST, "multicast"},
+	{ RTN_PROHIBIT, "prohibit"},
+	{ RTN_UNREACHABLE, "unreachable"},
+	{ RTN_BLACKHOLE, "blackhole"},
+	{ RTN_XRESOLVE, "xresolve"},
+	{ RTN_UNICAST, "unicast"},
+	{ RTN_THROW, "throw"},
+	{ 0, NULL},
+};
+
+static rt_entry_t rtprot_default[] = {
+        { RTPROT_UNSPEC, "none"},
+        { RTPROT_REDIRECT, "redirect"},
+        { RTPROT_KERNEL, "kernel"},
+        { RTPROT_BOOT, "boot"},
+        { RTPROT_STATIC, "static"},
+
+        { RTPROT_GATED, "gated"},
+        { RTPROT_RA, "ra"},
+        { RTPROT_MRT, "mrt"},
+        { RTPROT_ZEBRA, "zebra"},
+        { RTPROT_BIRD, "bird"},
+#ifdef RTPROT_BABEL
+        { RTPROT_BABEL, "babel"},
+#endif
+        { RTPROT_DNROUTED, "dnrouted"},
+        { RTPROT_XORP, "xorp"},
+        { RTPROT_NTK, "ntk"},
+        { RTPROT_DHCP, "dhcp"},
+	{ 0, NULL},
+};
+
+static rt_entry_t rtscope_default[] = {
+        { RT_SCOPE_UNIVERSE, "global"},
+        { RT_SCOPE_NOWHERE, "nowhere"},
+        { RT_SCOPE_HOST, "host"},
+        { RT_SCOPE_LINK, "link"},
+        { RT_SCOPE_SITE, "site"},
+	{ 0, NULL},
+};
+
+static rt_entry_t rttable_default[] = {
+        { RT_TABLE_DEFAULT, "default"},
+        { RT_TABLE_MAIN, "main"},
+        { RT_TABLE_LOCAL, "local"},
+	{ 0, NULL},
+};
+
+#define	MAX_RT_BUF	128
+
+static list rt_tables;
+static list rt_dsfields;
+static list rt_groups;
+static list rt_realms;
+static list rt_protos;
+static list rt_scopes;
+
+static char ret_buf[11];	/* uint32_t in decimal */
 
 static void
 free_rt_entry(void *e)
@@ -59,32 +132,19 @@ dump_rt_entry(void *e)
 	log_message(LOG_INFO, "rt_table %u, name %s", rte->id, rte->name);
 }
 
-static bool
-read_rttables(void)
+static void
+read_file(const char* file_name, list *l, uint32_t max)
 {
 	FILE *fp;
 	rt_entry_t *rte;
 	vector_t *strvec = NULL;
-	char buf[MAX_RT_TABLES_BUF];
+	char buf[MAX_RT_BUF];
 
-	if (rt_list)
-		return true;
+	fp = fopen(file_name, "r");
+	if (!fp)
+		return;
 
-	fp = fopen(RT_TABLES_FILE, "r");
-	if (!fp) {
-		if (errno == EACCES || errno == EISDIR || errno == ENOENT) {
-			/* This is a permanent error, so don't keep trying to reopen the file */
-			rt_list = alloc_list(NULL, NULL);
-			return true;
-		}
-		return false;
-	}
-
-	rt_list = alloc_list(free_rt_entry, dump_rt_entry);
-	if (!rt_list)
-		goto err;
-
-	while (fgets(buf, MAX_RT_TABLES_BUF, fp)) {
+	while (fgets(buf, MAX_RT_BUF, fp)) {
 		strvec = alloc_strvec(buf);
 
 		if (!strvec)
@@ -96,61 +156,125 @@ read_rttables(void)
 		}
 
 		rte = MALLOC(sizeof(rt_entry_t));
-		if (!rte)
+		if (!rte) {
+			free_strvec(strvec);
 			goto err;
+		}
 
 		rte->id = strtoul(FMT_STR_VSLOT(strvec, 0), NULL, 0);
+		if (rte->id > max) {
+			FREE(rte);
+			free_strvec(strvec);
+			continue;
+		}
+
 		rte->name = MALLOC(strlen(FMT_STR_VSLOT(strvec, 1)) + 1);
 		if (!rte->name) {
 			FREE(rte);
+			free_strvec(strvec);
 			goto err;
 		}
 
 		strcpy(rte->name, FMT_STR_VSLOT(strvec, 1));
 
-		list_add(rt_list, rte);
+		list_add(*l, rte);
 
 		free_strvec(strvec);
-		strvec = NULL;
 	}
 
 	fclose(fp);
 
-	return true;
+	return;
 err:
 	fclose(fp);
 
-	if (!strvec)
+	if (strvec)
 		free_strvec(strvec);
 
-	free_list(&rt_list);
+	free_list(l);
 
-	return false;
+	return;
 }
 
 void
-clear_rttables(void)
+clear_rt_names(void)
 {
-	free_list(&rt_list);
+	free_list(&rt_tables);
+	free_list(&rt_dsfields);
+	free_list(&rt_groups);
+	free_list(&rt_realms);
+	free_list(&rt_protos);
+	free_list(&rt_scopes);
 }
 
-bool
-find_rttables_table(const char *name, unsigned int *id)
+static void
+add_default(list *l, const struct rt_entry* default_list)
+{
+	bool found;
+	rt_entry_t *rte;
+	element e;
+
+	for (;default_list->name; default_list++) {
+		for (e = LIST_HEAD(*l), found = false; e; ELEMENT_NEXT(e)) {
+			rte = ELEMENT_DATA(e);
+
+			if (rte->id == default_list->id) {
+				found = true;
+				break;
+			}
+		}
+
+		if (found)
+			continue;
+
+		rte = MALLOC(sizeof(rt_entry_t));
+		rte->name = MALLOC(strlen(default_list->name) + 1);
+		if (!rte->name) {
+			FREE(rte);
+			return;
+		}
+
+		strcpy(rte->name, default_list->name);
+		rte->id = default_list->id;
+
+		list_add(*l, rte);
+	}
+}
+
+static void
+initialise_list(list *l, const char *file_name, const struct rt_entry *default_list, uint32_t max)
+{
+
+	if (*l)
+		return;
+
+	*l = alloc_list(free_rt_entry, dump_rt_entry);
+	if (!*l)
+		return;
+
+	read_file(file_name, l, max);
+
+	if (default_list)
+		add_default(l, default_list);
+}
+
+static bool
+find_entry(const char *name, unsigned int *id, list *l, const char* file_name, const struct rt_entry* default_list, uint32_t max)
 {
 	element e;
 	char	*endptr;
 
 	*id = strtoul(name, &endptr, 0);
 	if (endptr != name && *endptr == '\0')
-		return true;
+		return (*id <= max);
 
-	if (!rt_list && !read_rttables())
+	if (!(*l))
+		initialise_list(l, file_name, default_list, max);
+
+	if (LIST_ISEMPTY(*l))
 		return false;
 
-	if (LIST_ISEMPTY(rt_list))
-		return false;
-
-	for (e = LIST_HEAD(rt_list); e; ELEMENT_NEXT(e)) {
+	for (e = LIST_HEAD(*l); e; ELEMENT_NEXT(e)) {
 		rt_entry_t *rte = ELEMENT_DATA(e);
 
 		if (!strcmp(rte->name, name)) {
@@ -159,4 +283,109 @@ find_rttables_table(const char *name, unsigned int *id)
 		}
 	}
 	return false;
+}
+
+bool
+find_rttables_table(const char *name, uint32_t *id)
+{
+	return find_entry(name, id, &rt_tables, RT_TABLES_FILE, rttable_default, RT_TABLE_MAX);
+}
+
+bool
+find_rttables_dsfield(const char *name, uint32_t *id)
+{
+	return find_entry(name, id, &rt_dsfields, RT_DSFIELD_FILE, NULL, 255);
+}
+
+bool
+find_rttables_group(const char *name, uint32_t *id)
+{
+	return find_entry(name, id, &rt_groups, RT_GROUPS_FILE, NULL, INT32_MAX);
+}
+
+bool
+find_rttables_realms(const char *name, uint32_t *id)
+{
+	return find_entry(name, id, &rt_realms, RT_REALMS_FILE, NULL, 255);
+}
+
+bool
+find_rttables_proto(const char *name, uint32_t *id)
+{
+	return find_entry(name, id, &rt_protos, RT_PROTOS_FILE, rtprot_default, 255);
+}
+
+bool
+find_rttables_scope(const char *name, uint32_t *id)
+{
+	return find_entry(name, id, &rt_scopes, RT_SCOPES_FILE, rtscope_default, 255);
+}
+
+bool
+find_rttables_rtntype(const char *str, uint8_t *id)
+{
+	char *end;
+	unsigned long res;
+	int i;
+
+	for (i = 0; rtntypes[i].name; i++) {
+		if (!strcmp(str, rtntypes[i].name)) {
+			*id = (uint8_t)rtntypes[i].id;
+			return true;
+		}
+	}
+
+	res = strtoul(str, &end, 0);
+	if (*end || res > 255)
+		return false;
+
+	*id = res;
+	return true;
+}
+
+static const char *
+get_entry(unsigned int id, list* l, const char* file_name, const struct rt_entry* default_list, uint32_t max)
+{
+	element e;
+
+	if (!(*l))
+		initialise_list(l, file_name, default_list, max);
+
+	if (!LIST_ISEMPTY(*l)) {
+		for (e = LIST_HEAD(*l); e; ELEMENT_NEXT(e)) {
+			rt_entry_t *rte = ELEMENT_DATA(e);
+
+			if (rte->id == id)
+				return rte->name;
+		}
+	}
+
+	snprintf(ret_buf, sizeof(ret_buf), "%u", id);
+	return ret_buf;
+}
+
+const char *
+get_rttables_scope(uint32_t id)
+{
+	return get_entry(id, &rt_scopes, RT_SCOPES_FILE, rtscope_default, 255);
+}
+
+const char *
+get_rttables_group(uint32_t id)
+{
+	return get_entry(id, &rt_groups, RT_GROUPS_FILE, NULL, 255);
+}
+
+const char *
+get_rttables_rtntype(uint8_t val)
+{
+	int i;
+
+	for (i = 0; rtntypes[i].name; i++) {
+		if (val == rtntypes[i].id)
+			return rtntypes[i].name;
+	}
+
+	snprintf(ret_buf, sizeof(ret_buf), "%u", val);
+	return ret_buf;
 }

--- a/lib/rttables.h
+++ b/lib/rttables.h
@@ -24,7 +24,16 @@
 #ifndef _READ_RTTABLES_H
 #define _READ_RTTABLES_H
 
-extern void clear_rttables(void);
-extern bool find_rttables_table(const char *, unsigned int *);
+extern void clear_rt_names(void);
+extern bool find_rttables_table(const char *, uint32_t *);
+extern bool find_rttables_dsfield(const char *, uint32_t*);
+extern bool find_rttables_realms(const char *, uint32_t *);
+extern bool find_rttables_group(const char *, uint32_t *);
+extern bool find_rttables_proto(const char *, uint32_t *);
+extern bool find_rttables_scope(const char *, uint32_t *);
+extern bool find_rttables_rtntype(const char *, uint8_t *);
+extern const char *get_rttables_scope(uint32_t);
+extern const char *get_rttables_group(uint32_t);
+extern const char *get_rttables_rtntype(uint8_t);
 
 #endif

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -21,7 +21,9 @@
  * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@linux-vs.org>
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
All ip rule/ip route configuration options are now supported, using the syntax of ip rule and ip route commands.

This also tidies up commit fc7ea83 (setting priority for IPv6 packets), so that only the relevant option is set depending on IPv4 or IPv6.