### PR TITLE
More updates for removing pre-Linux 2.6 code, and stop "unknown keyword" messages.

### DIFF
--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -21,14 +21,14 @@
  * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
  */
 
-#ifndef O_CLOEXEC
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* to make O_CLOEXEC available */
-#ifndef O_CLOEXEC
-#define O_CLOEXEC 0	/* It doesn't really matter if O_CLOEXEC isn't set here */
 #endif
-#endif
+
 #include <fcntl.h>
+
+#ifndef O_CLOEXEC	/* Since Linux 2.6.23 and glibc 2.7 */
+#define O_CLOEXEC 0	/* It doesn't really matter if O_CLOEXEC isn't set here */
 #endif
 
 #include "ipvswrapper.h"

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -68,14 +68,14 @@ parse_timeout(char *buf, unsigned *timeout)
 	int i;
 
 	if (buf == NULL) {
-		*timeout = IP_VS_TEMPLATE_TIMEOUT;
+		*timeout = IPVS_SVC_PERSISTENT_TIMEOUT;
 		return 1;
 	}
 
 	if ((i = string_to_number(buf, 0, 86400 * 31)) == -1)
 		return 0;
 
-	*timeout = i * (IP_VS_TEMPLATE_TIMEOUT / (6*60));
+	*timeout = i * (IPVS_SVC_PERSISTENT_TIMEOUT / (6*60));
 	return 1;
 }
 

--- a/keepalived/check/libipvs.c
+++ b/keepalived/check/libipvs.c
@@ -56,6 +56,7 @@ static struct nl_sock *sock = NULL;
 static int family, try_nl = 1;
 
 /* Policy definitions */
+#ifdef _WITH_SNMP_CHECKER_
 static struct nla_policy ipvs_cmd_policy[IPVS_CMD_ATTR_MAX + 1] = {
 	[IPVS_CMD_ATTR_SERVICE]		= { .type = NLA_NESTED },
 	[IPVS_CMD_ATTR_DEST]		= { .type = NLA_NESTED },
@@ -137,6 +138,7 @@ static struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
 	[IPVS_STATS_ATTR_OUTBPS]	= { .type = NLA_U32 },
 };
 #endif
+#endif	/* _WITH_SNMP_CHECKER */
 
 #define CHECK_IPV4(s, ret) if (s->af && s->af != AF_INET)	\
 	{ errno = EAFNOSUPPORT; goto out_err; }			\
@@ -1050,7 +1052,7 @@ out_err:
 	FREE(svc);
 	return NULL;
 }
-#endif	/* _WITH_IPVS_CHECKER */
+#endif	/* _WITH_SNMP_CHECKER_ */
 
 void ipvs_close(void)
 {
@@ -1084,8 +1086,10 @@ const char *ipvs_strerror(int err)
 		{ ipvs_del_dest, ENOENT, "No such destination" },
 		{ ipvs_start_daemon, EEXIST, "Daemon has already run" },
 		{ ipvs_stop_daemon, ESRCH, "No daemon is running" },
+#ifdef _WITH_SNMP_CHECKER_
 		{ ipvs_get_dests, ESRCH, "No such service" },
 		{ ipvs_get_service, ESRCH, "No such service" },
+#endif
 		{ 0, EPERM, "Permission denied (you must be root)" },
 		{ 0, EINVAL, "Invalid operation.  Possibly wrong module version, address not unicast, ..." },
 		{ 0, ENOPROTOOPT, "Protocol not available" },

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -329,6 +329,6 @@ dump_global_data(data_t * data)
 #endif
 #ifdef _WITH_SNMP_
 	log_message(LOG_INFO, " SNMP traps %s", data->enable_traps ? "enabled" : "disabled");
-	log_message(LOG_INFO, " SNMP socket = %s", data->snmp_socket ? data->snmp_socket : "default (127.0.0.1:161)");
+	log_message(LOG_INFO, " SNMP socket = %s", data->snmp_socket ? data->snmp_socket : "default (unix:/var/agentx/master)");
 #endif
 }

--- a/keepalived/include/ipvswrapper.h
+++ b/keepalived/include/ipvswrapper.h
@@ -50,10 +50,6 @@
 #endif
 #endif
 
-#ifndef IP_VS_TEMPLATE_TIMEOUT
-#define IP_VS_TEMPLATE_TIMEOUT IPVS_SVC_PERSISTENT_TIMEOUT
-#endif
-
 /* locale includes */
 #include "scheduler.h"
 #include "check_data.h"

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -36,33 +36,9 @@
 #include "scheduler.h"
 #include "list.h"
 
-/* types definition */
-#ifndef SIOCETHTOOL
-/* should not happen, otherwise we have a broken toolchain */
-#warning "SIOCETHTOOL not defined. Defaulting to 0x8946, which is probably wrong !"
-#define SIOCETHTOOL     0x8946
-#endif
-#ifndef SIOCGMIIPHY
-/* should not happen, otherwise we have a broken toolchain */
-#warning "SIOCGMIIPHY not defined. Defaulting to SIOCDEVPRIVATE, which is probably wrong !"
-#define SIOCGMIIPHY (SIOCDEVPRIVATE)	/* Get the PHY in use. */
-#define SIOCGMIIREG (SIOCGMIIPHY+1)	/* Read a PHY register. */
-#endif
-
-/* ethtool.h cannot be included because old versions use kernel-only types
- * which cannot be included from user-land. We don't need much anyway.
- */
-#ifndef ETHTOOL_GLINK
-#define ETHTOOL_GLINK   0x0000000a
-/* for passing single values */
-struct ethtool_value {
-	uint32_t   cmd;
-	uint32_t   data;
-};
-#endif
 #define LINK_UP   1
 #define LINK_DOWN 0
-#define IF_NAMESIZ    20	/* Max interface lenght size */
+#define IF_NAMESIZ    20	/* Max interface length size */
 #define IF_HWADDR_MAX 20	/* Max MAC address length size */
 #define ARPHRD_ETHER 1
 #define ARPHRD_LOOPBACK 772

--- a/keepalived/include/vrrp_iproute.h
+++ b/keepalived/include/vrrp_iproute.h
@@ -173,9 +173,7 @@ typedef struct _ip_route {
 	ip_address_t		*via;
 	interface_t		*oif;
 	uint32_t		flags;
-#ifdef RTAX_FEATURES
 	uint32_t		features;
-#endif
 #ifdef RTAX_QUICKACK
 	bool			quickack;
 #endif
@@ -197,9 +195,7 @@ typedef struct _ip_route {
 	uint32_t		ssthresh;
 	uint32_t		rto_min;
 	uint32_t		initcwnd;
-#ifdef RTAX_INITRWND
 	uint32_t		initrwnd;
-#endif
 #ifdef RTAX_CC_ALGO
 	char			*congctl;
 #endif

--- a/keepalived/include/vrrp_netlink.h
+++ b/keepalived/include/vrrp_netlink.h
@@ -23,11 +23,6 @@
 #ifndef _VRRP_NETLINK_H
 #define _VRRP_NETLINK_H 1
 
-/* Hack for GNU libc version 2. */
-#ifndef MSG_TRUNC
-#define MSG_TRUNC      0x20
-#endif				/* MSG_TRUNC */
-
 /* global includes */
 #include <asm/types.h>
 #include <linux/netlink.h>

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -35,10 +35,6 @@ typedef uint8_t u8;
 #include <fcntl.h>
 #include <syslog.h>
 #include <ctype.h>
-#ifdef use_linux_libc5
-#include <linux/if_arp.h>
-#include <linux/if_ether.h>
-#endif
 #include <linux/ip.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -38,7 +38,7 @@ typedef uint8_t u8;
 #include <linux/ip.h>
 #include <stdlib.h>
 #include <stdio.h>
-//#include <linux/ethtool.h>
+#include <linux/ethtool.h>
 #ifndef _HAVE_SOCK_CLOEXEC_
 #include "old_socket.h"
 #endif
@@ -277,7 +277,6 @@ if_mii_probe(const char *ifname)
 static int
 if_ethtool_status(const int fd)
 {
-#ifdef ETHTOOL_GLINK
 	struct ethtool_value edata;
 	int err = 0;
 
@@ -287,7 +286,6 @@ if_ethtool_status(const int fd)
 	if (err == 0)
 		return (edata.data) ? 1 : 0;
 	else
-#endif
 		return -1;
 }
 

--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -405,10 +405,8 @@ netlink_route(ip_route_t *iproute, int cmd)
 	if (iproute->mask & IPROUTE_BIT_RTO_MIN)
 		rta_addattr32(rta, sizeof(buf), RTAX_RTO_MIN, iproute->rto_min);
 
-#ifdef RTAX_FEATURES
 	if (iproute->features)
 		rta_addattr32(rta, sizeof(buf), RTAX_FEATURES, iproute->features);
-#endif
 
 	if (iproute->mask & IPROUTE_BIT_MTU)
 		rta_addattr32(rta, sizeof(buf), RTAX_MTU, iproute->mtu);
@@ -434,10 +432,8 @@ netlink_route(ip_route_t *iproute, int cmd)
 	if (iproute->mask & IPROUTE_BIT_INITCWND)
 		rta_addattr32(rta, sizeof(buf), RTAX_INITCWND, iproute->initcwnd);
 
-#ifdef RTAX_INITRWND
 	if (iproute->mask & IPROUTE_BIT_INITRWND)
 		rta_addattr32(rta, sizeof(buf), RTAX_INITRWND, iproute->initrwnd);
-#endif
 
 #ifdef RTAX_QUICKACK
 	if (iproute->mask & IPROUTE_BIT_QUICKACK)
@@ -753,12 +749,10 @@ format_iproute(ip_route_t *route, char *buf, size_t buf_len)
 			op += snprintf(op, buf_end - op, "%ums", route->rto_min);
 	}
 
-#ifdef RTAX_FEATURES
 	if (route->features) {
 		if (route->features & RTAX_FEATURE_ECN)
 			op += snprintf(op, buf_end - op, " %s", "features ecn");
 	}
-#endif
 
 	if (route->mask & IPROUTE_BIT_MTU) {
 		op += snprintf(op, buf_end - op, " mtu %s%u",
@@ -799,10 +793,8 @@ format_iproute(ip_route_t *route, char *buf, size_t buf_len)
 	if (route->mask & IPROUTE_BIT_INITCWND)
 		op += snprintf(op, buf_end - op, " initcwnd %u", route->initcwnd);
 
-#ifdef RTAX_INITRWND
 	if (route->mask & IPROUTE_BIT_INITRWND)
 		op += snprintf(op, buf_end - op, " initrwnd %u", route->initrwnd);
-#endif
 
 #ifdef RTAX_QUICKACK
 	if (route->mask & IPROUTE_BIT_QUICKACK)
@@ -1509,24 +1501,16 @@ alloc_route(list rt_list, vector_t *strvec)
 		}
 		else if (!strcmp(str, "initrwnd")) {
 			i++;
-#ifdef RTAX_INITRWND
 			if (get_u32(&new->initrwnd, vector_slot(strvec, i), UINT32_MAX, "Invalid initrwnd value %s specified for route"))
 				goto err;
 			new->mask |= IPROUTE_BIT_INITRWND;
-#else
-			log_message(LOG_INFO, "initrwnd for route not supported by kernel");
-#endif
 		}
 		else if (!strcmp(str, "features")) {
 			i++;
-#ifdef RTAX_FEATURES
 			if (!strcmp("ecn", vector_slot(strvec, i)))
 				new->features |= RTAX_FEATURE_ECN;
 			else
 				log_message(LOG_INFO, "feature %s not supported", FMT_STR_VSLOT(strvec,i));
-#else
-			log_message(LOG_INFO, "features for route not supported by kernel");
-#endif
 		}
 		else if (!strcmp(str, "quickack")) {
 			i++;

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -934,12 +934,8 @@ vrrp_snmp_route(struct variable *vp, oid *name, size_t *length,
 		long_ret = route->protocol + 1;
 		return (u_char *)&long_ret;
 	case VRRP_SNMP_ROUTE_ECN:
-#ifndef RTAX_FEATURES
-		break;
-#else
 		long_ret = 2 - !!(route->features & RTAX_FEATURE_ECN);
 		return (u_char *)&long_ret;
-#endif
 	case VRRP_SNMP_ROUTE_QUICK_ACK:
 		long_ret = 2 - !!(route->mask & IPROUTE_BIT_QUICKACK);
 		return (u_char *)&long_ret;

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -74,6 +74,10 @@ keyword_alloc_sub(vector_t *keywords_vec, const char *string, void (*handler) (v
 	/* fetch last keyword */
 	keyword = vector_slot(keywords_vec, vector_size(keywords_vec) - 1);
 
+	/* Don't install subordinate keywords if configuration block inactive */
+	if (!keyword->active)
+		return;
+
 	/* position to last sub level */
 	for (i = 0; i < sublevel; i++)
 		keyword =
@@ -121,6 +125,9 @@ install_sublevel_end_handler(void (*handler) (void))
 	/* fetch last keyword */
 	keyword = vector_slot(keywords, vector_size(keywords) - 1);
 
+	if (!keyword->active)
+		return;
+
 	/* position to last sub level */
 	for (i = 0; i < sublevel; i++)
 		keyword =
@@ -143,8 +150,6 @@ dump_keywords(vector_t *keydump, int level, FILE *fp)
 		if (!fp)
 			return;
 	}
-
-	vector_dump(fp, keywords);
 
 	for (i = 0; i < vector_size(keydump); i++) {
 		keyword_vec = vector_slot(keydump, i);
@@ -501,9 +506,15 @@ alloc_value_block(vector_t *strvec, void (*alloc_func) (vector_t *))
 void *
 set_value(vector_t *strvec)
 {
-	char *str = vector_slot(strvec, 1);
-	int size = strlen(str);
+	char *str;
+	int size;
 	char *alloc;
+
+	if (vector_size(strvec) < 2)
+		return NULL;
+
+	str = vector_slot(strvec, 1);
+	size = strlen(str);
 
 	alloc = (char *) MALLOC(size + 1);
 	if (!alloc)
@@ -556,19 +567,19 @@ process_stream(vector_t *keywords_vec, int need_bob)
 
 		str = vector_slot(strvec, 0);
 
-		if (need_bob) {
-			need_bob = 0;
-			if (!strcmp(str, BOB) && kw_level > 0)
-				str[0] = 0;
-			else
-				log_message(LOG_INFO, "Missing '{' at beginning of configuration block");
+		if (skip_sublevel == -1) {
+			/* There wasn't a '{' on the keyword line */
+			if (!strcmp(str, BOB)) {
+				/* We've got the opening '{' now */
+				skip_sublevel = 1;
+				free_strvec(strvec);
+				continue;
+			}
+			else {
+				/* The skipped keyword doesn't have a {} block, so we no longer want to skip */
+				skip_sublevel = 0;
+			}
 		}
-		else if (!skip_sublevel && !strcmp(str, BOB)) {
-			log_message(LOG_INFO, "Unexpected '{' - ignoring");
-			free_strvec(strvec);
-			continue;
-		}
-
 		if (skip_sublevel) {
 			for (i = 0; i < vector_size(strvec); i++) {
 				str = vector_slot(strvec,i);
@@ -579,10 +590,23 @@ process_stream(vector_t *keywords_vec, int need_bob)
 						break;
 				}
 			}
-			free_strvec(strvec);
 
-			if (!skip_sublevel)
-				break;
+			free_strvec(strvec);
+			continue;
+		}
+
+		if (need_bob) {
+			need_bob = 0;
+			if (!strcmp(str, BOB) && kw_level > 0) {
+				free_strvec(strvec);
+				continue;
+			}
+			else
+				log_message(LOG_INFO, "Missing '{' at beginning of configuration block");
+		}
+		else if (!strcmp(str, BOB)) {
+			log_message(LOG_INFO, "Unexpected '{' - ignoring");
+			free_strvec(strvec);
 			continue;
 		}
 
@@ -595,6 +619,15 @@ process_stream(vector_t *keywords_vec, int need_bob)
 			keyword_vec = vector_slot(keywords_vec, i);
 
 			if (!strcmp(keyword_vec->string, str)) {
+				if (!keyword_vec->active) {
+					if (!strcmp(vector_slot(strvec, vector_size(strvec)-1), BOB))
+						skip_sublevel = 1;
+					else
+						skip_sublevel = -1;
+				}
+
+				/* There is an inconsistency here. 'static_ipaddress' for example
+				 * does not have sub levels, but needs a '{' */
 				if (keyword_vec->sub) {
 					/* Remove a trailing '{' */
 					char *bob = vector_slot(strvec, vector_size(strvec)-1) ;
@@ -607,13 +640,10 @@ process_stream(vector_t *keywords_vec, int need_bob)
 						bob_needed = 1;
 				}
 
-				if (keyword_vec->active && keyword_vec->handler)
+				if (keyword_vec->handler)
 					(*keyword_vec->handler) (strvec);
 
 				if (keyword_vec->sub) {
-					if (!keyword_vec->active)
-						skip_block();
-
 					kw_level++;
 					process_stream(keyword_vec->sub, bob_needed);
 					kw_level--;

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -116,9 +116,7 @@ signal_set(int signo, void (*func) (void *, int), void *v)
 		sig.sa_handler = signal_handler;
 	sigemptyset(&sig.sa_mask);
 	sig.sa_flags = 0;
-#ifdef SA_RESTART
 	sig.sa_flags |= SA_RESTART;
-#endif				/* SA_RESTART */
 
 	/* Block the signal we are about to configure, to avoid
 	 * any race conditions while setting the handler and


### PR DESCRIPTION
The majority of the commits are removing more pre Linux 2.6 code. There is also a commit that resolves the "unknown keyword" messages, and a cosmetic change to report the correct default for snmp socket.

The "unknown keyword" fix resolves issue #297.