### PR TITLE
Stop "Netlink: Received message overrun (No buffer space available)" messages

### DIFF
--- a/keepalived/include/vrrp_netlink.h
+++ b/keepalived/include/vrrp_netlink.h
@@ -84,6 +84,7 @@ extern struct rtattr *rta_nest(struct rtattr *, size_t, int);
 extern size_t rta_nest_end(struct rtattr *, struct rtattr *);
 extern int netlink_talk(nl_handle_t *, struct nlmsghdr *);
 extern int netlink_interface_lookup(void);
+extern void kernel_netlink_poll(void);
 extern void kernel_netlink_init(void);
 extern void kernel_netlink_close(void);
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -53,6 +53,7 @@
 #include "utils.h"
 #include "notify.h"
 #include "bitops.h"
+#include "vrrp_netlink.h"
 #if !HAVE_DECL_SOCK_CLOEXEC
 #include "old_socket.h"
 #endif
@@ -2234,8 +2235,6 @@ vrrp_complete_instance(vrrp_t * vrrp)
 		vrrp->vipset = true;	/* Set to force address removal */
 		vrrp_restore_interface(vrrp, false, true);
 	}
-
-	return 1;
 }
 
 int
@@ -2452,11 +2451,7 @@ vrrp_complete_init(void)
 bool
 vrrp_ipvs_needed(void)
 {
-#ifdef _WITH_LVS_
 	return !!(global_data->lvs_syncd.ifname);
-#else
-	return false;
-#endif
 }
 #endif
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2235,6 +2235,13 @@ vrrp_complete_instance(vrrp_t * vrrp)
 		vrrp->vipset = true;	/* Set to force address removal */
 		vrrp_restore_interface(vrrp, false, true);
 	}
+
+	/* If we are adding a large number of interfaces, the netlink socket
+	 * may run out of buffers if we don't receive the netlink messages
+	 * as we progress */
+	kernel_netlink_poll();
+
+	return 1;
 }
 
 int

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -202,13 +202,11 @@ start_vrrp(void)
 		    global_data->lvs_udp_timeout)
 			ipvs_set_timeouts(global_data->lvs_tcp_timeout, global_data->lvs_tcpfin_timeout, global_data->lvs_udp_timeout);
 
-#ifdef _WITH_LVS_
 		/* If we are managing the sync daemon, then stop any
 		 * instances of it that may have been running if
 		 * we terminated abnormally */
 		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_MASTER, true, true);
 		ipvs_syncd_cmd(IPVS_STOPDAEMON, NULL, IPVS_BACKUP, true, true);
-#endif
 	}
 #endif
 


### PR DESCRIPTION
keepalived was only polling for netlink messages on the kernel reflection channel on a timed basis. If a large number of vmacs were added at startup, the netlink socket would run out of receive buffers, and an ENOBUFS error would occur when the netlink socket was read.

Polling for netlink messages after adding each interface resolves the problem.

This should resolve issue #392.