### PR TITLE
Add polling of netlink messages when entering master state

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1205,6 +1205,8 @@ vrrp_state_become_master(vrrp_t * vrrp)
 		vrrp_handle_iprules(vrrp, IPRULE_ADD, false);
 #endif
 
+	kernel_netlink_poll();
+
 	/* remotes neighbour update */
 	vrrp_send_link_update(vrrp, vrrp->garp_rep);
 


### PR DESCRIPTION
Issue #392 has identified a further instance where the kernel reflection netlink socket can experience a buffer overrun. In this case, with 200 vrrp interfaces each with a vmac, adding a notify_master script caused the overrun. This is caused by the overhead of executing open(), close() and fork() synchronously for each vrrp instance as it transitions to master.

I think we should consider having a queue for the notify scripts, so that the fork()s are executed asynchronously from the actual vrrp work. This queue should be a low priority queue, so that the vrrp actions (state transitions, adding interfaces/addresses etc) aren't delayed by initiating the notify scripts.