### PR TITLE
Fix calculation of skew time, and timer_cmp() for extreme cases, and minor changes

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -49,6 +49,7 @@ global_defs {				# Block identification
 					   #   (in seconds, resolution microseconds)
     vrrp_mcast_group4 <IPv4 ADDRESS>	   # optional, default 224.0.0.18
     vrrp_mcast_group6 <IPv6 ADDRESS>	   # optional, default ff02::12
+    default_interface <INTERFACE>	   # sets the default interface for static addresses, default eth0
     lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE>	[id <SYNC_ID>] [maxlen <LEN>] [port <PORT>] [ttl <TTL>] [group <IP ADDR>]
 					   # Binding interface, vrrp instance and optional
 					   #  syncid (0 to 255) for lvs syncd
@@ -123,6 +124,7 @@ linkbeat_use_polling			   # Use media link failure detection polling fashion
 	The configuration block looks like :
 
 static_ipaddress {			# block identification
+					# If no dev element is specified, it defaults to the default_interface (default eth0)
     <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE>
     <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE>
     ...

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -54,6 +54,8 @@ and
                               # default: local host name
  vrrp_mcast_group4 224.0.0.18 # optional, default 224.0.0.18
  vrrp_mcast_group6 ff02::12   # optional, default ff02::12
+ default_interface p33p1.3    # sets the default interface for static addresses, default eth0
+
 
  lvs_sync_daemon <INTERFACE> <VRRP_INSTANCE> [id <SYNC_ID>] [maxlen <LEN>] [port <PORT>] [ttl <TTL>] [group <IP ADDR>]
                               # Binding interface, vrrp instance and optional
@@ -177,7 +179,8 @@ If you already have IPs and routes on your machines and
 your machines can ping each other, you don't need this section.
 The syntax for rules and routes is that same as for ip rule add/ip route add.
 .PP
-The syntax is the same for virtual addresses and virtual routes.
+The syntax is the same for virtual addresses and virtual routes. If no dev element
+is specified, it defaults to default_interface (default eth0).
 .PP
  static_ipaddress
  {

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -254,6 +254,7 @@ dump_global_data(data_t * data)
 				    , data->email_from);
 		dump_list(data->email);
 	}
+	log_message(LOG_INFO, " Default interface = %s", data->default_ifp ? data->default_ifp->ifname : DFLT_INT);
 #ifdef _WITH_LVS_
 	if (data->lvs_tcp_timeout)
 		log_message(LOG_INFO, " LVS TCP timeout = %d", data->lvs_tcp_timeout);

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -95,10 +95,10 @@ set_vrrp_defaults(data_t * data)
 	data->vrrp_lower_prio_no_advert = false;
 	data->vrrp_version = VRRP_VERSION_2;
 	strcpy(data->vrrp_iptables_inchain, "INPUT");
-	data->block_ipv4 = 0;
-	data->block_ipv6 = 0;
+	data->block_ipv4 = false;
+	data->block_ipv6 = false;
 #ifdef _HAVE_LIBIPSET_
-	data->using_ipsets = 1;
+	data->using_ipsets = true;
 	strcpy(data->vrrp_ipset_address, "keepalived");
 	strcpy(data->vrrp_ipset_address6, "keepalived6");
 	strcpy(data->vrrp_ipset_address_iface6, "keepalived_if6");

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -52,7 +52,7 @@
 static void
 use_polling_handler(vector_t *strvec)
 {
-	global_data->linkbeat_use_polling = 1;
+	global_data->linkbeat_use_polling = true;
 }
 static void
 routerid_handler(vector_t *strvec)

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -118,6 +118,21 @@ email_handler(vector_t *strvec)
 
 	free_strvec(email_vec);
 }
+static void
+default_interface_handler(vector_t *strvec)
+{
+	interface_t *ifp;
+
+	if (vector_size(strvec) < 2) {
+		log_message(LOG_INFO, "default_interface requires interface name");
+		return;
+	}
+	ifp = if_get_by_ifname(vector_slot(strvec, 1));
+	if (!ifp)
+		log_message(LOG_INFO, "Cannot find default interface %s", FMT_STR_VSLOT(strvec, 1));
+	else
+		global_data->default_ifp = ifp;
+}
 #ifdef _WITH_LVS_
 static void
 lvs_timeouts(vector_t *strvec)
@@ -647,6 +662,7 @@ init_global_keywords(bool global_active)
 	install_keyword("smtp_helo_name", &smtphelo_handler);
 	install_keyword("smtp_connect_timeout", &smtpto_handler);
 	install_keyword("notification_email", &email_handler);
+	install_keyword("default_interface", &default_interface_handler);
 #ifdef _WITH_LVS_
 	install_keyword("lvs_timeouts", &lvs_timeouts);
 	install_keyword("lvs_flush", &lvs_flush_handler);

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -65,6 +65,7 @@ typedef struct _data {
 	char				*smtp_helo_name;
 	long				smtp_connection_to;
 	list				email;
+	interface_t			*default_ifp;		/* Default interface for static addresses */
 #ifdef _WITH_LVS_
 	int				lvs_tcp_timeout;
 	int				lvs_tcpfin_timeout;

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -58,7 +58,7 @@ typedef struct _email {
 
 /* Configuration data root */
 typedef struct _data {
-	int				linkbeat_use_polling;
+	bool				linkbeat_use_polling;
 	char				*router_id;
 	char				*email_from;
 	struct sockaddr_storage		smtp_server;
@@ -89,10 +89,10 @@ typedef struct _data {
 	int				vrrp_version;	/* VRRP version (2 or 3) */
 	char				vrrp_iptables_inchain[XT_EXTENSION_MAXNAMELEN];
 	char				vrrp_iptables_outchain[XT_EXTENSION_MAXNAMELEN];
-	int				block_ipv4;
-	int				block_ipv6;
+	bool				block_ipv4;
+	bool				block_ipv6;
 #ifdef _HAVE_LIBIPSET_
-	int				using_ipsets;
+	bool				using_ipsets;
 	char				vrrp_ipset_address[IPSET_MAXNAMELEN];
 	char				vrrp_ipset_address6[IPSET_MAXNAMELEN];
 	char				vrrp_ipset_address_iface6[IPSET_MAXNAMELEN];
@@ -108,15 +108,15 @@ typedef struct _data {
 	bool				checker_no_swap;
 #endif
 #ifdef _WITH_SNMP_
-	int				enable_traps;
+	bool				enable_traps;
 	char				*snmp_socket;
 #ifdef _WITH_VRRP_
-	int				enable_snmp_keepalived;
-	int				enable_snmp_rfcv2;
-	int				enable_snmp_rfcv3;
+	bool				enable_snmp_keepalived;
+	bool				enable_snmp_rfcv2;
+	bool				enable_snmp_rfcv3;
 #endif
 #ifdef _WITH_LVS_
-	int				enable_snmp_checker;
+	bool				enable_snmp_checker;
 #endif
 #endif
 } data_t;

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -288,7 +288,8 @@ typedef struct _vrrp_t {
 #define VRRP_SEND_BUFFER(V)		((V)->send_buffer)
 #define VRRP_SEND_BUFFER_SIZE(V)	((V)->send_buffer_size)
 
-#define VRRP_TIMER_SKEW(svr)	((svr)->version == VRRP_VERSION_3 ? (((256-(svr)->base_priority) * (svr)->adver_int)/256) : ((256-(svr)->base_priority) * TIMER_HZ/256))
+/* We have to do some reduction of the calculation for VRRPv3 in order not to overflow a uint32; 625 / 16 == TIMER_CENTI_HZ / 256 */
+#define VRRP_TIMER_SKEW(svr)	((svr)->version == VRRP_VERSION_3 ? (((256-(svr)->base_priority) * ((svr)->adver_int / TIMER_CENTI_HZ) * 625) / 16) : ((256-(svr)->base_priority) * TIMER_HZ/256))
 #define VRRP_VIP_ISSET(V)	((V)->vipset)
 
 #define VRRP_MIN(a, b)	((a) < (b)?(a):(b))

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2119,6 +2119,10 @@ vrrp_complete_instance(vrrp_t * vrrp)
 			/* We've found a unique name */
 			strncpy(vrrp->vmac_ifname, ifname, IFNAMSIZ);
 		}
+		if (vrrp->strict_mode && __test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->vmac_flags)) {
+			log_message(LOG_INFO, "(%s): xmit_base is incompatible with strict mode - resetting", vrrp->iname);
+			__clear_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->vmac_flags);
+		}
 	}
 	else
 #endif

--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -470,16 +470,18 @@ alloc_ipaddress(list ip_list, vector_t *strvec, interface_t *ifp)
 	}
 
 	if (!ifp && !new->ifp) {
-		ifp_local = if_get_by_ifname(DFLT_INT);
-		if (!ifp_local) {
-			log_message(LOG_INFO, "Default interface " DFLT_INT
-				    " does not exist and no interface specified. "
-				    "Skipping static address %s.", FMT_STR_VSLOT(strvec, addr_idx));
-			FREE(new);
-			return;
+		if (!global_data->default_ifp) {
+			global_data->default_ifp = if_get_by_ifname(DFLT_INT);
+			if (!global_data->default_ifp) {
+				log_message(LOG_INFO, "Default interface " DFLT_INT
+					    " does not exist and no interface specified. "
+					    "Skipping static address %s.", FMT_STR_VSLOT(strvec, addr_idx));
+				FREE(new);
+				return;
+			}
 		}
-		new->ifa.ifa_index = IF_INDEX(ifp_local);
-		new->ifp = ifp_local;
+		new->ifa.ifa_index = IF_INDEX(global_data->default_ifp);
+		new->ifp = global_data->default_ifp;
 	}
 
 	if (new->ifa.ifa_family == AF_INET6) {

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -45,7 +45,7 @@ $(GIT_COMMIT_FILE):
 			GIT_REV=`git describe --tags`; \
 			echo $${GIT_REV} | grep -qE -- "-[1-9][0-9]*-g[0-9a-f]{7}$$"; \
 			if [ $$? -eq 0 ]; then \
-				if [ -n "`git status --porcelain`" ]; then EXTRA="+"; else EXTRA=""; fi ; \
+				if [ "`git status --porcelain | wc -l`" -ne 0 ]; then EXTRA="+"; else EXTRA=""; fi ; \
 				echo "#define GIT_COMMIT \"$${GIT_REV}$${EXTRA}\"" >$(abs_builddir)/$(GIT_COMMIT_FILE).new; \
 				diff -q $(abs_builddir)/$(GIT_COMMIT_FILE) $(abs_builddir)/$(GIT_COMMIT_FILE).new 2>/dev/null >/dev/null; \
 				if [ $$? -eq 0 ]; then \

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -606,7 +606,7 @@ $(GIT_COMMIT_FILE):
 			GIT_REV=`git describe --tags`; \
 			echo $${GIT_REV} | grep -qE -- "-[1-9][0-9]*-g[0-9a-f]{7}$$"; \
 			if [ $$? -eq 0 ]; then \
-				if [ -n "`git status --porcelain`" ]; then EXTRA="+"; else EXTRA=""; fi ; \
+				if [ "`git status --porcelain | wc -l`" -ne 0 ]; then EXTRA="+"; else EXTRA=""; fi ; \
 				echo "#define GIT_COMMIT \"$${GIT_REV}$${EXTRA}\"" >$(abs_builddir)/$(GIT_COMMIT_FILE).new; \
 				diff -q $(abs_builddir)/$(GIT_COMMIT_FILE) $(abs_builddir)/$(GIT_COMMIT_FILE).new 2>/dev/null >/dev/null; \
 				if [ $$? -eq 0 ]; then \

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -46,10 +46,10 @@ timer_dup(timeval_t b)
 int
 timer_cmp(timeval_t a, timeval_t b)
 {
-	int ret = a.tv_sec - b.tv_sec;
-	if (! ret)
+	time_t ret = a.tv_sec - b.tv_sec;
+	if (!ret)
 		return a.tv_usec - b.tv_usec;
-	return ret;
+	return ret < 0 ? -1 : 1;
 }
 
 /* timer sub */

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -94,6 +94,15 @@ timer_add_long(timeval_t a, long b)
 	timeval_t ret;
 
 	timer_reset_lazy(ret);
+
+	if (b == TIMER_NEVER)
+	{
+		ret.tv_usec = TIMER_HZ - 1;
+		ret.tv_sec = LONG_MAX;
+
+		return ret;
+	}
+
 	ret.tv_usec = a.tv_usec + b % TIMER_HZ;
 	ret.tv_sec = a.tv_sec + b / TIMER_HZ;
 

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -24,6 +24,7 @@
 #define _TIMER_H
 
 #include <sys/time.h>
+#include <limits.h>
 
 typedef struct timeval timeval_t;
 
@@ -35,6 +36,7 @@ extern timeval_t time_now;
 #define TIMER_HZ		1000000
 #define TIMER_CENTI_HZ		10000
 #define TIMER_MAX_SEC		1000
+#define TIMER_NEVER		LONG_MIN
 
 /* Some usefull macros */
 #define timer_sec(T) ((T).tv_sec)


### PR DESCRIPTION
Both VRRP_TIMER_SKEW() and timer_cmp() could overflow for large timer values.

The addition of TIMER_NEVER is to support threads that don't want to time out.

The addition of default_interface keyword is to avoid having to add dev IFACE after each static route if they are not using eth0.