### PR TITLE
Add keywords instance and use_pid_dir, plus sundry fixes/improvements

### DIFF
--- a/configure
+++ b/configure
@@ -4888,9 +4888,9 @@ ARFLAGS=cr
 
 
 KA_CPPFLAGS="$kernelinc"
-KA_CFLAGS="-Wall -Wunused -Wstrict-prototypes -g -O2"
-KA_LDFLAGS="-g"
-KA_LIBS="-ldl"
+KA_CFLAGS="-Wall -Wunused -Wstrict-prototypes"
+KA_LDFLAGS="-ldl"
+KA_LIBS=
 #KA_LIBTOOLFLAGS =
 
 
@@ -5254,10 +5254,53 @@ done
 
 # check for kernel headers
 CPPFLAGS="$kernelinc"
-for ac_header in asm/types.h linux/ethtool.h linux/fib_rules.h linux/icmpv6.h linux/if_addr.h linux/if_ether.h linux/if_link.h linux/if_packet.h linux/ip.h linux/sockios.h linux/types.h
+NETLINK_EXTRA_INCLUDE=
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+  #include <linux/netlink.h>
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+else
+  ac_fn_c_check_header_compile "$LINENO" "linux/netlink.h" "ac_cv_header_linux_netlink_h" "#include <sys/socket.h>
+"
+if test "x$ac_cv_header_linux_netlink_h" = xyes; then :
+
+
+$as_echo "#define NETLINK_H_NEEDS_SYS_SOCKET_H  1 " >>confdefs.h
+
+      NETLINK_EXTRA_INCLUDE="#include <sys/socket.h>"
+
+else
+  as_fn_error $? "Missing/unusable kernel header file <linux/netlink.h>" "$LINENO" 5
+fi
+
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+for ac_header in asm/types.h linux/ethtool.h linux/icmpv6.h linux/if_ether.h linux/if_packet.h linux/ip.h linux/sockios.h linux/types.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+
+else
+  as_fn_error $? "Missing/unusable kernel header file <$ac_header>" "$LINENO" 5
+fi
+
+done
+
+for ac_header in linux/fib_rules.h linux/if_addr.h linux/if_link.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$NETLINK_EXTRA_INCLUDE
+"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
 #define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
@@ -6536,7 +6579,23 @@ fi
 done
 
   fi
-  for ac_header in linux/netlink.h linux/rtnetlink.h libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h
+
+  for ac_header in linux/rtnetlink.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "linux/rtnetlink.h" "ac_cv_header_linux_rtnetlink_h" "$NETLINK_EXTRA_INCLUDE
+"
+if test "x$ac_cv_header_linux_rtnetlink_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LINUX_RTNETLINK_H 1
+_ACEOF
+
+else
+  as_fn_error $? "Unusable link/rtnetlink.h" "$LINENO" 5
+fi
+
+done
+
+  for ac_header in libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -6826,38 +6885,9 @@ fi
 
 USE_LIBIPTC=No
 USE_LIBIPSET=No
-if test "$enable_vrrp" != no; then
-    for ac_header in linux/netfilter/x_tables.h
-do :
-  ac_fn_c_check_header_mongrel "$LINENO" "linux/netfilter/x_tables.h" "ac_cv_header_linux_netfilter_x_tables_h" "$ac_includes_default"
-if test "x$ac_cv_header_linux_netfilter_x_tables_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LINUX_NETFILTER_X_TABLES_H 1
-_ACEOF
-
-            ac_fn_c_check_decl "$LINENO" "XT_EXTENSION_MAXNAMELEN" "ac_cv_have_decl_XT_EXTENSION_MAXNAMELEN" "#include <linux/netfilter/x_tables.h>
-"
-if test "x$ac_cv_have_decl_XT_EXTENSION_MAXNAMELEN" = xyes; then :
-
-else
-
-$as_echo "#define XT_EXTENSION_MAXNAMELEN  (XT_FUNCTION_MAXNAMELEN - 1) " >>confdefs.h
-
-fi
-
-
-else
-
-$as_echo "#define XT_EXTENSION_MAXNAMELEN  29 " >>confdefs.h
-
-fi
-
-done
-
-
-  if test .${enable_libiptc} != .no; then
-    USE_LIBIPTC=Yes
-        for ac_header in linux/netfilter/x_tables.h xtables.h libiptc/libip6tc.h libiptc/libiptc.h libiptc/libxtc.h
+if test .${enable_libiptc} != .no; then
+  USE_LIBIPTC=Yes
+    for ac_header in linux/netfilter/x_tables.h xtables.h libiptc/libip6tc.h libiptc/libiptc.h libiptc/libxtc.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -6868,15 +6898,15 @@ _ACEOF
 
 else
 
-        USE_LIBIPTC=No
-        break
+      USE_LIBIPTC=No
+      break
 
 fi
 
 done
 
-    if test $USE_LIBIPTC = Yes; then
-       if test 2 -ge 2; then
+  if test $USE_LIBIPTC = Yes; then
+     if test 2 -ge 2; then
       PKG_PFX=IPTC
     else
       PKG_PFX=KA
@@ -6922,9 +6952,9 @@ done
     eval ${PKG_PFX}_LIBS=\"\$${PKG_PFX}_LIBS $ADD_NEW\"
 
 
-      LIBS="$IPTC_LIBS"
-      CPPFLAGS="$kernelinc"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for iptc_init in -liptc" >&5
+    LIBS="$IPTC_LIBS"
+    CPPFLAGS="$kernelinc"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for iptc_init in -liptc" >&5
 $as_echo_n "checking for iptc_init in -liptc... " >&6; }
 if ${ac_cv_lib_iptc_iptc_init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6962,7 +6992,7 @@ fi
 $as_echo "$ac_cv_lib_iptc_iptc_init" >&6; }
 if test "x$ac_cv_lib_iptc_iptc_init" = xyes; then :
 
-           if test 1 -ge 2; then
+         if test 1 -ge 2; then
       PKG_PFX=
     else
       PKG_PFX=KA
@@ -7016,16 +7046,16 @@ else
   USE_LIBIPTC=No
 fi
 
-    fi
+  fi
 
-    if test $USE_LIBIPTC = Yes; then
-      BUILD_OPTIONS="$BUILD_OPTIONS LIBIPTC"
+  if test $USE_LIBIPTC = Yes; then
+    BUILD_OPTIONS="$BUILD_OPTIONS LIBIPTC"
 
-            CPPFLAGS="$kernelinc"
-      if test "${enable_libipset}" != no; then
-        pkg-config --exists libipset
-        if test $? -eq 0; then
-           if test 2 -ge 2; then
+        CPPFLAGS="$kernelinc"
+    if test "${enable_libipset}" != no; then
+      pkg-config --exists libipset
+      if test $? -eq 0; then
+         if test 2 -ge 2; then
       PKG_PFX=IPSET
     else
       PKG_PFX=KA
@@ -7071,12 +7101,12 @@ fi
     eval ${PKG_PFX}_LIBS=\"\$${PKG_PFX}_LIBS $ADD_NEW\"
 
 
-        else
-          IPSET_LIBS="-lipset"
-        fi
-        LIBS="$IPTC_LIBS $IPSET_LIBS"
+      else
+        IPSET_LIBS="-lipset"
+      fi
+      LIBS="$IPTC_LIBS $IPSET_LIBS"
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ipset_session_init in -lipset" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ipset_session_init in -lipset" >&5
 $as_echo_n "checking for ipset_session_init in -lipset... " >&6; }
 if ${ac_cv_lib_ipset_ipset_session_init+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -7114,8 +7144,8 @@ fi
 $as_echo "$ac_cv_lib_ipset_ipset_session_init" >&6; }
 if test "x$ac_cv_lib_ipset_ipset_session_init" = xyes; then :
 
-            USE_LIBIPSET=Yes
-            for ac_header in libipset/data.h libipset/linux_ip_set.h libipset/session.h libipset/types.h
+          USE_LIBIPSET=Yes
+          for ac_header in libipset/data.h libipset/linux_ip_set.h libipset/session.h libipset/types.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -7126,16 +7156,16 @@ _ACEOF
 
 else
 
-                USE_LIBIPSET=No
-                break
+              USE_LIBIPSET=No
+              break
 
 fi
 
 done
 
 
-            if test $USE_LIBIPSET = Yes; then
-              { $as_echo "$as_me:${as_lineno-$LINENO}: checking for xtables_insmod in -lxtables" >&5
+          if test $USE_LIBIPSET = Yes; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for xtables_insmod in -lxtables" >&5
 $as_echo_n "checking for xtables_insmod in -lxtables... " >&6; }
 if ${ac_cv_lib_xtables_xtables_insmod+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -7182,16 +7212,16 @@ else
   USE_LIBIPSET=No
 fi
 
-            fi
+          fi
 
-            if test $USE_LIBIPSET = Yes; then
+          if test $USE_LIBIPSET = Yes; then
 
 $as_echo "#define _HAVE_LIBIPSET_  1 " >>confdefs.h
 
-              BUILD_OPTIONS="$BUILD_OPTIONS LIBIPSET"
-              pkg-config --exists libipset
-              if test $? -eq 0; then
-                 if test 1 -ge 2; then
+            BUILD_OPTIONS="$BUILD_OPTIONS LIBIPSET"
+            pkg-config --exists libipset
+            if test $? -eq 0; then
+               if test 1 -ge 2; then
       PKG_PFX=
     else
       PKG_PFX=KA
@@ -7237,10 +7267,10 @@ $as_echo "#define _HAVE_LIBIPSET_  1 " >>confdefs.h
     eval ${PKG_PFX}_LIBS=\"\$${PKG_PFX}_LIBS $ADD_NEW\"
 
 
-              else
-                KA_LDFLAGS="$KA_LDFLAGS -lipset"
-              fi
-               if test 1 -ge 2; then
+            else
+              KA_LDFLAGS="$KA_LDFLAGS -lipset"
+            fi
+             if test 1 -ge 2; then
       PKG_PFX=
     else
       PKG_PFX=KA
@@ -7287,11 +7317,11 @@ $as_echo "#define _HAVE_LIBIPSET_  1 " >>confdefs.h
 
 
 
-                            EXTRA_INCLUDE=
-              cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+                        EXTRA_INCLUDE=
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-                #include <linux/netfilter/xt_set.h>
+              #include <linux/netfilter/xt_set.h>
 
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
@@ -7304,7 +7334,7 @@ if test "x$ac_cv_header_linux_netfilter_xt_set_h" = xyes; then :
 
 $as_echo "#define XT_SET_H_NEEDS_LINUX_IP_SET_H  1 " >>confdefs.h
 
-                    EXTRA_INCLUDE="#include <libipset/linux_ip_set.h>"
+                  EXTRA_INCLUDE="#include <libipset/linux_ip_set.h>"
 
 else
   as_fn_error $? "Missing/unusable kernel header file <linux/netfilter/xt_set.h>" "$LINENO" 5
@@ -7313,7 +7343,7 @@ fi
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-              for ac_header in linux/netfilter/xt_set.h
+            for ac_header in linux/netfilter/xt_set.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "linux/netfilter/xt_set.h" "ac_cv_header_linux_netfilter_xt_set_h" "$EXTRA_INCLUDE
 "
@@ -7328,12 +7358,9 @@ fi
 
 done
 
-            fi
+          fi
 
-                        ac_fn_c_check_member "$LINENO" "struct xt_set_info_match_v1" "match_set.index" "ac_cv_member_struct_xt_set_info_match_v1_match_set_index" "#ifdef XT_SET_H_NEEDS_LINUX_IP_SET_H
-               #include <libipset/linux_ip_set.h>
-               #endif
-               #include <linux/netfilter/xt_set.h>
+                    ac_fn_c_check_member "$LINENO" "struct xt_set_info_match_v1" "match_set.index" "ac_cv_member_struct_xt_set_info_match_v1_match_set_index" "#include <linux/netfilter/xt_set.h>
 "
 if test "x$ac_cv_member_struct_xt_set_info_match_v1_match_set_index" = xyes; then :
 
@@ -7342,11 +7369,11 @@ $as_echo "#define HAVE_XT_SET_INFO_MATCH_V1  1 " >>confdefs.h
 fi
 
 
-                        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+                    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-              #include <linux/netfilter/ipset/ip_set.h>
-              int main(void) { int var = IPSET_ATTR_IFACE; }
+            #include <linux/netfilter/ipset/ip_set.h>
+            int main(void) { int var = IPSET_ATTR_IFACE; }
 
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
@@ -7358,8 +7385,18 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
-      fi
     fi
+
+        ac_fn_c_check_decl "$LINENO" "XT_EXTENSION_MAXNAMELEN" "ac_cv_have_decl_XT_EXTENSION_MAXNAMELEN" "#include <linux/netfilter/x_tables.h>
+"
+if test "x$ac_cv_have_decl_XT_EXTENSION_MAXNAMELEN" = xyes; then :
+
+else
+
+$as_echo "#define XT_EXTENSION_MAXNAMELEN  (XT_FUNCTION_MAXNAMELEN - 1) " >>confdefs.h
+
+fi
+
   fi
 fi
  if test $USE_LIBIPTC = Yes; then
@@ -8023,13 +8060,13 @@ $as_echo "#define _SNMP_REPLY_V3_FOR_V2_  1 " >>confdefs.h
       SNMP_CHECKER_SUPPORT=Yes
     fi
   fi
-  if test ${VRRP_SUPPORT} = No -a \
-          \( ${SNMP_KEEPALIVED_SUPPORT} = Yes -o ${SNMP_RFC_SUPPORT} = Yes \); then
-    as_fn_error $? "VRRP SNMP support requires VRRP" "$LINENO" 5
+  if test ${VRRP_SUPPORT} != Yes -a \
+          ${SNMP_KEEPALIVED_SUPPORT} = Yes; then
+    as_fn_error $? "KEEPALIVED SNMP support requires VRRP" "$LINENO" 5
   fi
   if test ${IPVS_SUPPORT} = No -a \
           ${SNMP_CHECKER_SUPPORT} = Yes; then
-    as_fn_error $? "LVS SNMP support requires LVS" "$LINENO" 5
+    as_fn_error $? "CHECKER SNMP support requires checker" "$LINENO" 5
   fi
 
   unset LIBS

--- a/configure.ac
+++ b/configure.ac
@@ -135,9 +135,9 @@ ARFLAGS=cr
 AC_SUBST(ARFLAGS)
 
 KA_CPPFLAGS="$kernelinc"
-KA_CFLAGS="-Wall -Wunused -Wstrict-prototypes -g -O2"
-KA_LDFLAGS="-g"
-KA_LIBS="-ldl"
+KA_CFLAGS="-Wall -Wunused -Wstrict-prototypes"
+KA_LDFLAGS="-ldl"
+KA_LIBS=
 #KA_LIBTOOLFLAGS = 
 
 AC_SUBST(KA_CPPFLAGS)
@@ -154,8 +154,24 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stdint.h std
 
 # check for kernel headers
 CPPFLAGS="$kernelinc"
-AC_CHECK_HEADERS([asm/types.h linux/ethtool.h linux/fib_rules.h linux/icmpv6.h linux/if_addr.h linux/if_ether.h linux/if_link.h linux/if_packet.h linux/ip.h linux/sockios.h linux/types.h],
+dnl -- <linux/netlink.h> needed <sys/socket.h> until Linux 3.1
+dnl -- using AC_CHECK_HEADER causes a horrible error message for the user
+NETLINK_EXTRA_INCLUDE=
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+  #include <linux/netlink.h>
+  ]])], [],
+  [AC_CHECK_HEADER([linux/netlink.h],
+    [
+      AC_DEFINE([NETLINK_H_NEEDS_SYS_SOCKET_H], [ 1 ], [Define to 1 if <linux/netlink.h> needs <sys/socket.h>])
+      NETLINK_EXTRA_INCLUDE="#include <sys/socket.h>"
+    ], [AC_MSG_ERROR([Missing/unusable kernel header file <linux/netlink.h>])],
+    [[#include <sys/socket.h>]])])
+
+AC_CHECK_HEADERS([asm/types.h linux/ethtool.h linux/icmpv6.h linux/if_ether.h linux/if_packet.h linux/ip.h linux/sockios.h linux/types.h],
   [], [AC_MSG_ERROR([Missing/unusable kernel header file <$ac_header>])])
+AC_CHECK_HEADERS([linux/fib_rules.h linux/if_addr.h linux/if_link.h],
+  [], [AC_MSG_ERROR([Missing/unusable kernel header file <$ac_header>])],
+  [[$NETLINK_EXTRA_INCLUDE]])
 AC_CHECK_HEADERS([linux/if_arp.h],
   [], [AC_MSG_ERROR([Missing/unusable <$ac_header>])],
   [[#include <sys/socket.h>]])
@@ -293,7 +309,9 @@ if test $NETLINK_VER != None; then
     CPPFLAGS="$NL3_CFLAGS"
     AC_CHECK_HEADERS([netlink/route/link.h netlink/route/link/inet.h], [], [AC_MSG_ERROR([libnl-3 headers missing])])
   fi
-  AC_CHECK_HEADERS([linux/netlink.h linux/rtnetlink.h libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h], [], [AC_MSG_ERROR([netlink headers missing])])
+
+  AC_CHECK_HEADERS([linux/rtnetlink.h], [], [AC_MSG_ERROR([Unusable link/rtnetlink.h])], [$NETLINK_EXTRA_INCLUDE])
+  AC_CHECK_HEADERS([libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h], [], [AC_MSG_ERROR([netlink headers missing])])
 fi
 
 dnl -- Check for the following variables introduced at various times into Linux
@@ -367,108 +385,94 @@ fi
 dnl ----[Check for iptables libraries]----
 USE_LIBIPTC=No
 USE_LIBIPSET=No
-if test "$enable_vrrp" != no; then
-  dnl -- <linux/netfilter/x_tables.h> exists since 2.6.16
-  AC_CHECK_HEADERS([linux/netfilter/x_tables.h],
+if test .${enable_libiptc} != .no; then
+  USE_LIBIPTC=Yes
+  dnl -- linux/netfilter/x_tables.h since Linux 2.6.16
+  AC_CHECK_HEADERS([linux/netfilter/x_tables.h xtables.h libiptc/libip6tc.h libiptc/libiptc.h libiptc/libxtc.h], [],
     [
-      dnl -- XT_EXTENSION_MAXNAMELEN not defined until Linux 2.6.35
-      AC_CHECK_DECL([XT_EXTENSION_MAXNAMELEN], [],
-        [AC_DEFINE([XT_EXTENSION_MAXNAMELEN], [ (XT_FUNCTION_MAXNAMELEN - 1) ], [Define if <linux/netfilter/x_tables.h> doesnt define it])],
-        [#include <linux/netfilter/x_tables.h>])
-    ],
-    [AC_DEFINE([XT_EXTENSION_MAXNAMELEN], [ 29 ], [Define if <linux/netfilter/x_tables.h> doesnt exist])])
-
-  if test .${enable_libiptc} != .no; then
-    USE_LIBIPTC=Yes
-    dnl -- linux/netfilter/x_tables.h since Linux 2.6.16
-    AC_CHECK_HEADERS([linux/netfilter/x_tables.h xtables.h libiptc/libip6tc.h libiptc/libiptc.h libiptc/libxtc.h], [],
+      USE_LIBIPTC=No
+      break
+    ])
+  if test $USE_LIBIPTC = Yes; then
+    add_pkg_config([--static libiptc], [IPTC])
+    LIBS="$IPTC_LIBS"
+    CPPFLAGS="$kernelinc"
+    AC_CHECK_LIB(iptc, iptc_init,
       [
-        USE_LIBIPTC=No
-        break
-      ])
-    if test $USE_LIBIPTC = Yes; then
-      add_pkg_config([--static libiptc], [IPTC])
-      LIBS="$IPTC_LIBS"
-      CPPFLAGS="$kernelinc"
-      AC_CHECK_LIB(iptc, iptc_init,
-        [
-          add_pkg_config([--static libiptc])
-          AC_DEFINE([_HAVE_LIBIPTC_], [ 1 ], [Define to 1 if have iptables libraries])
-        ],
-        [USE_LIBIPTC=No])
-    fi
-  
-    if test $USE_LIBIPTC = Yes; then
-      add_build_opt([LIBIPTC])
-  
-      dnl ----[Check for ipset libraries]----
-      CPPFLAGS="$kernelinc"
-      if test "${enable_libipset}" != no; then
-        pkg-config --exists libipset
-        if test $? -eq 0; then
-          add_pkg_config([libipset], [IPSET])
-        else
-          IPSET_LIBS="-lipset"
-        fi
-        LIBS="$IPTC_LIBS $IPSET_LIBS"
-  
-        AC_CHECK_LIB(ipset, ipset_session_init,
-          [
-            USE_LIBIPSET=Yes
-            AC_CHECK_HEADERS([libipset/data.h libipset/linux_ip_set.h libipset/session.h libipset/types.h], [],
-              [
-                USE_LIBIPSET=No
-                break
-              ])
-    
-            if test $USE_LIBIPSET = Yes; then
-              AC_CHECK_LIB(xtables, xtables_insmod, [], [USE_LIBIPSET=No])
-            fi
-  
-            if test $USE_LIBIPSET = Yes; then
-              AC_DEFINE([_HAVE_LIBIPSET_], [ 1 ], [Define to 1 if have ipset library])
-              add_build_opt([LIBIPSET])
-              pkg-config --exists libipset
-              if test $? -eq 0; then
-                add_pkg_config(libipset)
-              else
-                add_to_var([KA_LDFLAGS], [-lipset])
-              fi
-              add_pkg_config([xtables])
-  
-              dnl -- Need to include <libipset/linux_ip_set.h> for <linux/netfilter/xt_set.h> prior to Linux 3.4
-              EXTRA_INCLUDE=
-              AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-                #include <linux/netfilter/xt_set.h>
-                ]])], [],
-                [AC_CHECK_HEADER([linux/netfilter/xt_set.h],
-                  [
-                    AC_DEFINE([XT_SET_H_NEEDS_LINUX_IP_SET_H], [ 1 ], [Define to 1 if <linux/netfilter/xt_set.h> needs <libipset/linux_ip_set.h>])
-                    EXTRA_INCLUDE="#include <libipset/linux_ip_set.h>"
-                  ], [AC_MSG_ERROR([Missing/unusable kernel header file <linux/netfilter/xt_set.h>])],
-                  [[#include <libipset/linux_ip_set.h>]])])
-              AC_CHECK_HEADERS([linux/netfilter/xt_set.h], [], [USE_LIBIPSET=No], [$EXTRA_INCLUDE])
-            fi
-    
-            dnl -- xt_set_info_match_v1 declared since Linux 3.1
-            AC_CHECK_MEMBER(
-              [struct xt_set_info_match_v1.match_set.index],
-              [AC_DEFINE([HAVE_XT_SET_INFO_MATCH_V1], [ 1 ], [Define to 1 if have struct xt_set_info_match_v1])],
-              [],
-              [#ifdef XT_SET_H_NEEDS_LINUX_IP_SET_H
-               #include <libipset/linux_ip_set.h>
-               #endif
-               #include <linux/netfilter/xt_set.h>])
-    
-            dnl - ipset type iface introduced in Linux 3.1
-            AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-              #include <linux/netfilter/ipset/ip_set.h>
-              int main(void) { int var = IPSET_ATTR_IFACE; }
-              ]])],
-              [AC_DEFINE([HAVE_IPSET_ATTR_IFACE], [ 1 ], [Define to 1 if ipset supports iface type])])
-          ])
+        add_pkg_config([--static libiptc])
+        AC_DEFINE([_HAVE_LIBIPTC_], [ 1 ], [Define to 1 if have iptables libraries])
+      ],
+      [USE_LIBIPTC=No])
+  fi
+
+  if test $USE_LIBIPTC = Yes; then
+    add_build_opt([LIBIPTC])
+
+    dnl ----[Check for ipset libraries]----
+    CPPFLAGS="$kernelinc"
+    if test "${enable_libipset}" != no; then
+      pkg-config --exists libipset
+      if test $? -eq 0; then
+        add_pkg_config([libipset], [IPSET])
+      else
+        IPSET_LIBS="-lipset"
       fi
+      LIBS="$IPTC_LIBS $IPSET_LIBS"
+
+      AC_CHECK_LIB(ipset, ipset_session_init,
+        [
+          USE_LIBIPSET=Yes
+          AC_CHECK_HEADERS([libipset/data.h libipset/linux_ip_set.h libipset/session.h libipset/types.h], [],
+            [
+              USE_LIBIPSET=No
+              break
+            ])
+  
+          if test $USE_LIBIPSET = Yes; then
+            AC_CHECK_LIB(xtables, xtables_insmod, [], [USE_LIBIPSET=No])
+          fi
+
+          if test $USE_LIBIPSET = Yes; then
+            AC_DEFINE([_HAVE_LIBIPSET_], [ 1 ], [Define to 1 if have ipset library])
+            add_build_opt([LIBIPSET])
+            pkg-config --exists libipset
+            if test $? -eq 0; then
+              add_pkg_config(libipset)
+            else
+              add_to_var([KA_LDFLAGS], [-lipset])
+            fi
+            add_pkg_config([xtables])
+
+            dnl -- Need to include <libipset/linux_ip_set.h> for <linux/netfilter/xt_set.h> prior to Linux 3.4
+            EXTRA_INCLUDE=
+            AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+              #include <linux/netfilter/xt_set.h>
+              ]])], [],
+              [AC_CHECK_HEADER([linux/netfilter/xt_set.h],
+                [
+                  AC_DEFINE([XT_SET_H_NEEDS_LINUX_IP_SET_H], [ 1 ], [Define to 1 if <linux/netfilter/xt_set.h> needs <libipset/linux_ip_set.h>])
+                  EXTRA_INCLUDE="#include <libipset/linux_ip_set.h>"
+                ], [AC_MSG_ERROR([Missing/unusable kernel header file <linux/netfilter/xt_set.h>])],
+                [[#include <libipset/linux_ip_set.h>]])])
+            AC_CHECK_HEADERS([linux/netfilter/xt_set.h], [], [USE_LIBIPSET=No], [$EXTRA_INCLUDE])
+          fi
+  
+          dnl -- xt_set_info_match_v1 declared since Linux 3.1
+          AC_CHECK_MEMBER([struct xt_set_info_match_v1.match_set.index], [AC_DEFINE([HAVE_XT_SET_INFO_MATCH_V1], [ 1 ], [Define to 1 if have struct xt_set_info_match_v1])], [], [#include <linux/netfilter/xt_set.h>])
+  
+          dnl - ipset type iface introduced in Linux 3.1
+          AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+            #include <linux/netfilter/ipset/ip_set.h>
+            int main(void) { int var = IPSET_ATTR_IFACE; }
+            ]])],
+            [AC_DEFINE([HAVE_IPSET_ATTR_IFACE], [ 1 ], [Define to 1 if ipset supports iface type])])
+        ])
     fi
+
+    dnl -- XT_EXTENSION_MAXNAMELEN not defined until Linux 2.6.35
+    AC_CHECK_DECL([XT_EXTENSION_MAXNAMELEN], [],
+      [AC_DEFINE([XT_EXTENSION_MAXNAMELEN], [ (XT_FUNCTION_MAXNAMELEN - 1) ], [Define if <linux/netfilter/x_tables.h> doesnt define it])],
+      [#include <linux/netfilter/x_tables.h>])
   fi
 fi
 AM_CONDITIONAL([LIBIPTC], [test $USE_LIBIPTC = Yes])
@@ -719,13 +723,13 @@ if test "$enable_snmp" = yes -o \
       SNMP_CHECKER_SUPPORT=Yes
     fi
   fi
-  if test ${VRRP_SUPPORT} = No -a \
-          \( ${SNMP_KEEPALIVED_SUPPORT} = Yes -o ${SNMP_RFC_SUPPORT} = Yes \); then
-    AC_MSG_ERROR([VRRP SNMP support requires VRRP])
+  if test ${VRRP_SUPPORT} != Yes -a \
+          ${SNMP_KEEPALIVED_SUPPORT} = Yes; then
+    AC_MSG_ERROR([KEEPALIVED SNMP support requires VRRP])
   fi
   if test ${IPVS_SUPPORT} = No -a \
           ${SNMP_CHECKER_SUPPORT} = Yes; then
-    AC_MSG_ERROR([LVS SNMP support requires LVS])
+    AC_MSG_ERROR([CHECKER SNMP support requires checker])
   fi
 
   unset LIBS

--- a/doc/KEEPALIVED-MIB
+++ b/doc/KEEPALIVED-MIB
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201608030000Z"
+     LAST-UPDATED "201608230000Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201608230000Z"
+     DESCRIPTION "add IPv6 persistence granularity"
      REVISION "201608030000Z"
      DESCRIPTION "net-namespace added"
      REVISION "201607260000Z"
@@ -2248,7 +2250,8 @@ VirtualServerEntry ::= SEQUENCE {
     virtualServerRateInBPSLow Unsigned32,
     virtualServerRateInBPSHigh Unsigned32,
     virtualServerRateOutBPSLow Unsigned32,
-    virtualServerRateOutBPSHigh Unsigned32
+    virtualServerRateOutBPSHigh Unsigned32,
+    virtualServerPersistGranularity6 Unsigned32
 }
 
 virtualServerIndex OBJECT-TYPE
@@ -2392,7 +2395,7 @@ virtualServerPersistGranularity OBJECT-TYPE
     MAX-ACCESS read-only
     STATUS current
     DESCRIPTION
-        "Netmask specifying the granularity of the persistence mechanism."
+        "Netmask specifying the granularity of the IPv4 persistence mechanism."
     ::= { virtualServerEntry 15 }
 
 virtualServerDelayLoop OBJECT-TYPE
@@ -2709,6 +2712,15 @@ virtualServerRateOutBPSHigh OBJECT-TYPE
         "Current outgoing rate for this virtual server.
 	Together with virtualServerRateOutBPSLow composes 64-bit number."
     ::= { virtualServerEntry 50 }
+
+virtualServerPersistGranularity6 OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Netmask specifying the granularity of the IPv6 persistence mechanism."
+    ::= { virtualServerEntry 51 }
+
 
 -- real servers
 
@@ -3624,7 +3636,8 @@ virtualServerGroup OBJECT-GROUP
     virtualServerRateInBPSLow,
     virtualServerRateInBPSHigh,
     virtualServerRateOutBPSLow,
-    virtualServerRateOutBPSHigh
+    virtualServerRateOutBPSHigh,
+    virtualServerPersistGranularity6
     }
     STATUS current
     DESCRIPTION

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -117,6 +117,10 @@ net_namespace NAME			   # Set the network namespace to run in
 					   # syslog entries will have _NAME appended to the ident.
 					   # Note: the namespace cannot be changed on a configuration reload
 
+instance NAME				   # If multiple instances of keepalived are run in the same namespace, this will
+					   #   create pid files with NAME as part of the file names, in /var/run/keepalived.
+					   # Note: the instance name cannot be changed on a configuration reload
+
 linkbeat_use_polling			   # Use media link failure detection polling fashion
 
 	1.2. Static addresses

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -420,7 +420,7 @@ virtual_server group <STRING>      {	# VS group declaration
     ops					# Apply One-Packet-Scheduling (only for UDP)
     lvs_method NAT|DR|TUN		# LVS method used
     persistence_engine <STRING>	        # LVS persistence engine name
-    persistence_timeout <INTEGER>	# LVS persistence timeout
+    persistence_timeout [<INTEGER>]	# LVS persistence timeout, default 6 minutes
     persistence_granularity <NETMASK>	# LVS granularity mask
     protocol TCP|UDP|SCTP               # L4 protocol
     ha_suspend				# If VS IP address is not set, suspend

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -121,6 +121,8 @@ instance NAME				   # If multiple instances of keepalived are run in the same na
 					   #   create pid files with NAME as part of the file names, in /var/run/keepalived.
 					   # Note: the instance name cannot be changed on a configuration reload
 
+use_pid_dir				   # Create pid files in /var/run/keepalived
+
 linkbeat_use_polling			   # Use media link failure detection polling fashion
 
 	1.2. Static addresses

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -562,8 +562,8 @@ A virtual_server can be a declaration of one of
     lb_kind NAT|DR|TUN
     # LVS persistence engine name
     persistence_engine <STRING>
-    # LVS persistence timeout in seconds
-    persistence_timeout <INT>
+    # LVS persistence timeout in seconds, default 6 minutes
+    persistence_timeout [<INT>]
     # LVS granularity mask (-M in ipvsadm)
     persistence_granularity <NETMASK>
     # L4 protocol

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -172,6 +172,8 @@ and
                               #   create pid files with NAME as part of the file names, in /var/run/keepalived.
                               # Note: the instance name cannot be changed on a configuration reload
 
+ use_pid_dir		      # Create pid files in /var/run/keepalived
+
  linkbeat_use_polling         # Poll to detect media link failure otherwise attempt to use ETHTOOL or MII interface
 
 .SH Static routes/addresses/rules

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -166,7 +166,11 @@ and
                               # The directory /var/run/keepalived will be created as an unshared mount point,
                               #   for example for pid files.
                               # syslog entries will have _NAME appended to the ident.
-                              # Note: the namespace cannot be changed on a network reload
+                              # Note: the namespace cannot be changed on a configuration reload
+
+ instance NAME                # If multiple instances of keepalived are run in the same namespace, this will
+                              #   create pid files with NAME as part of the file names, in /var/run/keepalived.
+                              # Note: the instance name cannot be changed on a configuration reload
 
  linkbeat_use_polling         # Poll to detect media link failure otherwise attempt to use ETHTOOL or MII interface
 

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -324,7 +324,7 @@ start_check_child(void)
 			    , (log_facility==LOG_DAEMON) ? LOG_LOCAL2 : log_facility);
 
 #ifdef _MEM_CHECK_
-	mem_log_init(PROG_CHECK, "Healthcheck child process", true);
+	mem_log_init(PROG_CHECK, "Healthcheck child process");
 #endif
 
 	free_parent_mallocs_startup(true);

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -48,9 +48,7 @@
   #include "check_snmp.h"
 #endif
 
-#if HAVE_DECL_CLONE_NEWNET
 static char *check_syslog_ident;
-#endif
 
 /* Daemon stop sequence */
 static void
@@ -302,21 +300,14 @@ start_check_child(void)
 		return 0;
 	}
 
+	if ((instance_name
 #if HAVE_DECL_CLONE_NEWNET
-	if (network_namespace) {
-		syslog_ident = MALLOC(strlen(PROG_CHECK) + 1 + strlen (network_namespace) + 1);
-		if (syslog_ident) {
-			strcpy(syslog_ident, PROG_CHECK);
-			strcat(syslog_ident, "_");
-			strcat(syslog_ident, network_namespace);
-
-			check_syslog_ident = syslog_ident;
-		}
-		else
-			syslog_ident = PROG_CHECK;
-	}
-	else
+			   || network_namespace
 #endif
+					       ) &&
+	     (check_syslog_ident = make_syslog_ident(PROG_CHECK)))
+		syslog_ident = check_syslog_ident;
+	else
 		syslog_ident = PROG_CHECK;
 
 	/* Opening local CHECK syslog channel */

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -186,11 +186,16 @@ dump_vs(void *data)
 						   vs->delay_loop,
 	       vs->sched);
 	log_message(LOG_INFO, "   One packet scheduling = %sabled%s", vs->ops ? "en" : "dis", (vs->ops && vs->service_type != IPPROTO_UDP) ? " (inactive due to not UDP)" : "");
-	if (vs->timeout_persistence)
-		log_message(LOG_INFO, "   persistence timeout = %u", vs->timeout_persistence);
-	if (vs->granularity_persistence)
-		log_message(LOG_INFO, "   persistence granularity = %s",
-		       inet_ntop2(vs->granularity_persistence));
+	if (vs->persistence_timeout)
+		log_message(LOG_INFO, "   persistence timeout = %u", vs->persistence_timeout);
+	if (vs->persistence_granularity) {
+		if (vs->addr.ss_family == AF_INET6)
+			log_message(LOG_INFO, "   persistence granularity = %d",
+				       vs->persistence_granularity);
+		else
+			log_message(LOG_INFO, "   persistence granularity = %s",
+				       inet_ntop2(vs->persistence_granularity));
+	}
 	if (vs->service_type == IPPROTO_TCP)
 		log_message(LOG_INFO, "   protocol = TCP");
 	else if (vs->service_type == IPPROTO_UDP)

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -186,9 +186,8 @@ dump_vs(void *data)
 						   vs->delay_loop,
 	       vs->sched);
 	log_message(LOG_INFO, "   One packet scheduling = %sabled%s", vs->ops ? "en" : "dis", (vs->ops && vs->service_type != IPPROTO_UDP) ? " (inactive due to not UDP)" : "");
-	if (atoi(vs->timeout_persistence) > 0)
-		log_message(LOG_INFO, "   persistence timeout = %s",
-		       vs->timeout_persistence);
+	if (vs->timeout_persistence)
+		log_message(LOG_INFO, "   persistence timeout = %u", vs->timeout_persistence);
 	if (vs->granularity_persistence)
 		log_message(LOG_INFO, "   persistence granularity = %s",
 		       inet_ntop2(vs->granularity_persistence));
@@ -253,7 +252,6 @@ alloc_vs(char *ip, char *port)
 	}
 
 	new->delay_loop = KEEPALIVED_DEFAULT_DELAY;
-	strncpy(new->timeout_persistence, "0", 1);
 	new->virtualhost = NULL;
 	new->alpha = 0;
 	new->omega = 0;

--- a/keepalived/check/check_snmp.c
+++ b/keepalived/check/check_snmp.c
@@ -63,6 +63,7 @@ enum check_snmp_virtualserver_magic {
 	CHECK_SNMP_VSPERSIST,
 	CHECK_SNMP_VSPERSISTTIMEOUT,
 	CHECK_SNMP_VSPERSISTGRANULARITY,
+	CHECK_SNMP_VSPERSISTGRANULARITY6,
 	CHECK_SNMP_VSDELAYLOOP,
 	CHECK_SNMP_VSHASUSPEND,
 	CHECK_SNMP_VSOPS,
@@ -99,7 +100,7 @@ enum check_snmp_virtualserver_magic {
 	CHECK_SNMP_VSRATEINBPSLOW,
 	CHECK_SNMP_VSRATEINBPSHIGH,
 	CHECK_SNMP_VSRATEOUTBPSLOW,
-	CHECK_SNMP_VSRATEOUTBPSHIGH
+	CHECK_SNMP_VSRATEOUTBPSHIGH,
 #endif
 #endif
 };
@@ -471,16 +472,20 @@ check_snmp_virtualserver(struct variable *vp, oid *name, size_t *length,
 		*var_len = strlen(v->virtualhost);
 		return (u_char*)v->virtualhost;
 	case CHECK_SNMP_VSPERSIST:
-		long_ret = (v->timeout_persistence)?1:2;
+		long_ret = (v->persistence_timeout)?1:2;
 		return (u_char*)&long_ret;
 	case CHECK_SNMP_VSPERSISTTIMEOUT:
-		if (!v->timeout_persistence) break;
-		long_ret = v->timeout_persistence;
+		if (!v->persistence_timeout) break;
+		long_ret = v->persistence_timeout;
 		return (u_char*)&long_ret;
 	case CHECK_SNMP_VSPERSISTGRANULARITY:
-		if (!v->granularity_persistence) break;
-		*var_len = sizeof(v->granularity_persistence);
-		return (u_char*)&v->granularity_persistence;
+		if (!v->persistence_granularity || v->addr.ss_family == AF_INET6) break;
+		*var_len = sizeof(v->persistence_granularity);
+		return (u_char*)&v->persistence_granularity;
+	case CHECK_SNMP_VSPERSISTGRANULARITY6:
+		if (!v->persistence_granularity || v->addr.ss_family == AF_INET) break;
+		*var_len = sizeof(v->persistence_granularity);
+		return (u_char*)&v->persistence_granularity;
 	case CHECK_SNMP_VSDELAYLOOP:
 		if (v->delay_loop >= TIMER_MAX_SEC)
 			long_ret = v->delay_loop/TIMER_HZ;
@@ -1212,6 +1217,8 @@ static struct variable8 check_vars[] = {
 	 check_snmp_virtualserver, 3, {3, 1, 50}},
 #endif
 #endif
+	{CHECK_SNMP_VSPERSISTGRANULARITY6, ASN_UNSIGNED, RONLY,
+	 check_snmp_virtualserver, 3, {3, 1, 51}},
 	/* realServerTable */
 	{CHECK_SNMP_RSTYPE, ASN_INTEGER, RONLY,
 	 check_snmp_realserver, 3, {4, 1, 2}},

--- a/keepalived/check/check_snmp.c
+++ b/keepalived/check/check_snmp.c
@@ -471,16 +471,15 @@ check_snmp_virtualserver(struct variable *vp, oid *name, size_t *length,
 		*var_len = strlen(v->virtualhost);
 		return (u_char*)v->virtualhost;
 	case CHECK_SNMP_VSPERSIST:
-		long_ret = (atol(v->timeout_persistence) > 0)?1:2;
+		long_ret = (v->timeout_persistence)?1:2;
 		return (u_char*)&long_ret;
 	case CHECK_SNMP_VSPERSISTTIMEOUT:
-		if (atol(v->timeout_persistence) <= 0) break;
-		long_ret = atol(v->timeout_persistence);
+		if (!v->timeout_persistence) break;
+		long_ret = v->timeout_persistence;
 		return (u_char*)&long_ret;
 	case CHECK_SNMP_VSPERSISTGRANULARITY:
-		if (atol(v->timeout_persistence) <= 0) break;
 		if (!v->granularity_persistence) break;
-		*var_len = 4;
+		*var_len = sizeof(v->granularity_persistence);
 		return (u_char*)&v->granularity_persistence;
 	case CHECK_SNMP_VSDELAYLOOP:
 		if (v->delay_loop >= TIMER_MAX_SEC)

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -44,43 +44,6 @@
  * Utility functions coming from Wensong code
  */
 
-static int
-string_to_number(const char *s, int min, int max)
-{
-	int number;
-	char *end;
-
-	number = (int) strtol(s, &end, 10);
-	if (*end || end == s)
-		return -1;
-
-	/*
-	 * We parsed a number, let's see if we want this.
-	 * If max <= min then ignore ranges
-	 */
-	if (max <= min || (min <= number && number <= max))
-		return number;
-
-	return -1;
-}
-
-static int
-parse_timeout(char *buf, unsigned *timeout)
-{
-	int i;
-
-	if (buf == NULL) {
-		*timeout = IPVS_SVC_PERSISTENT_TIMEOUT;
-		return 1;
-	}
-
-	if ((i = string_to_number(buf, 0, 86400 * 31)) == -1)
-		return 0;
-
-	*timeout = i * (IPVS_SVC_PERSISTENT_TIMEOUT / (6*60));
-	return 1;
-}
-
 static char*
 get_modprobe(void)
 {
@@ -447,11 +410,9 @@ ipvs_set_rule(int cmd, virtual_server_t * vs, real_server_t * rs)
 	srule->user.netmask = (vs->addr.ss_family == AF_INET6) ? 128 : ((u_int32_t) 0xffffffff);
 	srule->user.protocol = vs->service_type;
 
-	if (!parse_timeout(vs->timeout_persistence, &srule->user.timeout))
-		log_message(LOG_INFO, "IPVS : Virtual service %s illegal timeout."
-				    , FMT_VS(vs));
+	srule->user.timeout = vs->timeout_persistence;
 
-	if (srule->user.timeout != 0 || vs->granularity_persistence)
+	if (vs->timeout_persistence || vs->granularity_persistence)
 		srule->user.flags |= IP_VS_SVC_F_PERSISTENT;
 
 	/* Only for UDP services */

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -118,6 +118,7 @@ email_handler(vector_t *strvec)
 
 	free_strvec(email_vec);
 }
+#ifdef _WITH_VRRP_
 static void
 default_interface_handler(vector_t *strvec)
 {
@@ -133,6 +134,7 @@ default_interface_handler(vector_t *strvec)
 	else
 		global_data->default_ifp = ifp;
 }
+#endif
 #ifdef _WITH_LVS_
 static void
 lvs_timeouts(vector_t *strvec)
@@ -662,7 +664,9 @@ init_global_keywords(bool global_active)
 	install_keyword("smtp_helo_name", &smtphelo_handler);
 	install_keyword("smtp_connect_timeout", &smtpto_handler);
 	install_keyword("notification_email", &email_handler);
+#ifdef _WITH_VRRP_
 	install_keyword("default_interface", &default_interface_handler);
+#endif
 #ifdef _WITH_LVS_
 	install_keyword("lvs_timeouts", &lvs_timeouts);
 	install_keyword("lvs_flush", &lvs_flush_handler);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -623,7 +623,7 @@ net_namespace_handler(vector_t *strvec)
 	if (!reload) {
 		if (!network_namespace)
 			network_namespace = set_value(strvec);
-		else if (!global_data)	/* We only need to check in the parent, since the children will be the same as the parent */
+		else
 			log_message(LOG_INFO, "Duplicate net_namespace definition %s - ignoring", FMT_STR_VSLOT(strvec, 1));
 	}
 
@@ -653,7 +653,7 @@ init_global_keywords(bool global_active)
 	/* global definitions mapping */
 	install_keyword_root("linkbeat_use_polling", use_polling_handler, global_active);
 #if HAVE_DECL_CLONE_NEWNET
-	install_keyword_root("net_namespace", &net_namespace_handler, true);
+	install_keyword_root("net_namespace", &net_namespace_handler, !global_active);
 #endif
 	install_keyword_root("global_defs", NULL, global_active);
 	install_keyword("router_id", &routerid_handler);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -34,6 +34,7 @@
 
 #include "global_parser.h"
 #include "global_data.h"
+#include "main.h"
 #include "check_data.h"
 #include "parser.h"
 #include "memory.h"
@@ -648,6 +649,16 @@ net_namespace_handler(vector_t *strvec)
 #endif
 }
 #endif
+static void
+instance_handler(vector_t *strvec)
+{
+	if (!reload) {
+		if (!instance_name)
+			instance_name = set_value(strvec);
+		else
+			log_message(LOG_INFO, "Duplicate instance definition %s - ignoring", FMT_STR_VSLOT(strvec, 1));
+	}
+}
 
 void
 init_global_keywords(bool global_active)
@@ -657,6 +668,7 @@ init_global_keywords(bool global_active)
 #if HAVE_DECL_CLONE_NEWNET
 	install_keyword_root("net_namespace", &net_namespace_handler, !global_active);
 #endif
+	install_keyword_root("instance", &instance_handler, !global_active);
 	install_keyword_root("global_defs", NULL, global_active);
 	install_keyword("router_id", &routerid_handler);
 	install_keyword("notification_email_from", &emailfrom_handler);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -28,6 +28,10 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#ifdef _WITH_SNMP_
+#include "snmp.h"
+#endif
+
 #include "global_parser.h"
 #include "global_data.h"
 #include "check_data.h"
@@ -39,10 +43,6 @@
 
 #ifdef HAVE_DECL_CLONE_NEWNET
 #include "namespaces.h"
-#endif
-
-#ifdef _WITH_SNMP_
-#include "snmp.h"
 #endif
 
 #define LVS_MAX_TIMEOUT		(86400*31)	/* 31 days */

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -41,7 +41,7 @@
 #include "utils.h"
 #include "logger.h"
 
-#ifdef HAVE_DECL_CLONE_NEWNET
+#if HAVE_DECL_CLONE_NEWNET
 #include "namespaces.h"
 #endif
 

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -624,8 +624,10 @@ net_namespace_handler(vector_t *strvec)
 	/* If we are reloading, there has already been a check that the
 	 * namespace hasn't changed */ 
 	if (!reload) {
-		if (!network_namespace)
+		if (!network_namespace) {
 			network_namespace = set_value(strvec);
+			use_pid_dir = true;
+		}
 		else
 			log_message(LOG_INFO, "Duplicate net_namespace definition %s - ignoring", FMT_STR_VSLOT(strvec, 1));
 	}
@@ -649,15 +651,24 @@ net_namespace_handler(vector_t *strvec)
 #endif
 }
 #endif
+
 static void
 instance_handler(vector_t *strvec)
 {
 	if (!reload) {
-		if (!instance_name)
+		if (!instance_name) {
 			instance_name = set_value(strvec);
+			use_pid_dir = true;
+		}
 		else
 			log_message(LOG_INFO, "Duplicate instance definition %s - ignoring", FMT_STR_VSLOT(strvec, 1));
 	}
+}
+
+static void
+use_pid_dir_handler(vector_t *strvec)
+{
+	use_pid_dir = true;
 }
 
 void
@@ -668,6 +679,7 @@ init_global_keywords(bool global_active)
 #if HAVE_DECL_CLONE_NEWNET
 	install_keyword_root("net_namespace", &net_namespace_handler, !global_active);
 #endif
+	install_keyword_root("use_pid_dir", &use_pid_dir_handler, !global_active);
 	install_keyword_root("instance", &instance_handler, !global_active);
 	install_keyword_root("global_defs", NULL, global_active);
 	install_keyword("router_id", &routerid_handler);

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -135,13 +135,17 @@ stop_keepalived(void)
 	signal_handler_destroy();
 	thread_destroy_master(master);
 
-	pidfile_rm(main_pidfile);
-
+#ifdef _WITH_VRRP_
 	if (__test_bit(DAEMON_VRRP, &daemon_mode))
 		pidfile_rm(vrrp_pidfile);
+#endif
 
+#ifdef _WITH_LVS_
 	if (__test_bit(DAEMON_CHECKERS, &daemon_mode))
 		pidfile_rm(checkers_pidfile);
+#endif
+
+	pidfile_rm(main_pidfile);
 #endif
 }
 
@@ -375,8 +379,12 @@ usage(const char *prog)
 	fprintf(stderr, "  -n, --dont-fork              Don't fork the daemon process\n");
 	fprintf(stderr, "  -d, --dump-conf              Dump the configuration data\n");
 	fprintf(stderr, "  -p, --pid=FILE               Use specified pidfile for parent process\n");
+#ifdef _WITH_VRRP_
 	fprintf(stderr, "  -r, --vrrp_pid=FILE          Use specified pidfile for VRRP child process\n");
+#endif
+#ifdef _WITH_LVS_
 	fprintf(stderr, "  -c, --checkers_pid=FILE      Use specified pidfile for checkers child process\n");
+#endif
 #ifdef _WITH_SNMP_
 	fprintf(stderr, "  -x, --snmp                   Enable SNMP subsystem\n");
 	fprintf(stderr, "  -A, --snmp-agent-socket=FILE Use the specified socket for master agent\n");
@@ -410,8 +418,12 @@ parse_cmdline(int argc, char **argv)
 		{"dont-fork",         no_argument,       0, 'n'},
 		{"dump-conf",         no_argument,       0, 'd'},
 		{"pid",               required_argument, 0, 'p'},
+#ifdef _WITH_VRRP_
 		{"vrrp_pid",          required_argument, 0, 'r'},
+#endif
+#ifdef _WITH_LVS_
 		{"checkers_pid",      required_argument, 0, 'c'},
+#endif
  #ifdef _WITH_SNMP_
 		{"snmp",              no_argument,       0, 'x'},
 		{"snmp-agent-socket", required_argument, 0, 'A'},
@@ -486,12 +498,16 @@ parse_cmdline(int argc, char **argv)
 		case 'p':
 			main_pidfile = optarg;
 			break;
+#ifdef _WITH_LVS_
 		case 'c':
 			checkers_pidfile = optarg;
 			break;
+#endif
+#ifdef _WITH_VRRP_
 		case 'r':
 			vrrp_pidfile = optarg;
 			break;
+#endif
 #ifdef _WITH_SNMP_
 		case 'x':
 			snmp = 1;
@@ -615,10 +631,14 @@ keepalived_main(int argc, char **argv)
 	{
 		if (!main_pidfile)
 			main_pidfile = PID_DIR KEEPALIVED_PID_FILE;
+#ifdef _WITH_LVS_
 		if (!checkers_pidfile)
 			checkers_pidfile = PID_DIR CHECKERS_PID_FILE;
+#endif
+#ifdef _WITH_VRRP_
 		if (!vrrp_pidfile)
 			vrrp_pidfile = PID_DIR VRRP_PID_FILE;
+#endif
 	}
 
 	/* Check if keepalived is already running */

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -599,7 +599,7 @@ keepalived_main(int argc, char **argv)
 #endif
 
 #ifdef _MEM_CHECK_
-	mem_log_init(PACKAGE_NAME, "Parent process", false);
+	mem_log_init(PACKAGE_NAME, "Parent process");
 #endif
 
 	/* Handle any core file requirements */

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -588,10 +588,12 @@ keepalived_main(int argc, char **argv)
 		else
 			log_message(LOG_INFO, "Unable to change syslog ident to %s_%s", PACKAGE_NAME, network_namespace);
 
-		if (!set_namespaces(network_namespace)) {
+#if HAVE_DECL_CLONE_NEWNET
+		if (network_namespace && !set_namespaces(network_namespace)) {
 			log_message(LOG_ERR, "Unable to set network namespace %s - exiting", network_namespace);
 			goto end;
 		}
+#endif
 
 		if (!main_pidfile)
 			main_pidfile = NAMESPACE_PID_DIR KEEPALIVED_PID_FILE;

--- a/keepalived/core/namespaces.c
+++ b/keepalived/core/namespaces.c
@@ -195,12 +195,12 @@ char *network_namespace;
 /* Local data */
 static const char *netns_dir = "/var/run/netns/";
 static const char *mount_point = PID_DIR PACKAGE;
-static char *dirname;
+static char *mount_dirname;
 
 void
 free_dirname(void)
 {
-	FREE_PTR(dirname);
+	FREE_PTR(mount_dirname);
 }
 
 static void
@@ -211,20 +211,20 @@ set_run_mount(const char *net_namespace)
 		return;
 	}
 
-	/* /var/run/keepalived/keepalived.NAMESPACE */
-	dirname = MALLOC(strlen(PID_DIR PACKAGE "/" PACKAGE) + 1 + strlen(net_namespace) + 1);
-	if (!dirname) {
+	/* /var/run/keepalived/NAMESPACE */
+	mount_dirname = MALLOC(strlen(PID_DIR PACKAGE "/") + 1 + strlen(net_namespace));
+	if (!mount_dirname) {
 		log_message(LOG_INFO, "Unable at allocate memory for pid file dirname");
 		return;
 	}
 
-	strcpy(dirname, PID_DIR PACKAGE "/" PACKAGE ".");
-	strcat(dirname, net_namespace);
+	strcpy(mount_dirname, PID_DIR PACKAGE "/");
+	strcat(mount_dirname, net_namespace);
 
-	if (mkdir(dirname, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) && errno != EEXIST) {
-		log_message(LOG_INFO, "Unable to create directory %s", dirname);
-		FREE(dirname);
-		dirname = NULL;
+	if (mkdir(mount_dirname, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) && errno != EEXIST) {
+		log_message(LOG_INFO, "Unable to create directory %s", mount_dirname);
+		FREE(mount_dirname);
+		mount_dirname = NULL;
 		return;
 	}
 
@@ -239,7 +239,7 @@ set_run_mount(const char *net_namespace)
 		log_message(LOG_INFO, "Mount slave failed, error (%d) '%s'", errno, strerror(errno));
 #endif
 
-	if (mount(dirname, mount_point, NULL, MS_BIND, NULL))
+	if (mount(mount_dirname, mount_point, NULL, MS_BIND, NULL))
 		log_message(LOG_INFO, "Mount failed, error (%d) '%s'", errno, strerror(errno));
 }
 
@@ -248,10 +248,10 @@ unmount_run(void)
 {
 	if (umount(mount_point))
 		log_message(LOG_INFO, "unmount of %s failed - errno %d", mount_point, errno);
-	if (dirname) {
-		if (rmdir(dirname) && errno != ENOTEMPTY && errno != EBUSY)
-			log_message(LOG_INFO, "unlink of %s failed - error (%d) '%s'", dirname, errno, strerror(errno));
-		FREE(dirname);
+	if (mount_dirname) {
+		if (rmdir(mount_dirname) && errno != ENOTEMPTY && errno != EBUSY)
+			log_message(LOG_INFO, "unlink of %s failed - error (%d) '%s'", mount_dirname, errno, strerror(errno));
+		FREE(mount_dirname);
 	}
 	if (rmdir(mount_point) && errno != ENOTEMPTY && errno != EBUSY)
 		log_message(LOG_INFO, "unlink of %s failed - error (%d) '%s'", mount_point, errno, strerror(errno));

--- a/keepalived/core/namespaces.c
+++ b/keepalived/core/namespaces.c
@@ -208,7 +208,7 @@ set_run_mount(const char *net_namespace)
 	/* /var/run/keepalived/NAMESPACE */
 	mount_dirname = MALLOC(strlen(PID_DIR PACKAGE "/") + 1 + strlen(net_namespace));
 	if (!mount_dirname) {
-		log_message(LOG_INFO, "Unable at allocate memory for pid file dirname");
+		log_message(LOG_INFO, "Unable to allocate memory for pid file dirname");
 		return;
 	}
 

--- a/keepalived/core/namespaces.c
+++ b/keepalived/core/namespaces.c
@@ -194,7 +194,6 @@ char *network_namespace;
 
 /* Local data */
 static const char *netns_dir = "/var/run/netns/";
-static const char *mount_point = PID_DIR PACKAGE;
 static char *mount_dirname;
 
 void
@@ -206,11 +205,6 @@ free_dirname(void)
 static void
 set_run_mount(const char *net_namespace)
 {
-	if (mkdir(mount_point, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) && errno != EEXIST) {
-		log_message(LOG_INFO, "Unable to create directory %s", mount_point);
-		return;
-	}
-
 	/* /var/run/keepalived/NAMESPACE */
 	mount_dirname = MALLOC(strlen(PID_DIR PACKAGE "/") + 1 + strlen(net_namespace));
 	if (!mount_dirname) {
@@ -239,22 +233,20 @@ set_run_mount(const char *net_namespace)
 		log_message(LOG_INFO, "Mount slave failed, error (%d) '%s'", errno, strerror(errno));
 #endif
 
-	if (mount(mount_dirname, mount_point, NULL, MS_BIND, NULL))
+	if (mount(mount_dirname, pid_directory, NULL, MS_BIND, NULL))
 		log_message(LOG_INFO, "Mount failed, error (%d) '%s'", errno, strerror(errno));
 }
 
 static void
 unmount_run(void)
 {
-	if (umount(mount_point))
-		log_message(LOG_INFO, "unmount of %s failed - errno %d", mount_point, errno);
+	if (umount(pid_directory))
+		log_message(LOG_INFO, "unmount of %s failed - errno %d", pid_directory, errno);
 	if (mount_dirname) {
 		if (rmdir(mount_dirname) && errno != ENOTEMPTY && errno != EBUSY)
 			log_message(LOG_INFO, "unlink of %s failed - error (%d) '%s'", mount_dirname, errno, strerror(errno));
 		FREE(mount_dirname);
 	}
-	if (rmdir(mount_point) && errno != ENOTEMPTY && errno != EBUSY)
-		log_message(LOG_INFO, "unlink of %s failed - error (%d) '%s'", mount_point, errno, strerror(errno));
 }
 
 bool

--- a/keepalived/core/pidfile.c
+++ b/keepalived/core/pidfile.c
@@ -90,18 +90,18 @@ process_running(const char *pid_file)
 }
 
 /* Return parent process daemon state */
-int
+bool
 keepalived_running(unsigned long mode)
 {
 	if (process_running(main_pidfile))
-		return 1;
+		return true;
 #ifdef _WITH_VRRP_
 	if (__test_bit(DAEMON_VRRP, &mode) && process_running(vrrp_pidfile))
-		return 1;
+		return true;
 #endif
 #ifdef _WITH_LVS_
 	if (__test_bit(DAEMON_CHECKERS, &mode) && process_running(checkers_pidfile))
-		return 1;
+		return true;
 #endif
-	return 0;
+	return false;
 }

--- a/keepalived/core/pidfile.c
+++ b/keepalived/core/pidfile.c
@@ -94,9 +94,13 @@ keepalived_running(unsigned long mode)
 {
 	if (process_running(main_pidfile))
 		return 1;
+#ifdef _WITH_VRRP_
 	if (__test_bit(DAEMON_VRRP, &mode) && process_running(vrrp_pidfile))
 		return 1;
+#endif
+#ifdef _WITH_LVS_
 	if (__test_bit(DAEMON_CHECKERS, &mode) && process_running(checkers_pidfile))
 		return 1;
+#endif
 	return 0;
 }

--- a/keepalived/core/pidfile.c
+++ b/keepalived/core/pidfile.c
@@ -30,7 +30,26 @@
 #include "main.h"
 #include "bitops.h"
 
-/* Create the runnnig daemon pidfile */
+const char *pid_directory = PID_DIR PACKAGE;
+
+/* Create the directory for non-standard pid files */
+void
+create_pid_dir(void)
+{
+	if (mkdir(pid_directory, S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) && errno != EEXIST) {
+		log_message(LOG_INFO, "Unable to create directory %s", pid_directory);
+		return;
+	}
+}
+
+void
+remove_pid_dir(void)
+{
+	if (rmdir(pid_directory) && errno != ENOTEMPTY && errno != EBUSY)
+		log_message(LOG_INFO, "unlink of %s failed - error (%d) '%s'", pid_directory, errno, strerror(errno));
+}
+
+/* Create the running daemon pidfile */
 int
 pidfile_write(const char *pid_file, int pid)
 {
@@ -39,7 +58,7 @@ pidfile_write(const char *pid_file, int pid)
 	if (pidfd != -1) pidfile = fdopen(pidfd, "w");
 
 	if (!pidfile) {
-		log_message(LOG_INFO, "pidfile_write : Can not open %s pidfile",
+		log_message(LOG_INFO, "pidfile_write : Cannot open %s pidfile",
 		       pid_file);
 		return 0;
 	}

--- a/keepalived/core/pidfile.c
+++ b/keepalived/core/pidfile.c
@@ -60,7 +60,7 @@ static int
 process_running(const char *pid_file)
 {
 	FILE *pidfile = fopen(pid_file, "r");
-	pid_t pid;
+	pid_t pid = 0;
 	int ret;
 
 	/* No pidfile */
@@ -68,11 +68,12 @@ process_running(const char *pid_file)
 		return 0;
 
 	ret = fscanf(pidfile, "%d", &pid);
+	fclose(pidfile);
 	if (ret != 1) {
 		log_message(LOG_INFO, "Error reading pid file %s", pid_file);
 		pid = 0;
+		pidfile_rm(pid_file);
 	}
-	fclose(pidfile);
 
 	/* What should we return - we don't know if it is running or not. */
 	if (!pid)

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -44,7 +44,6 @@
 typedef unsigned int checker_id_t;
 
 /* Daemon dynamic data structure definition */
-#define MAX_TIMEOUT_LENGTH		5
 #define KEEPALIVED_DEFAULT_DELAY	(60 * TIMER_HZ)
 
 /* SSL specific data */
@@ -120,7 +119,7 @@ typedef struct _virtual_server {
 	int				ops;
 #ifdef _WITH_LVS_
 	char				sched[IP_VS_SCHEDNAME_MAXLEN];
-	char				timeout_persistence[MAX_TIMEOUT_LENGTH];
+	uint32_t			timeout_persistence;
 	char				pe_name[IP_VS_PENAME_MAXLEN];
 	unsigned			loadbalancing_kind;
 	uint32_t			granularity_persistence;
@@ -229,7 +228,7 @@ static inline int inaddr_equal(sa_family_t family, void *addr1, void *addr2)
 			    ((X)->quorum_up && (Y)->quorum_up && !strcmp ((X)->quorum_up, (Y)->quorum_up)) \
 			 ) &&\
 			 !strcmp((X)->sched, (Y)->sched)				&&\
-			 !strcmp((X)->timeout_persistence, (Y)->timeout_persistence)	&&\
+			 (X)->timeout_persistence     == (Y)->timeout_persistence 	&&\
 			 (((X)->vsgname && (Y)->vsgname &&				\
 			   !strcmp((X)->vsgname, (Y)->vsgname)) ||			\
 			  (!(X)->vsgname && !(Y)->vsgname)))

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -119,10 +119,12 @@ typedef struct _virtual_server {
 	int				ops;
 #ifdef _WITH_LVS_
 	char				sched[IP_VS_SCHEDNAME_MAXLEN];
-	uint32_t			timeout_persistence;
+	uint32_t			persistence_timeout;
+#ifdef IPVS_SVC_ATTR_PE_NAME
 	char				pe_name[IP_VS_PENAME_MAXLEN];
+#endif
 	unsigned			loadbalancing_kind;
-	uint32_t			granularity_persistence;
+	uint32_t			persistence_granularity;
 #endif
 	char				*virtualhost;
 	list				rs;
@@ -223,12 +225,12 @@ static inline int inaddr_equal(sa_family_t family, void *addr1, void *addr2)
 			 (X)->af                      == (Y)->af                        &&\
 			 (X)->service_type            == (Y)->service_type		&&\
 			 (X)->loadbalancing_kind      == (Y)->loadbalancing_kind	&&\
-			 (X)->granularity_persistence == (Y)->granularity_persistence	&&\
+			 (X)->persistence_granularity == (Y)->persistence_granularity	&&\
 			 (  (!(X)->quorum_up && !(Y)->quorum_up) || \
 			    ((X)->quorum_up && (Y)->quorum_up && !strcmp ((X)->quorum_up, (Y)->quorum_up)) \
 			 ) &&\
 			 !strcmp((X)->sched, (Y)->sched)				&&\
-			 (X)->timeout_persistence     == (Y)->timeout_persistence 	&&\
+			 (X)->persistence_timeout     == (Y)->persistence_timeout 	&&\
 			 (((X)->vsgname && (Y)->vsgname &&				\
 			   !strcmp((X)->vsgname, (Y)->vsgname)) ||			\
 			  (!(X)->vsgname && !(Y)->vsgname)))

--- a/keepalived/include/ip_vs.h
+++ b/keepalived/include/ip_vs.h
@@ -38,7 +38,9 @@ struct ip_vs_service_app {
 	struct ip_vs_service_user user;
 	u_int16_t		af;
 	union nf_inet_addr	nf_addr;
+#ifdef IPVS_SVC_ATTR_PE_NAME
 	char			pe_name[IP_VS_PENAME_MAXLEN];
+#endif
 };
 
 struct ip_vs_dest_app {
@@ -53,7 +55,9 @@ struct ip_vs_service_entry_app {
 	ip_vs_stats_t		stats;
 	u_int16_t		af;
 	union nf_inet_addr	nf_addr;
+#ifdef IPVS_SVC_ATTR_PE_NAME
 	char			pe_name[IP_VS_PENAME_MAXLEN];
+#endif
 
 };
 

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -56,19 +56,21 @@ extern char *conf_file;			/* Configuration file */
 extern int log_facility;		/* Optional logging facilities */
 extern pid_t vrrp_child;		/* VRRP child process ID */
 extern pid_t checkers_child;		/* Healthcheckers child process ID */
-extern const char *main_pidfile;	/* overrule default pidfile */
-extern const char *checkers_pidfile;	/* overrule default pidfile */
-extern const char *vrrp_pidfile;	/* overrule default pidfile */
+extern char *main_pidfile;		/* overrule default pidfile */
+extern char *checkers_pidfile;		/* overrule default pidfile */
+extern char *vrrp_pidfile;		/* overrule default pidfile */
 #ifdef _WITH_SNMP_
-extern int snmp;			/* Enable SNMP support */
+extern bool snmp;			/* Enable SNMP support */
 extern const char *snmp_socket;		/* Socket to use for SNMP agent */
 #endif
 #if HAVE_DECL_CLONE_NEWNET
 extern char *network_namespace;		/* network namespace name */
 #endif
+extern char *instance_name;		/* keepalived instance name */
 
 extern void free_parent_mallocs_startup(bool);
 extern void free_parent_mallocs_exit(void);
+extern char *make_syslog_ident(const char*);
 
 extern int keepalived_main(int, char**); /* The "real" main function */
 #endif

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -63,7 +63,7 @@ extern const char *snmp_socket;		/* Socket to use for SNMP agent */
 extern char *network_namespace;		/* network namespace name */
 #endif
 
-extern void free_parent_mallocs_startup(void);
+extern void free_parent_mallocs_startup(bool);
 extern void free_parent_mallocs_exit(void);
 
 extern int keepalived_main(int, char**); /* The "real" main function */

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -41,8 +41,12 @@
 
 /* State flags */
 enum daemon_bits {
+#ifdef _WITH_VRRP_
 	DAEMON_VRRP,
-	DAEMON_CHECKERS
+#endif
+#ifdef _WITH_LVS_
+	DAEMON_CHECKERS,
+#endif
 };
 
 /* Global vars exported */

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -59,7 +59,7 @@ extern const char *vrrp_pidfile;	/* overrule default pidfile */
 extern int snmp;			/* Enable SNMP support */
 extern const char *snmp_socket;		/* Socket to use for SNMP agent */
 #endif
-#ifdef HAVE_DECL_CLONE_NEWNET
+#if HAVE_DECL_CLONE_NEWNET
 extern char *network_namespace;		/* network namespace name */
 #endif
 

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -67,6 +67,7 @@ extern const char *snmp_socket;		/* Socket to use for SNMP agent */
 extern char *network_namespace;		/* network namespace name */
 #endif
 extern char *instance_name;		/* keepalived instance name */
+extern bool use_pid_dir;		/* pid files in /var/run/keepalived */
 
 extern void free_parent_mallocs_startup(bool);
 extern void free_parent_mallocs_exit(void);

--- a/keepalived/include/pidfile.h
+++ b/keepalived/include/pidfile.h
@@ -30,15 +30,21 @@
 #include <sys/types.h>
 #include <syslog.h>
 #include <stdbool.h>
+#include <paths.h>
 
 /* lock pidfile */
-#define PID_DIR			"/var/run/"
-#define NAMESPACE_PID_DIR	PID_DIR PACKAGE "/"
-#define KEEPALIVED_PID_FILE	PACKAGE ".pid"
-#define VRRP_PID_FILE		"vrrp.pid"
-#define CHECKERS_PID_FILE 	"checkers.pid"
+#define PID_DIR			_PATH_VARRUN
+#define KEEPALIVED_PID_DIR	PID_DIR PACKAGE "/"
+#define KEEPALIVED_PID_FILE	PACKAGE
+#define VRRP_PID_FILE		"vrrp"
+#define CHECKERS_PID_FILE 	"checkers"
+#define	PID_EXTENSION		".pid"
+
+extern const char *pid_directory;
 
 /* Prototypes */
+extern void create_pid_dir(void);
+extern void remove_pid_dir(void);
 extern int pidfile_write(const char *, int);
 extern void pidfile_rm(const char *);
 extern bool keepalived_running(unsigned long);

--- a/keepalived/include/pidfile.h
+++ b/keepalived/include/pidfile.h
@@ -29,6 +29,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <syslog.h>
+#include <stdbool.h>
 
 /* lock pidfile */
 #define PID_DIR			"/var/run/"
@@ -40,6 +41,6 @@
 /* Prototypes */
 extern int pidfile_write(const char *, int);
 extern void pidfile_rm(const char *);
-extern int keepalived_running(unsigned long);
+extern bool keepalived_running(unsigned long);
 
 #endif

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -82,6 +82,7 @@ typedef struct _interface {
 							   otherwise the physical interface (i.e. ifindex) */
 #endif
 	garp_delay_t		*garp_delay;		/* Delays for sending gratuitous ARP/NA */
+	bool			gna_router;		/* Router flag for NA messages */
 	int			reset_arp_config;	/* Count of how many vrrps have changed arp parameters on interface */
 	uint32_t		reset_arp_ignore_value;	/* Original value of arp_ignore to be restored */
 	uint32_t		reset_arp_filter_value;	/* Original value of arp_filter to be restored */

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1181,6 +1181,8 @@ vrrp_remove_delayed_arp(vrrp_t *vrrp)
 static void
 vrrp_state_become_master(vrrp_t * vrrp)
 {
+	interface_t *ifp ;
+
 	++vrrp->stats->become_master;
 
 	if (vrrp->version == VRRP_VERSION_3)
@@ -1208,6 +1210,11 @@ vrrp_state_become_master(vrrp_t * vrrp)
 	kernel_netlink_poll();
 
 	/* remotes neighbour update */
+	if (vrrp->family == AF_INET6) {
+		/* Refresh whether we are acting as a router for NA messages */
+		ifp = IF_BASE_IFP(vrrp->ifp);
+		ifp->gna_router = get_ipv6_forwarding(ifp);
+	}
 	vrrp_send_link_update(vrrp, vrrp->garp_rep);
 
 	/* set refresh timer */

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -472,7 +472,7 @@ start_vrrp_child(void)
 			    , (log_facility==LOG_DAEMON) ? LOG_LOCAL1 : log_facility);
 
 #ifdef _MEM_CHECK_
-	mem_log_init(PROG_VRRP, "VRRP Child process", true);
+	mem_log_init(PROG_VRRP, "VRRP Child process");
 #endif
 
 	free_parent_mallocs_startup(true);

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -67,9 +67,7 @@ static int print_vrrp_data(thread_t * thread);
 static int print_vrrp_stats(thread_t * thread);
 static int reload_vrrp_thread(thread_t * thread);
 
-#if HAVE_DECL_CLONE_NEWNET
 static char *vrrp_syslog_ident;
-#endif
 
 /* Daemon stop sequence */
 static void
@@ -451,21 +449,14 @@ start_vrrp_child(void)
 	signal_handler_destroy();
 
 	/* Opening local VRRP syslog channel */
+	if ((instance_name
 #if HAVE_DECL_CLONE_NEWNET
-	if (network_namespace) {
-		syslog_ident = MALLOC(strlen(PROG_VRRP) + 1 + strlen (network_namespace) + 1);
-		if (syslog_ident) {
-			strcpy(syslog_ident, PROG_VRRP);
-			strcat(syslog_ident, "_");
-			strcat(syslog_ident, network_namespace);
-
-			vrrp_syslog_ident = syslog_ident;
-		}
-		else
-			syslog_ident = PROG_VRRP;
-	}
-	else
+			   || network_namespace
 #endif
+					       ) &&
+	    (vrrp_syslog_ident = make_syslog_ident(PROG_VRRP)))
+			syslog_ident = vrrp_syslog_ident;
+	else
 		syslog_ident = PROG_VRRP;
 
 	openlog(syslog_ident, LOG_PID | ((__test_bit(LOG_CONSOLE_BIT, &debug)) ? LOG_CONS : 0)

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -139,8 +139,12 @@ stop_vrrp(int status)
 	log_message(LOG_INFO, "Stopped");
 
 	closelog();
-#if HAVE_DECL_CLONE_NEWNET
+
+#ifndef _MEM_CHECK_LOG_
 	FREE_PTR(vrrp_syslog_ident);
+#else
+	if (vrrp_syslog_ident)
+		free(vrrp_syslog_ident);
 #endif
 
 	exit(status);
@@ -444,8 +448,6 @@ start_vrrp_child(void)
 		return 0;
 	}
 
-	free_parent_mallocs_startup();
-
 	signal_handler_destroy();
 
 	/* Opening local VRRP syslog channel */
@@ -472,6 +474,8 @@ start_vrrp_child(void)
 #ifdef _MEM_CHECK_
 	mem_log_init(PROG_VRRP, "VRRP Child process", true);
 #endif
+
+	free_parent_mallocs_startup(true);
 
 	/* Child process part, write pidfile */
 	if (!pidfile_write(vrrp_pidfile, getpid())) {

--- a/keepalived/vrrp/vrrp_ndisc.c
+++ b/keepalived/vrrp/vrrp_ndisc.c
@@ -146,9 +146,6 @@ ndisc_send_unsolicited_na_immediate(interface_t *ifp, ip_address_t *ipaddress)
 	char *nd_opt_lladdr = (char *) ((char *)nd_opt_h + sizeof(struct nd_opt_hdr));
 	char *lladdr = (char *) IF_HWADDR(ipaddress->ifp);
 	int len;
-	bool router;
-
-	router = get_ipv6_forwarding(ifp);
 
 	/* Ethernet header:
 	 * Destination ethernet address MUST use specific address Mapping
@@ -171,7 +168,7 @@ ndisc_send_unsolicited_na_immediate(interface_t *ifp, ip_address_t *ipaddress)
 
 	/* ICMPv6 Header */
 	icmp6h->icmp6_type = NDISC_NEIGHBOUR_ADVERTISEMENT;
-	icmp6h->icmp6_router = router;
+	icmp6h->icmp6_router = ifp->gna_router;
 
 	/* Override flag is set to indicate that the advertisement
 	 * should override an existing cache entry and update the

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -737,24 +737,26 @@ vrrp_goto_master(vrrp_t * vrrp)
 		vrrp_snmp_instance_trap(vrrp);
 #endif
 		vrrp->last_transition = timer_now();
-	} else {
+
+		return;
+	}
+
 #if defined _WITH_VRRP_AUTH_
-		/* If becoming MASTER in IPSEC AH AUTH, we reset the anti-replay */
-		if (vrrp->version == VRRP_VERSION_2 && vrrp->ipsecah_counter->cycle) {
-			vrrp->ipsecah_counter->cycle = 0;
-			vrrp->ipsecah_counter->seq_number = 0;
-		}
+	/* If becoming MASTER in IPSEC AH AUTH, we reset the anti-replay */
+	if (vrrp->version == VRRP_VERSION_2 && vrrp->ipsecah_counter->cycle) {
+		vrrp->ipsecah_counter->cycle = 0;
+		vrrp->ipsecah_counter->seq_number = 0;
+	}
 #endif
 
 #ifdef _WITH_SNMP_RFCV3_
-		if ((vrrp->version == VRRP_VERSION_2 && vrrp->ms_down_timer >= 3 * vrrp->adver_int) ||
-		    (vrrp->version == VRRP_VERSION_3 && vrrp->ms_down_timer >= 3 * vrrp->master_adver_int))
-			vrrp->stats->master_reason = VRRPV3_MASTER_REASON_MASTER_NO_RESPONSE;
+	if ((vrrp->version == VRRP_VERSION_2 && vrrp->ms_down_timer >= 3 * vrrp->adver_int) ||
+	    (vrrp->version == VRRP_VERSION_3 && vrrp->ms_down_timer >= 3 * vrrp->master_adver_int))
+		vrrp->stats->master_reason = VRRPV3_MASTER_REASON_MASTER_NO_RESPONSE;
 #endif
-		/* handle master state transition */
-		vrrp->wantstate = VRRP_STATE_MAST;
-		vrrp_state_goto_master(vrrp);
-	}
+	/* handle master state transition */
+	vrrp->wantstate = VRRP_STATE_MAST;
+	vrrp_state_goto_master(vrrp);
 }
 
 /* Delayed gratuitous ARP thread */

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -23,6 +23,9 @@
 #include "config.h"
 
 /* global include */
+#ifdef NETLINK_H_NEEDS_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
 #include <linux/if_link.h>
 
 /* local include */

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -236,9 +236,6 @@
 /* Define to 1 if you have the <linux/netfilter/x_tables.h> header file. */
 #undef HAVE_LINUX_NETFILTER_X_TABLES_H
 
-/* Define to 1 if you have the <linux/netlink.h> header file. */
-#undef HAVE_LINUX_NETLINK_H
-
 /* Define to 1 if you have the <linux/rtnetlink.h> header file. */
 #undef HAVE_LINUX_RTNETLINK_H
 
@@ -416,6 +413,9 @@
 /* Define to 1 if libipvs can use netlink */
 #undef LIBIPVS_USE_NL
 
+/* Define to 1 if <linux/netlink.h> needs <sys/socket.h> */
+#undef NETLINK_H_NEEDS_SYS_SOCKET_H
+
 /* Name of package */
 #undef PACKAGE
 
@@ -446,7 +446,7 @@
 /* Date of build configuration */
 #undef VERSION_DATE
 
-/* Define if <linux/netfilter/x_tables.h> doesnt exist */
+/* Define if <linux/netfilter/x_tables.h> doesnt define it */
 #undef XT_EXTENSION_MAXNAMELEN
 
 /* Define to 1 if <linux/netfilter/xt_set.h> needs <libipset/linux_ip_set.h>

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -289,7 +289,7 @@ keepalived_free_final(void)
 				if (free_list[j].ptr == alloc_list[i].ptr)
 					if (free_list[j].type == 8)
 						fprintf
-						    (log_op, "  -> pointer allready released at [%3d:%3d], at %s, %3d, %s\n",
+						    (log_op, "  -> pointer already released at [%3d:%3d], at %s, %3d, %s\n",
 						     (int) free_list[j].csum,
 						     number_alloc_list,
 						     free_list[j].file,

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -233,9 +233,6 @@ keepalived_free(void *buffer, char *file, char *function, int line)
 		return n;
 	}
 
-	if (buffer != NULL)
-		free(buffer);
-
 	fprintf(log_op, "free  [%3d:%3d], %p, %4zu at %s, %3d, %s\n",
 	       i, number_alloc_list, buf,
 	       alloc_list[i].size, file, line, function);
@@ -245,6 +242,9 @@ keepalived_free(void *buffer, char *file, char *function, int line)
 		       i, number_alloc_list, buf,
 		       alloc_list[i].size, file, line, function);
 #endif
+
+	if (buffer != NULL)
+		free(buffer);
 
 	free_list[f].file = file;
 	free_list[f].line = line;

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -414,7 +414,7 @@ keepalived_realloc(void *buffer, size_t size, char *file, char *function,
 }
 
 void
-mem_log_init(const char* prog_name, const char *banner, bool enable)
+mem_log_init(const char* prog_name, const char *banner)
 {
 	size_t log_name_len;
 	char *log_name;
@@ -458,9 +458,6 @@ mem_log_init(const char* prog_name, const char *banner, bool enable)
 	free(log_name);
 
 	terminate_banner = banner;
-
-	if (enable)
-		atexit(keepalived_free_final);
 }
 
 void enable_mem_log_termination(void)

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -64,11 +64,5 @@ extern void *zalloc(unsigned long size);
 #endif
 
 /* Common defines */
-static inline void
-FREE_PTR(void *p)
-{
-	if (p)
-		FREE(p);
-}
-
+#define FREE_PTR(p)	{ if (p) { FREE(p);} }
 #endif

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -50,7 +50,7 @@ extern int keepalived_free(void *, char *, char *, int);
 extern void *keepalived_realloc(void *, size_t, char *, char *, int)
 		__attribute__((alloc_size(2)));
 
-extern void mem_log_init(const char *, const char*, bool);
+extern void mem_log_init(const char *, const char *);
 extern void enable_mem_log_termination(void);
 
 #else

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -30,6 +30,14 @@
 #include "signals.h"
 #include "bitops.h"
 
+#ifdef _INCLUDE_UNUSED_CODE_
+/* Needed for write_stacktrace */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <execinfo.h>
+#endif
+
 /* global vars */
 unsigned long debug = 0;
 
@@ -75,6 +83,21 @@ dump_buffer(char *buff, int count, FILE* fp)
 		}
 	}
 }
+
+#ifdef _INCLUDE_UNUSED_CODE_
+/* To use write_stacktrace, the program must be linked with -rdynamic */
+void
+write_stacktrace(void)
+{
+	int fd = open("/tmp/stacktrace.keepalived", O_WRONLY | O_APPEND | O_CREAT, 0644);
+	void *buffer[100];
+	int nptrs;
+
+	nptrs = backtrace(buffer, 100);
+	backtrace_symbols_fd(buffer, nptrs, fd);
+	close(fd);
+}
+#endif
 
 /* Compute a checksum */
 u_short

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -380,6 +380,7 @@ inet_sockaddrcmp(struct sockaddr_storage *a, struct sockaddr_storage *b)
 }
 
 
+#ifdef _INCLUDE_UNUSED_CODE_
 /*
  * IP string to network representation
  * Highly inspired from Paul Vixie code.
@@ -423,7 +424,6 @@ inet_ston(const char *addr, uint32_t * dst)
 	return 1;
 }
 
-#ifdef _INCLUDE_UNUSED_CODE_
 /*
  * Return broadcast address from network and netmask.
  */

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -65,7 +65,6 @@ extern uint32_t inet_sockaddrip4(struct sockaddr_storage *);
 extern int inet_sockaddrip6(struct sockaddr_storage *, struct in6_addr *);
 extern int inet_inaddrcmp(int, void *, void *);
 extern int inet_sockaddrcmp(struct sockaddr_storage *, struct sockaddr_storage *);
-extern int inet_ston(const char *, uint32_t *);
 extern char *get_local_name(void);
 extern int string_equal(const char *, const char *);
 extern void set_std_fd(int);


### PR DESCRIPTION
Adding `instance red` to the config will add `_red` to the pid file names, e.g. `keepalived_red.pid`, thereby allowing multiple instances of keepalived to be run concurrently without the pid file names colliding.

`use_pid_dir` option puts the pid files in /var/run/keepalived rather than /var/run; the former is used already if keywords `instance` or `net_namespace` are used.