### PR TITLE
Add script to setup a test environment in a separate namespace

### DIFF
--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -781,7 +781,6 @@ keepalived_main(int argc, char **argv)
 
 #if HAVE_DECL_CLONE_NEWNET
 	if (network_namespace) {
-log_message(LOG_INFO, "Wanting %s namespace", network_namespace);
 		if (network_namespace && !set_namespaces(network_namespace)) {
 			log_message(LOG_ERR, "Unable to set network namespace %s - exiting", network_namespace);
 			goto end;

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -72,6 +72,10 @@ static char *syslog_ident;				/* syslog ident if not default */
 char *instance_name;					/* keepalived instance name */
 bool use_pid_dir;					/* Put pid files in /var/run/keepalived */
 
+#if HAVE_DECL_CLONE_NEWNET
+static char *override_namespace;			/* If namespace specified on command line */
+#endif
+
 /* Log facility table */
 static struct {
 	int facility;
@@ -506,6 +510,9 @@ usage(const char *prog)
 	fprintf(stderr, "  -x, --snmp                   Enable SNMP subsystem\n");
 	fprintf(stderr, "  -A, --snmp-agent-socket=FILE Use the specified socket for master agent\n");
 #endif
+#if HAVE_DECL_CLONE_NEWNET
+	fprintf(stderr, "  -s, --namespace=NAME         Run in network namespace NAME (overrides config)\n");
+#endif
 	fprintf(stderr, "  -m, --core-dump              Produce core dump if terminate abnormally\n");
 	fprintf(stderr, "  -M, --core-dump-pattern=PATN Also set /proc/sys/kernel/core_pattern to PATN (default 'core')\n");
 #ifdef _MEM_CHECK_LOG_
@@ -543,25 +550,43 @@ parse_cmdline(int argc, char **argv)
 #ifdef _WITH_LVS_
 		{"checkers_pid",      required_argument, 0, 'c'},
 #endif
- #ifdef _WITH_SNMP_
+#ifdef _WITH_SNMP_
 		{"snmp",              no_argument,       0, 'x'},
 		{"snmp-agent-socket", required_argument, 0, 'A'},
- #endif
+#endif
 		{"core-dump",         no_argument,       0, 'm'},
 		{"core-dump-pattern", optional_argument, 0, 'M'},
 #ifdef _MEM_CHECK_LOG_
 		{"mem-check-log",     no_argument,       0, 'L'},
 #endif
+#if HAVE_DECL_CLONE_NEWNET
+		{"namespace",         required_argument, 0, 's'},
+#endif	
 		{"version",           no_argument,       0, 'v'},
 		{"help",              no_argument,       0, 'h'},
 		{0, 0, 0, 0}
 	};
 
-	while ((c = getopt_long(argc, argv, "vhlndVIDRS:f:PCp:c:r:mML"
+	while ((c = getopt_long(argc, argv, "vhlndVIDRS:f:p:mM"
+#if defined _WITH_VRRP_ && defined _WITH_LVS_
+					    "PC"
+#endif
+#ifdef _WITH_VRRP_ 
+					    "r:"
+#endif
+#ifdef _WITH_LVS_
+					    "c:"
+#endif
 #ifdef _WITH_SNMP_
 					    "xA:"
 #endif
-									, long_options, NULL)) != EOF) {
+#ifdef _MEM_CHECK_LOG_
+					    "L"
+#endif
+#if HAVE_DECL_CLONE_NEWNET
+					    "s:"
+#endif
+				, long_options, NULL)) != EOF) {
 		switch (c) {
 		case 'v':
 			fprintf(stderr, "%s", version_string);
@@ -649,6 +674,12 @@ parse_cmdline(int argc, char **argv)
 			__set_bit(MEM_CHECK_LOG_BIT, &debug);
 			break;
 #endif
+#if HAVE_DECL_CLONE_NEWNET
+		case 's':
+			override_namespace = MALLOC(strlen(optarg) + 1);
+			strcpy(override_namespace, optarg);
+			break;
+#endif
 		default:
 			exit(0);
 			break;
@@ -716,6 +747,17 @@ keepalived_main(int argc, char **argv)
 
 	read_config_file();
 
+#if HAVE_DECL_CLONE_NEWNET
+	if (override_namespace) {
+		if (network_namespace) {
+			log_message(LOG_INFO, "Overriding config net_namespace '%s' with command line namespace '%s'", network_namespace, override_namespace);
+			FREE(network_namespace);
+		}
+		network_namespace = override_namespace;
+		override_namespace = NULL;
+	}
+#endif
+
 	if (instance_name
 #if HAVE_DECL_CLONE_NEWNET
 			  || network_namespace
@@ -729,31 +771,38 @@ keepalived_main(int argc, char **argv)
 		else
 			log_message(LOG_INFO, "Unable to change syslog ident");
 
-#if HAVE_DECL_CLONE_NEWNET
-		if (network_namespace && !set_namespaces(network_namespace)) {
-			log_message(LOG_ERR, "Unable to set network namespace %s - exiting", network_namespace);
-			goto end;
-		}
-#endif
-
-		if (instance_name) {
-			if (!main_pidfile && (main_pidfile = make_pidfile_name(KEEPALIVED_PID_DIR KEEPALIVED_PID_FILE, instance_name, PID_EXTENSION)))
-				free_main_pidfile = true;
-#ifdef _WITH_LVS_
-			if (!checkers_pidfile && (checkers_pidfile = make_pidfile_name(KEEPALIVED_PID_DIR CHECKERS_PID_FILE, instance_name, PID_EXTENSION)))
-				free_checkers_pidfile = true;
-#endif
-#ifdef _WITH_VRRP_
-			if (!vrrp_pidfile && (vrrp_pidfile = make_pidfile_name(KEEPALIVED_PID_DIR VRRP_PID_FILE, instance_name, PID_EXTENSION)))
-				free_vrrp_pidfile = true;
-#endif
-		}
+		use_pid_dir = true;
 	}
 
 	if (use_pid_dir) {
 		/* Create the directory for pid files */
 		create_pid_dir();
+	}
 
+#if HAVE_DECL_CLONE_NEWNET
+	if (network_namespace) {
+log_message(LOG_INFO, "Wanting %s namespace", network_namespace);
+		if (network_namespace && !set_namespaces(network_namespace)) {
+			log_message(LOG_ERR, "Unable to set network namespace %s - exiting", network_namespace);
+			goto end;
+		}
+	}
+#endif
+
+	if (instance_name) {
+		if (!main_pidfile && (main_pidfile = make_pidfile_name(KEEPALIVED_PID_DIR KEEPALIVED_PID_FILE, instance_name, PID_EXTENSION)))
+			free_main_pidfile = true;
+#ifdef _WITH_LVS_
+		if (!checkers_pidfile && (checkers_pidfile = make_pidfile_name(KEEPALIVED_PID_DIR CHECKERS_PID_FILE, instance_name, PID_EXTENSION)))
+			free_checkers_pidfile = true;
+#endif
+#ifdef _WITH_VRRP_
+		if (!vrrp_pidfile && (vrrp_pidfile = make_pidfile_name(KEEPALIVED_PID_DIR VRRP_PID_FILE, instance_name, PID_EXTENSION)))
+			free_vrrp_pidfile = true;
+#endif
+	}
+
+	if (use_pid_dir) {
 		if (!main_pidfile)
 			main_pidfile = KEEPALIVED_PID_DIR KEEPALIVED_PID_FILE PID_EXTENSION;
 #ifdef _WITH_LVS_

--- a/keepalived/core/namespaces.c
+++ b/keepalived/core/namespaces.c
@@ -28,10 +28,10 @@
  * In order not to have to specify different pid files for each instance of
  * keepalived, if keepalived is running in a network namespace it will also create
  * its own mount namespace, and will slave bind mount a unique directory
- * (/var/run/keepalived/keepalived.PID) on /var/run/keepalived, so keepalived will
+ * (/var/run/keepalived/NAMESPACE) on /var/run/keepalived, so keepalived will
  * write its usual pid files (but to /var/run/keepalived rather than to /var/run),
  * and outside the mount namespace these will be visible at
- * /var/run/keepalived/keepalived.PID
+ * /var/run/keepalived/NAMESPACE.
  *
  * If you are familiar with network namespaces, then you will know what you can do
  * with them. If not, then the following scenarios should give you an idea of what

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1532,13 +1532,10 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, int buflen)
 		return 0;
 	}
 
-	if (hd->priority == vrrp->effective_priority) {
-		addr_cmp = vrrp_saddr_cmp(&vrrp->pkt_saddr, vrrp);
-		if (addr_cmp == 0)
-			log_message(LOG_INFO, "(%s): WARNING - advert received from remote host with our IP address.", vrrp->iname);
-	}
- 	else
-		addr_cmp = 0; 	/* Avoid compiler warning */
+	addr_cmp = vrrp_saddr_cmp(&vrrp->pkt_saddr, vrrp);
+
+	if (hd->priority == vrrp->effective_priority && addr_cmp == 0)
+			log_message(LOG_INFO, "(%s): WARNING - equal priority advert received from remote host with our IP address.", vrrp->iname);
 
 	if (hd->priority < vrrp->effective_priority ||
 		   (hd->priority == vrrp->effective_priority &&

--- a/test/netns-test.sh
+++ b/test/netns-test.sh
@@ -151,6 +151,6 @@ fi
 echo
 echo Network namespace $NS_NAME set up to mirror default namespace$EXTRA.
 echo
-[[ -n $CONF ]] && echo To test keepalived execute \`$IPN keepalived -f $CONF\` && echo
+[[ -n $CONF ]] && echo To test keepalived execute \`$IP netns exec $NS_NAME keepalived [OPTIONS] -f $CONF -s $NS_NAME\` && echo
 echo Don\'t forget to delete namespace $NS_NAME with \'$IP netns del $NS_NAME\' when finished.
 echo

--- a/test/netns-test.sh
+++ b/test/netns-test.sh
@@ -135,12 +135,16 @@ while read line; do
 	fi
 done
 
-# Now create any additional interfaces in the config that don't exist
-if [[ -n $CONF && -n $EXTRA_IF ]]; then
+# Now deal with any additional interfaces in the config that don't exist
+if [[ -n $CONF ]]; then
 	for if in $IFACES; do
 		if [[ ! $CREATED_IFACES =~ " $if " ]]; then
-			$IPN link add $if type dummy
-			$IPN link set up $if
+			if [[ -z $EXTRA_IF ]]; then
+				echo Interface $if specified in configuration file doesn\'t exist
+			else
+				$IPN link add $if type dummy
+				$IPN link set up $if
+			fi
 		fi
 	done
 fi

--- a/test/netns-test.sh
+++ b/test/netns-test.sh
@@ -1,0 +1,156 @@
+#! /bin/bash
+
+# Usage:
+#  netns-test.sh [options]
+#
+# This script will create interfaces in a network namespace (default test)
+# that are needed for the specified keepalived configuration (or all
+# interfaces if configuration explicitly set to ""), so that keepalived
+# can be run in that namespace for testing or other purposes.
+
+DFLT_NS=test
+DFLT_CONF=/etc/keepalived/keepalived.conf
+
+NS_NAME=$DFLT_NS
+CONF=$DFLT_CONF
+IP=ip
+CREATE_PREFIX=
+EXTRA_IF=
+
+CREATED_IFACES=
+SHOW_IFACES=
+
+show_help()
+{
+	cat <<EOF
+$0 - Usage:
+        -h              Show this!
+	-n		network namespace name (default test)
+	-c		keepalived config file to read interfaces from
+			  if no config file, all interfaces will be duplicated
+	-i		command to use instead of \`ip\`
+	-u		use 'unshare -n' before creating network namespace
+	-x		create interfaces in config file that don't exist
+	-p		show created interfaces
+EOF
+}
+
+while getopts ":hn:c:i:uxp" opt; do
+	case $opt in
+	h)
+		show_help
+		exit 0
+		;;
+	n)
+		NS_NAME=$OPTARG
+		;;
+	c)
+		CONF=$OPTARG
+		;;
+	i)
+		IP=$OPTARG
+		;;
+	u)
+		CREATE_PREFIX="unshare -n"
+		;;
+	x)
+		EXTRA_IF=yes
+		;;
+	p)
+		SHOW_IFACES=yes
+		;;
+	?)
+		echo Unknown option \'$OPTARG\' && show_help && exit 1
+		;;
+	esac
+done
+
+[[ -n $CONF && ! -f $CONF ]] && echo Cannot read config file $CONF && exit 1
+
+IPN="$IP netns exec $NS_NAME $IP"
+
+if [[ -n $CONF ]]; then
+	IFACES=$(grep interface $CONF | sed -e "s/[!#].*//" -e "s/interface //" | sort -u)
+	IFACES=$(echo $IFACES)
+	IFACES=" $IFACES "
+
+	HOSTED_IFACES=$($IP link show | grep @ | sed -e "s/^[0-9]*: //" -e "s/:.*//")
+
+	# Add parents of any sub interfaces
+	for if in $HOSTED_IFACES; do
+		[[ $IFACES =~ " ${if%@*} " ]] && IFACES="$IFACES ${if##*@} "
+	done
+else
+	IFACES=
+fi
+
+$IP netns del $NS_NAME 2>/dev/null
+
+$CREATE_PREFIX $IP netns add $NS_NAME
+
+$IPN link set up lo
+
+ip addr show | \
+while read line; do
+	set $line
+	if [[ ${line:0:1} =~ [1-9] ]]; then
+		iface=$(<<<$line sed -e "s/^[0-9]*: *//" -e "s/:.*//")
+		[[ -n $IFACES && ! $IFACES =~ " ${iface%@*} " ]] && iface= && continue
+
+		if [[ $iface =~ @ ]]; then
+			# This is an interface built on top of another one
+			vlan_info=$(grep "^${iface%@*} " /proc/net/vlan/config)
+			if [[ -n $vlan_info ]]; then
+				set $vlan_info
+				vlan_id=$3
+				vlan_parent=$5
+			fi
+
+			iface=${iface%@*}
+		else
+			vlan_id=
+		fi
+		continue
+	fi
+
+	[[ -z $iface ]] && continue
+
+	if [[ $line =~ "link/ether" ]]; then
+		if [[ -n $vlan_id ]]; then
+			$IPN link add link $vlan_parent name $iface type vlan id $vlan_id
+		else
+			$IPN link add $iface address $2 broadcast $4 type dummy
+		fi
+		$IPN link set up $iface
+		CREATED_IFACES=" $CREATED_IFACES $iface "
+	elif [[ $1 = inet ]]; then
+		[[ $3 = brd ]] && BCAST="$3 $4" || BCAST=
+		$IPN addr add $2 $BCAST dev $iface 2>/dev/null
+	elif [[ $1 = inet6 ]]; then
+		# We could try and detect the default link local address, and not try to
+		# add it again, but let's just be lazy and ignore an error.
+		$IPN addr add $2 dev $iface 2>/dev/null
+	else
+:		echo Unknown line: $line
+	fi
+done
+
+# Now create any additional interfaces in the config that don't exist
+if [[ -n $CONF && -n $EXTRA_IF ]]; then
+	for if in $IFACES; do
+		if [[ ! $CREATED_IFACES =~ " $if " ]]; then
+			$IPN link add $if type dummy
+			$IPN link set up $if
+		fi
+	done
+fi
+
+[[ -n $SHOW_IFACES ]] && $IPN addr show
+
+[[ -n $CONF ]] && EXTRA=" for config $CONF" || EXTRA=
+echo
+echo Network namespace $NS_NAME set up to mirror default namespace$EXTRA.
+echo
+[[ -n $CONF ]] && echo To test keepalived execute \`$IPN keepalived -f $CONF\` && echo
+echo Don\'t forget to delete namespace $NS_NAME with \'$IP netns del $NS_NAME\' when finished.
+echo

--- a/test/netns-test.sh
+++ b/test/netns-test.sh
@@ -26,7 +26,7 @@ show_help()
 $0 - Usage:
         -h              Show this!
 	-n		network namespace name (default test)
-	-c		keepalived config file to read interfaces from
+	-f		keepalived config file to read interfaces from
 			  if no config file, all interfaces will be duplicated
 	-i		command to use instead of \`ip\`
 	-u		use 'unshare -n' before creating network namespace
@@ -35,7 +35,7 @@ $0 - Usage:
 EOF
 }
 
-while getopts ":hn:c:i:uxp" opt; do
+while getopts ":hn:f:i:uxp" opt; do
 	case $opt in
 	h)
 		show_help
@@ -44,7 +44,7 @@ while getopts ":hn:c:i:uxp" opt; do
 	n)
 		NS_NAME=$OPTARG
 		;;
-	c)
+	f)
 		CONF=$OPTARG
 		;;
 	i)


### PR DESCRIPTION
Issue #389 requested an option for being able to test that a configuration file is valid.

This commit adds test/netns-test.sh script that will set up a network configuration in a separate namespace (default test) which mirrors the system's main configuration for interfaces that are specified in the keepalived config file. keepalived can then be run with the -s test (or whatever namespace has been used) to test the configuration completely independently from the main system.