### PR TITLE
Add DNS health checker

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -574,6 +574,25 @@ virtual_server group <STRING>      {	# VS group declaration
         notify_up <STRING>|<QUOTED-STRING> # Idem
         notify_down <STRING>|<QUOTED-STRING> # Idem
 
+        DNS_CHECK {                     # DNS healthchecker
+            connect_ip <IP ADDRESS>     # Optional IP address to connect to
+            connect_port <PORT>         # Optional port to connect to
+            bindto <IP ADDRESS>         # Optional interface to use to originate the connection
+            bind_port <PORT>            # Optional source port to originate the connection from
+            connect_timeout <INTEGER>   # Optional per-host connection timeout.
+            fwmark <INTEGER>            # Optional fwmark to mark all outgoing checker pakets with
+            retry <INTEGER>             # Number of times to retry a failed check
+            type <STRING>               # DNS query type
+            name <STRING>               # Domain name to use for the DNS query
+        }
+    }
+
+    real_server <IP ADDRESS> <PORT> {	# Idem
+        weight <INTEGER>		# Idem
+        inhibit_on_failure		# Idem
+        notify_up <STRING>|<QUOTED-STRING> # Idem
+        notify_down <STRING>|<QUOTED-STRING> # Idem
+
         MISC_CHECK {				# MISC healthchecker
             misc_path <STRING>|<QUOTED-STRING>	# External system script or program
             misc_timeout <INTEGER>		# Script execution timeout

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -659,7 +659,7 @@ A virtual_server can be a declaration of one of
            lthreshold <INTEGER> # minimum number of connections to server
 
            # pick one healthchecker
-           # HTTP_GET|SSL_GET|TCP_CHECK|SMTP_CHECK|MISC_CHECK
+           # HTTP_GET|SSL_GET|TCP_CHECK|SMTP_CHECK|DNS_CHECK|MISC_CHECK
 
            # HTTP and SSL healthcheckers
            HTTP_GET|SSL_GET
@@ -810,6 +810,41 @@ A virtual_server can be a declaration of one of
               # the maximum at delay_loop. Specify 0 to disable
               warmup <INT>
            } #SMTP_CHECK
+
+           # DNS healthchecker
+           DNS_CHECK
+           {
+               # ======== generic connection options
+               # Optional IP address to connect to.
+               # The default is the realserver IP
+               connect_ip <IP ADDRESS>
+               # Optional port to connect to
+               # The default is the realserver port
+               connect_port <PORT>
+               # Optional interface to use to
+               # originate the connection
+               bindto <IP ADDRESS>
+               # Optional source port to
+               # originate the connection from
+               bind_port <PORT>
+               # Optional connection timeout in seconds.
+               # The default is 5 seconds
+               connect_timeout <INTEGER>
+               # Optional fwmark to mark all outgoing
+               # checker packets with
+               fwmark <INTEGER>
+
+               # Number of times to retry a failed check
+               # The default is 3 times.
+               retry <INTEGER>
+               # DNS query type
+               #   A|NS|CNAME|SOA|MX|TXT|AAAA
+               # The default is SOA
+               type <STRING>
+               # Domain name to use for the DNS query
+               # The default is . (dot)
+               name <STRING>
+           }
 
            # MISC healthchecker, run a program
            MISC_CHECK

--- a/keepalived/check/Makefile.am
+++ b/keepalived/check/Makefile.am
@@ -15,8 +15,8 @@ noinst_LIBRARIES	= libcheck.a
 libcheck_a_SOURCES = \
 	check_daemon.c check_data.c check_parser.c \
 	check_api.c check_tcp.c check_http.c check_ssl.c \
-	check_smtp.c check_misc.c ipwrapper.c ipvswrapper.c \
-	libipvs.c
+	check_smtp.c check_misc.c check_dns.c ipwrapper.c \
+	ipvswrapper.c libipvs.c
 
 AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 

--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -37,6 +37,7 @@
 #include "check_tcp.h"
 #include "check_http.h"
 #include "check_ssl.h"
+#include "check_dns.h"
 
 /* Global vars */
 static checker_id_t ncheckers = 0;
@@ -310,4 +311,5 @@ install_checkers_keyword(void)
 	install_tcp_check_keyword();
 	install_http_check_keyword();
 	install_ssl_check_keyword();
+	install_dns_check_keyword();
 }

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -1,0 +1,433 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        DNS checker
+ *
+ * Author:      Masanobu Yasui, <yasui-m@klab.com>
+ *              Masaya Yamamoto, <yamamoto-ma@klab.com>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2016 KLab Inc.
+ */
+
+#include "config.h"
+
+#include <strings.h>
+#include "check_dns.h"
+#include "check_api.h"
+#include "memory.h"
+#include "ipwrapper.h"
+#include "logger.h"
+#include "smtp.h"
+#include "utils.h"
+#include "parser.h"
+#include "timer.h"
+#if !HAVE_DECL_SOCK_CLOEXEC
+#include "old_socket.h"
+#include "string.h"
+#endif
+
+#ifdef _DEBUG_
+#define DNS_DBG(args...) dns_log_message(thread, LOG_DEBUG, ## args)
+#else
+#define DNS_DBG(args...)
+#endif
+
+const dns_type_t DNS_TYPE[] = {
+	{DNS_TYPE_A, "A"},
+	{DNS_TYPE_NS, "NS"},
+	{DNS_TYPE_CNAME, "CNAME"},
+	{DNS_TYPE_SOA, "SOA"},
+	{DNS_TYPE_MX, "MX"},
+	{DNS_TYPE_TXT, "TXT"},
+	{DNS_TYPE_AAAA, "AAAA"},
+	{0, NULL}
+};
+
+static int dns_connect_thread(thread_t *);
+
+static uint16_t
+dns_type_lookup(const char *label)
+{
+	const dns_type_t *t;
+
+	for (t = DNS_TYPE; t->type; t++) {
+		if (!strcasecmp(label, t->label)) {
+			return t->type;
+		}
+	}
+	return 0;
+}
+
+static void
+dns_log_message(thread_t * thread, int level, const char *fmt, ...)
+{
+	char buf[MAX_LOG_MSG];
+	va_list args;
+
+	checker_t *checker = THREAD_ARG(thread);
+
+	va_start(args, fmt);
+	vsnprintf(buf, sizeof (buf), fmt, args);
+	va_end(args);
+
+	log_message(level, "DNS_CHECK (%s) %s", FMT_DNS_RS(checker), buf);
+}
+
+static int
+dns_final(thread_t * thread, int error, const char *fmt, ...)
+{
+	char buf[MAX_LOG_MSG];
+	va_list args;
+
+	checker_t *checker = THREAD_ARG(thread);
+	dns_check_t *dns_check = CHECKER_ARG(checker);
+
+	DNS_DBG("final error=%d attempts=%d retry=%d", error,
+		dns_check->attempts, dns_check->retry);
+
+	close(thread->u.fd);
+
+	if (error) {
+		if (svr_checker_up(checker->id, checker->rs)) {
+			if (fmt) {
+				va_start(args, fmt);
+				vsnprintf(buf, sizeof (buf), fmt, args);
+				dns_log_message(thread, LOG_INFO, buf);
+				va_end(args);
+			}
+			if (dns_check->attempts < dns_check->retry) {
+				dns_check->attempts++;
+				thread_add_timer(thread->master,
+						 dns_connect_thread, checker,
+						 checker->vs->delay_loop);
+				return 0;
+			}
+			update_svr_checker_state(DOWN, checker->id, checker->vs,
+						 checker->rs);
+			smtp_alert(checker->rs, NULL, NULL, "DOWN",
+				   "=> DNS_CHECK: failed on service <=");
+		}
+	} else {
+		if (!svr_checker_up(checker->id, checker->rs)) {
+			smtp_alert(checker->rs, NULL, NULL, "UP",
+				   "=> DNS_CHECK: succeed on service <=");
+			update_svr_checker_state(UP, checker->id, checker->vs,
+						 checker->rs);
+		}
+	}
+
+	dns_check->attempts = 0;
+	thread_add_timer(thread->master, dns_connect_thread, checker,
+			 checker->vs->delay_loop);
+
+	return 0;
+}
+
+static int
+dns_recv_thread(thread_t * thread)
+{
+	long timeout;
+	ssize_t ret;
+	char rbuf[DNS_BUFFER_SIZE];
+	dns_header_t *s_header, *r_header;
+	int flags, rcode;
+
+	checker_t *checker = THREAD_ARG(thread);
+	dns_check_t *dns_check = CHECKER_ARG(checker);
+
+	if (thread->type == THREAD_READ_TIMEOUT) {
+		dns_final(thread, 1, "read timeout from socket.");
+		return 0;
+	}
+
+	timeout = timer_long(thread->sands) - timer_long(time_now);
+
+	ret = recv(thread->u.fd, rbuf, sizeof (rbuf), 0);
+	if (ret == -1) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+			thread_add_read(thread->master, dns_recv_thread,
+					checker, thread->u.fd, timeout);
+			return 0;
+		}
+		dns_final(thread, 1, "failed to read socket. %s.", strerror(errno));
+		return 0;
+	}
+
+	if (ret < (ssize_t) sizeof (r_header)) {
+		DNS_DBG("too small message. (%d bytes)", ret);
+		thread_add_read(thread->master, dns_recv_thread, checker,
+				thread->u.fd, timeout);
+		return 0;
+	}
+
+	s_header = (dns_header_t *) dns_check->sbuf;
+	r_header = (dns_header_t *) rbuf;
+
+	if (s_header->id != r_header->id) {
+		DNS_DBG("ID does not match. (%04x != %04x)",
+			ntohs(s_header->id), ntohs(r_header->id));
+		thread_add_read(thread->master, dns_recv_thread, checker,
+				thread->u.fd, timeout);
+		return 0;
+	}
+
+	flags = ntohs(r_header->flags);
+
+	if (!DNS_QR(flags)) {
+		DNS_DBG("recieve query message?");
+		thread_add_read(thread->master, dns_recv_thread, checker,
+				thread->u.fd, timeout);
+		return 0;
+	}
+
+	if ((rcode = DNS_RC(flags)) != 0) {
+		dns_final(thread, 1, "error occurread. (rcode = %d)", rcode);
+		return 0;
+	}
+
+	/* success */
+	dns_final(thread, 0, NULL);
+
+	return 0;
+}
+
+#define APPEND16(x, y) do { \
+		*(uint16_t *) (x) = htons(y); \
+		(x) = (uint8_t *) (x) + 2; \
+	} while(0)
+
+static int
+dns_make_query(thread_t * thread)
+{
+	uint16_t flags = 0;
+	uint8_t *p;
+	char *s, *e;
+	size_t n;
+
+	checker_t *checker = THREAD_ARG(thread);
+	dns_check_t *dns_check = CHECKER_ARG(checker);
+
+	dns_header_t *header = (dns_header_t *) dns_check->sbuf;
+
+	DNS_SET_RD(flags, 1);	/* Recursion Desired */
+
+	header->id = htons(random());
+	header->flags = htons(flags);
+	header->qdcount = htons(1);
+	header->ancount = htons(0);
+	header->nscount = htons(0);
+	header->arcount = htons(0);
+
+	p = (uint8_t *) (header + 1);
+
+	/* QNAME */
+	for (s = dns_check->name; *s; s = *e ? ++e : e) {
+		if (!(e = strchr(s, '.'))) {
+			e = s + strlen(s);
+		}
+		*(p++) = n = e - s;
+		memcpy(p, s, n);
+		p += n;
+	}
+	n = strlen(dns_check->name);
+	if (n && dns_check->name[--n] != '.') {
+		*(p++) = 0;
+	}
+
+	APPEND16(p, dns_type_lookup(dns_check->type));
+	APPEND16(p, 1);		/* IN */
+
+	dns_check->slen = p - (uint8_t *) header;
+
+	return 0;
+}
+
+static int
+dns_send_thread(thread_t * thread)
+{
+	long timeout;
+	ssize_t ret;
+
+	checker_t *checker = THREAD_ARG(thread);
+	dns_check_t *dns_check = CHECKER_ARG(checker);
+
+	if (thread->type == THREAD_WRITE_TIMEOUT) {
+		dns_final(thread, 1, "write timeout to socket.");
+		return 0;
+	}
+
+	timeout = timer_long(thread->sands) - timer_long(time_now);
+
+	ret = send(thread->u.fd, dns_check->sbuf, dns_check->slen, 0);
+	if (ret == -1) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+			thread_add_write(thread->master, dns_send_thread,
+					 checker, thread->u.fd, timeout);
+			return 0;
+		}
+		dns_final(thread, 1, "failed to write socket.");
+		return 0;
+	}
+
+	if (ret != (ssize_t) dns_check->slen) {
+		dns_final(thread, 1, "failed to write all of the datagram.");
+		return 0;
+	}
+
+	thread_add_read(thread->master, dns_recv_thread, checker, thread->u.fd,
+			timeout);
+
+	return 0;
+}
+
+static int
+dns_check_thread(thread_t * thread)
+{
+	int status;
+	long timeout;
+
+	checker_t *checker = THREAD_ARG(thread);
+
+	status = socket_state(thread, dns_check_thread);
+
+	/* If status = connect_in_progress, next thread is already registered.
+	 * If it is connect_success, the fd is still open.
+	 * Otherwise we have a real connection error or connection timeout.
+	 */
+	switch (status) {
+	case connect_error:
+		dns_final(thread, 1, "connection error.");
+		break;
+	case connect_timeout:
+		dns_final(thread, 1, "connection failure.");
+		break;
+	case connect_success:
+		dns_make_query(thread);
+		fcntl(thread->u.fd, F_SETFL,
+		      fcntl(thread->u.fd, F_GETFL, 0) | O_NONBLOCK);
+		timeout = timer_long(thread->sands) - timer_long(time_now);
+		thread_add_write(thread->master, dns_send_thread, checker,
+				 thread->u.fd, timeout);
+		break;
+	}
+
+	return 0;
+}
+
+static int
+dns_connect_thread(thread_t * thread)
+{
+	int fd, status;
+
+	checker_t *checker = THREAD_ARG(thread);
+	conn_opts_t *co = checker->co;
+
+	if (!CHECKER_ENABLED(checker)) {
+		thread_add_timer(thread->master, dns_connect_thread, checker,
+				 checker->vs->delay_loop);
+		return 0;
+	}
+
+	if ((fd = socket(co->dst.ss_family, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP)) == -1) {
+		dns_log_message(thread, LOG_INFO,
+				"failed to create socket. Rescheduling.");
+		thread_add_timer(thread->master, dns_connect_thread, checker,
+				 checker->vs->delay_loop);
+		return 0;
+	}
+#if !HAVE_DECL_SOCK_CLOEXEC
+	if (set_sock_flags(fd, F_SETFD, FD_CLOEXEC))
+		dns_log_message(thread, LOG_INFO,
+				"unable to set CLOEXEC on socket - %s (%d)",
+				strerror(errno), errno);
+#endif
+
+	status = socket_bind_connect(fd, co);
+
+	/* handle connection status & register check worker thread */
+	if (socket_connection_state(fd, status, thread, dns_check_thread, co->connection_to)) {
+		close(fd);
+		dns_log_message(thread, LOG_INFO,
+				"UDP socket bind failed. Rescheduling.");
+		thread_add_timer(thread->master, dns_connect_thread, checker,
+				 checker->vs->delay_loop);
+	}
+
+	return 0;
+}
+
+static void
+dns_free(void *data)
+{
+	FREE(CHECKER_CO(data));
+	FREE(CHECKER_DATA(data));
+	FREE(data);
+}
+
+static void
+dns_dump(void *data)
+{
+	dns_check_t *dns_check = CHECKER_DATA(data);
+	log_message(LOG_INFO, "   Keepalive method = DNS_CHECK");
+	dump_conn_opts(CHECKER_CO(data));
+	log_message(LOG_INFO, "   Retry = %d", dns_check->retry);
+	log_message(LOG_INFO, "   Type = %s", dns_check->type);
+	log_message(LOG_INFO, "   Name = %s", dns_check->name);
+}
+
+static void
+dns_check_handler(__attribute__((unused)) vector_t * strvec)
+{
+	dns_check_t *dns_check = (dns_check_t *) MALLOC(sizeof (dns_check_t));
+	dns_check->retry = DNS_DEFAULT_RETRY;
+	dns_check->attempts = 0;
+	dns_check->type = DNS_DEFAULT_TYPE;
+	dns_check->name = DNS_DEFAULT_NAME;
+	queue_checker(dns_free, dns_dump, dns_connect_thread, dns_check,
+		      CHECKER_NEW_CO());
+}
+
+static void
+dns_retry_handler(vector_t * strvec)
+{
+	dns_check_t *dns_check = CHECKER_GET();
+	dns_check->retry = CHECKER_VALUE_INT(strvec);
+}
+
+static void
+dns_type_handler(vector_t * strvec)
+{
+	dns_check_t *dns_check = CHECKER_GET();
+	dns_check->type = CHECKER_VALUE_STRING(strvec);
+}
+
+static void
+dns_name_handler(vector_t * strvec)
+{
+	dns_check_t *dns_check = CHECKER_GET();
+	dns_check->name = CHECKER_VALUE_STRING(strvec);
+}
+
+void
+install_dns_check_keyword(void)
+{
+	install_keyword("DNS_CHECK", &dns_check_handler);
+	install_sublevel();
+	install_connect_keywords();
+	install_keyword("retry", &dns_retry_handler);
+	install_keyword("type", &dns_type_handler);
+	install_keyword("name", &dns_name_handler);
+	install_sublevel_end();
+}

--- a/keepalived/core/layer4.c
+++ b/keepalived/core/layer4.c
@@ -28,8 +28,10 @@
 #include "logger.h"
 
 enum connect_result
-tcp_bind_connect(int fd, conn_opts_t *co)
+socket_bind_connect(int fd, conn_opts_t *co)
 {
+	int opt;
+	socklen_t optlen;
 	struct linger li;
 	socklen_t addrlen;
 	int ret;
@@ -37,10 +39,17 @@ tcp_bind_connect(int fd, conn_opts_t *co)
 	struct sockaddr_storage *addr = &co->dst;
 	struct sockaddr_storage *bind_addr = &co->bindto;
 
-	/* free the tcp port after closing the socket descriptor */
-	li.l_onoff = 1;
-	li.l_linger = 0;
-	setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *) &li, sizeof (struct linger));
+	optlen = sizeof(opt);
+	if (getsockopt(fd, SOL_SOCKET, SO_TYPE, (void *) &opt, &optlen) < 0) {
+		log_message(LOG_ERR, "Can't get socket type: %s", strerror(errno));
+		return connect_error;
+	}
+	if (opt == SOCK_STREAM) {
+		/* free the tcp port after closing the socket descriptor */
+		li.l_onoff = 1;
+		li.l_linger = 0;
+		setsockopt(fd, SOL_SOCKET, SO_LINGER, (char *) &li, sizeof (struct linger));
+	}
 
 	/* Make socket non-block. */
 	val = fcntl(fd, F_GETFL, 0);
@@ -84,16 +93,16 @@ tcp_bind_connect(int fd, conn_opts_t *co)
 }
 
 enum connect_result
-tcp_connect(int fd, struct sockaddr_storage *addr)
+socket_connect(int fd, struct sockaddr_storage *addr)
 {
 	conn_opts_t co;
 	memset(&co, 0, sizeof(co));
 	co.dst = *addr;
-	return tcp_bind_connect(fd, &co);
+	return socket_bind_connect(fd, &co);
 }
 
 enum connect_result
-tcp_socket_state(thread_t * thread, int (*func) (thread_t *))
+socket_state(thread_t * thread, int (*func) (thread_t *))
 {
 	int status;
 	socklen_t addrlen;
@@ -136,7 +145,7 @@ tcp_socket_state(thread_t * thread, int (*func) (thread_t *))
 }
 
 int
-tcp_connection_state(int fd, enum connect_result status, thread_t * thread,
+socket_connection_state(int fd, enum connect_result status, thread_t * thread,
 		     int (*func) (thread_t *), long timeout)
 {
 	checker_t *checker;

--- a/keepalived/include/check_dns.h
+++ b/keepalived/include/check_dns.h
@@ -1,0 +1,92 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        check_dns.c include file.
+ *
+ * Author:      Masanobu Yasui, <yasui-m@klab.com>
+ *              Masaya Yamamoto, <yamamoto-ma@klab.com>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2016 KLab Inc.
+ */
+
+#ifndef _CHECK_DNS_CHECK_H
+#define _CHECK_DNS_CHECK_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "scheduler.h"
+
+#define DNS_DEFAULT_RETRY    3
+#define DNS_DEFAULT_TYPE  "SOA"
+#define DNS_DEFAULT_NAME    "."
+#define DNS_BUFFER_SIZE    768
+
+#define DNS_QR(flags) ((flags >> 15) & 0x0001)
+#define DNS_OP(flags) ((flags >> 11) & 0x000F)
+#define DNS_AA(flags) ((flags >> 10) & 0x0001)
+#define DNS_TC(flags) ((flags >>  9) & 0x0001)
+#define DNS_RD(flags) ((flags >>  8) & 0x0001)
+#define DNS_RA(flags) ((flags >>  7) & 0x0001)
+#define DNS_Z(flags)  ((flags >>  4) & 0x0007)
+#define DNS_RC(flags) ((flags >>  0) & 0x000F)
+
+#define DNS_SET_QR(flags, val) (flags |= ((val & 0x0001) << 15))
+#define DNS_SET_OP(flags, val) (flags |= ((val & 0x000F) << 11))
+#define DNS_SET_AA(flags, val) (flags |= ((val & 0x0001) << 10))
+#define DNS_SET_TC(flags, val) (flags |= ((val & 0x0001) <<  9))
+#define DNS_SET_RD(flags, val) (flags |= ((val & 0x0001) <<  8))
+#define DNS_SET_RA(flags, val) (flags |= ((val & 0x0001) <<  7))
+#define DNS_SET_Z(flags, val)  (flags |= ((val & 0x0007) <<  4))
+#define DNS_SET_RC(flags, val) (flags |= ((val & 0x000F) <<  0))
+
+#define DNS_TYPE_A     1
+#define DNS_TYPE_NS    2
+#define DNS_TYPE_CNAME 5
+#define DNS_TYPE_SOA   6
+#define DNS_TYPE_MX   15
+#define DNS_TYPE_TXT  16
+#define DNS_TYPE_AAAA 28
+
+#define FMT_DNS_RS(C) FMT_CHK(C)
+
+typedef struct _dns_type {
+	uint16_t type;
+	char *label;
+} dns_type_t;
+
+extern const dns_type_t DNS_TYPE[];
+
+typedef struct _dns_header {
+	uint16_t id;
+	uint16_t flags;
+	uint16_t qdcount;
+	uint16_t ancount;
+	uint16_t nscount;
+	uint16_t arcount;
+} dns_header_t;
+
+typedef struct _dns_check {
+	int retry;
+	int attempts;
+	char *type;
+	char *name;
+	uint8_t sbuf[DNS_BUFFER_SIZE];
+	size_t slen;
+} dns_check_t;
+
+extern void install_dns_check_keyword(void);
+
+#endif

--- a/keepalived/include/layer4.h
+++ b/keepalived/include/layer4.h
@@ -45,16 +45,42 @@ enum connect_result {
 
 /* Prototypes defs */
 extern enum connect_result
- tcp_bind_connect(int, conn_opts_t *);
+ socket_bind_connect(int, conn_opts_t *);
 
 extern enum connect_result
- tcp_connect(int, struct sockaddr_storage *);
+ socket_connect(int, struct sockaddr_storage *);
 
 extern enum connect_result
- tcp_socket_state(thread_t *, int (*func) (thread_t *));
+ socket_state(thread_t *, int (*func) (thread_t *));
 
 extern int
- tcp_connection_state(int, enum connect_result
+ socket_connection_state(int, enum connect_result
 		      , thread_t *, int (*func) (thread_t *)
 		      , long);
+
+/* Backward compatibility */
+static inline enum connect_result
+tcp_bind_connect(int fd, conn_opts_t *co)
+{
+	return socket_bind_connect(fd, co);
+}
+
+static inline enum connect_result
+tcp_connect(int fd, struct sockaddr_storage *addr)
+{
+	return socket_connect(fd, addr);
+}
+
+static inline enum connect_result
+tcp_socket_state(thread_t * thread, int (*func) (thread_t *))
+{
+	return socket_state(thread, func);
+}
+
+static inline int
+tcp_connection_state(int fd, enum connect_result status, thread_t * thread,
+             int (*func) (thread_t *), long timeout)
+{
+	return socket_connection_state(fd, status, thread, func, timeout);
+}
 #endif


### PR DESCRIPTION
Hi,

I implemented DNS helath checker.
It has been running stable for several years in our system.

I want merge it to the built-in health checker.

There is also a way to use MISC_CHECK, but we avoided it for the following reasons.

- MISC_CHECK requires /bin/sh

 MISC_CHECK is using the system(3). It is equivalent to the "/bin/sh -c". Therefore, we can't use MISC_CHECK in environment does not have /bin/sh. It is, e.g. not uncommon in the application container environment.

- Risk of the process increase in MISC_CHECK

 If misc_path of the program has blocked, the process will increase. You can check the symptoms with the following settings.

 ```
MISC_CHECK {
      misc_path "/bin/sleep 3600"
      misc_timeout 10 
}
 ```

 It's results.

 ```
  UID   PID  PPID  PGID   SID COMMAND
    0 41010     1 41010 41010 /sbin/keepalived
    0 41013 41010 41010 41010  \_ /sbin/keepalived
    0 41361 41013 41010 41010  |   \_ /sbin/keepalived
    0 41362 41361 41010 41010  |   |   \_ sh -c /bin/sleep 3600
    0 41363 41362 41010 41010  |   |       \_ /bin/sleep 3600
    0 41364 41013 41010 41010  |   \_ /sbin/keepalived
    0 41365 41364 41010 41010  |   |   \_ sh -c /bin/sleep 3600
    0 41366 41365 41010 41010  |   |       \_ /bin/sleep 3600
    0 41367 41013 41010 41010  |   \_ /sbin/keepalived
    0 41368 41367 41010 41010  |       \_ sh -c /bin/sleep 3600
    0 41369 41368 41010 41010  |           \_ /bin/sleep 3600
    0 41014 41010 41010 41010  \_ /sbin/keepalived
    0 41019     1 41010 41010 sh -c /bin/sleep 3600
    0 41020 41019 41010 41010  \_ /bin/sleep 3600
    0 41025     1 41010 41010 sh -c /bin/sleep 3600
    0 41026 41025 41010 41010  \_ /bin/sleep 3600
    0 41031     1 41010 41010 sh -c /bin/sleep 3600
    0 41032 41031 41010 41010  \_ /bin/sleep 3600
 ```
 MISC_CHECK is calling system(3) after fork(2). In check_misc.c, it's sending SIGTERM and SIGKILL on timeout. However, the signal is received only in the process that called system(3), the subsequent process is not propagated.

 For this matter, I'm going to send the proposal of the pull request.

In preparing the DNS checker, also modified layer4 library. It's added support for implementation of the UDP-based health checker.

I believe to add to the built-in health checker is a good way, given the importance of the DNS.
Please consider the merge of this pull request.

Best regards,
Masaya Yamamoto