### PR TITLE
Add check for PE selection support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -644,6 +644,13 @@ dnl ----[ Checks for glibc SOCK_CLOEXEC support ]----
 # Introduced in Linux 2.6.27 and glibc 2.9
 AC_CHECK_DECLS([SOCK_CLOEXEC], [add_build_opt([SOCK_CLOEXEC])], [],[[#include <sys/socket.h>]])
 
+dnl ----[ Checks for pe support ]----
+AC_CHECK_DECL([IPVS_SVC_ATTR_PE_NAME],
+   [
+     AC_DEFINE([_HAVE_PE_NAME_], [ 1 ], [Define to 1 if have pe selection support])
+   ],
+   [], [[#include <linux/ip_vs.h>]])
+
 dnl ----[ Checks for FIB routing support ]----
 # Introduced in Linux 2.6.19
 SAV_CPPFLAGS="$CPPFLAGS"

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -190,7 +190,7 @@ pto_handler(vector_t *strvec)
 
 	vs->persistence_timeout = timeout;
 }
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 static void
 pengine_handler(vector_t *strvec)
 {
@@ -398,7 +398,7 @@ init_check_keywords(bool active)
 #endif
 	install_keyword("lb_kind", &lbkind_handler);
 	install_keyword("lvs_method", &lbkind_handler);
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	install_keyword("persistence_engine", &pengine_handler);
 #endif
 	install_keyword("persistence_timeout", &pto_handler);

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -425,7 +425,7 @@ ipvs_set_rule(int cmd, virtual_server_t * vs, real_server_t * rs)
 		srule->user.flags &= ~IP_VS_SVC_F_ONEPACKET;
 #endif
 
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	strcpy(srule->pe_name, vs->pe_name);
 #endif
 

--- a/keepalived/check/libipvs.c
+++ b/keepalived/check/libipvs.c
@@ -83,7 +83,7 @@ static struct nla_policy ipvs_service_policy[IPVS_SVC_ATTR_MAX + 1] = {
 	[IPVS_SVC_ATTR_TIMEOUT]		= { .type = NLA_U32 },
 	[IPVS_SVC_ATTR_NETMASK]		= { .type = NLA_U32 },
 	[IPVS_SVC_ATTR_STATS]		= { .type = NLA_NESTED },
-#ifdef IPVS_SVC_ATTR_PE_NAME		/* Since Linux 2.6.37 */
+#ifdef _HAVE_PE_NAME_		/* Since Linux 2.6.37 */
 	[IPVS_SVC_ATTR_PE_NAME]		= { .type = NLA_STRING,
 					    .maxlen = IP_VS_PENAME_MAXLEN }
 #endif
@@ -146,14 +146,14 @@ static struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
 	{ errno = EAFNOSUPPORT; goto out_err; }			\
 	s->user.addr = s->nf_addr.ip;				\
 
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 #define CHECK_PE(s, ret) if (s->pe_name[0])			\
 	{ errno = EAFNOSUPPORT; goto out_err; }
 #endif
 
 #define CHECK_COMPAT_DEST(s, ret) CHECK_IPV4(s, ret)
 
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 #define CHECK_COMPAT_SVC(s, ret)				\
 	CHECK_IPV4(s, ret);					\
 	CHECK_PE(s, ret);
@@ -320,7 +320,7 @@ static int ipvs_nl_fill_service_attr(struct nl_msg *msg, ipvs_service_t *svc)
 	}
 
 	NLA_PUT_STRING(msg, IPVS_SVC_ATTR_SCHED_NAME, svc->user.sched_name);
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	if (svc->pe_name[0])
 		NLA_PUT_STRING(msg, IPVS_SVC_ATTR_PE_NAME, svc->pe_name);
 #endif
@@ -779,7 +779,7 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg)
 		nla_get_string(svc_attrs[IPVS_SVC_ATTR_SCHED_NAME]),
 		IP_VS_SCHEDNAME_MAXLEN);
 
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	if (svc_attrs[IPVS_SVC_ATTR_PE_NAME])
 		strncpy(get->user.entrytable[i].pe_name,
 			nla_get_string(svc_attrs[IPVS_SVC_ATTR_PE_NAME]),
@@ -1059,7 +1059,7 @@ ipvs_get_service_err2:
 	}
 	svc->af = AF_INET;
 	svc->nf_addr.ip = svc->user.addr;
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	svc->pe_name[0] = '\0';
 #endif
 	return svc;

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -120,7 +120,7 @@ typedef struct _virtual_server {
 	char				sched[IP_VS_SCHEDNAME_MAXLEN];
 	uint32_t			flags;
 	uint32_t			persistence_timeout;
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	char				pe_name[IP_VS_PENAME_MAXLEN];
 #endif
 	unsigned			loadbalancing_kind;

--- a/keepalived/include/ip_vs.h
+++ b/keepalived/include/ip_vs.h
@@ -38,7 +38,7 @@ struct ip_vs_service_app {
 	struct ip_vs_service_user user;
 	u_int16_t		af;
 	union nf_inet_addr	nf_addr;
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	char			pe_name[IP_VS_PENAME_MAXLEN];
 #endif
 };
@@ -55,7 +55,7 @@ struct ip_vs_service_entry_app {
 	ip_vs_stats_t		stats;
 	u_int16_t		af;
 	union nf_inet_addr	nf_addr;
-#ifdef IPVS_SVC_ATTR_PE_NAME
+#ifdef _HAVE_PE_NAME_
 	char			pe_name[IP_VS_PENAME_MAXLEN];
 #endif
 


### PR DESCRIPTION
Without this patch, pe selection doesn't work with kernel 3.10 on centos 7.
