### PR TITLE
Fix loading of ipset library when development library not installed

### DIFF
--- a/keepalived/vrrp/vrrp_ipset.c
+++ b/keepalived/vrrp/vrrp_ipset.c
@@ -172,9 +172,12 @@ bool ipset_init(void)
 	if (libipset_handle)
 		return true;
 
-	libipset_handle = dlopen("libipset.so", RTLD_NOW);
+	if (!(libipset_handle = dlopen("libipset.so", RTLD_NOW)) &&
+	    !(libipset_handle = dlopen("libipset.so.3", RTLD_NOW)) &&
+	    !(libipset_handle = dlopen("libipset.so.2", RTLD_NOW))) {
+		/* Generate the most useful error message */
+		dlopen("libipset.so.3", RTLD_NOW);
 
-	if (!libipset_handle) {
 		log_message(LOG_INFO, "Unable to load ipset library - %s", dlerror());
 		return false;
 	}


### PR DESCRIPTION
Issue #435 identified that the wrong library name was being used when
attempting to open the ipset library.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>