### PR TITLE
Implement not accepting packets to VIPs for VRRPv2

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -276,6 +276,9 @@ vrrp_instance <STRING> {		# VRRP instance declaration
 					#  when using mixed IPv4&IPv6 conf
     state MASTER|BACKUP			# Start-up default state
     interface <STRING>			# Binding interface
+    accept				# Allow a non address-owner to process packets
+					# destined to VIPs and eVIPs. For VRRPv3, but
+					# also VRRPv2 if not strict mode.
     track_interface {			# Interfaces state we monitor
       <STRING>
       <STRING>

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -460,7 +460,11 @@ which will transition together on any state change.
         to 192.168.2.0/24 table 1
     }
 
-    accept    # Allow the non-master owner to process the packets destined to VIP
+    # VRRPv3 has an Accept Mode to allow the virtual router when not the address owner to
+    # receive packets address to a VIP. This parameter enables accept mode.
+    # This also works for VRRPv2 unless strict mode is set (RFC 3768 doesn't define an
+    # accept mode 
+    accept
 
     # VRRP will normally preempt a lower priority
     # machine when a higher priority machine comes

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -114,9 +114,7 @@ vrrp_handle_accept_mode(vrrp_t *vrrp, int cmd, bool force)
 #endif
 	struct ipt_handle *h = NULL;
 
-	if ((vrrp->version == VRRP_VERSION_3) &&
-	    (vrrp->base_priority != VRRP_PRIO_OWNER) &&
-	    !vrrp->accept) {
+	if (vrrp->base_priority != VRRP_PRIO_OWNER && !vrrp->accept) {
 		if (__test_bit(LOG_DETAIL_BIT, &debug))
 			log_message(LOG_INFO, "VRRP_Instance(%s) %s protocol %s", vrrp->iname,
 				(cmd == IPADDRESS_ADD) ? "setting" : "removing", "iptable drop rule");
@@ -1894,8 +1892,12 @@ vrrp_complete_instance(vrrp_t * vrrp)
 	if (vrrp->accept) {
 		if (vrrp->version == VRRP_VERSION_2)
 		{
-			log_message(LOG_INFO,"(%s): cannot set accept mode for VRRP version 2", vrrp->iname);
-			vrrp->accept = false;
+			if (vrrp->strict_mode) {
+				log_message(LOG_INFO, "(%s): cannot set accept mode for VRRP version 2 - disabling", vrrp->iname);
+				vrrp->accept = false;
+			}
+			else
+				log_message(LOG_INFO, "(%s): warning - accept mode for VRRP version 2 does not comply with RFC3768", vrrp->iname);
 		}
 		else
 			vrrp->version = VRRP_VERSION_3;
@@ -2209,9 +2211,7 @@ vrrp_complete_instance(vrrp_t * vrrp)
 
 	/* Spin through all our addresses, setting ifindex and ifp.
 	   We also need to know what addresses we might block */
-	if ((vrrp->version == VRRP_VERSION_3) &&
-	    (vrrp->base_priority != VRRP_PRIO_OWNER) &&
-	    !vrrp->accept) {
+	if (vrrp->base_priority != VRRP_PRIO_OWNER && !vrrp->accept) {
 //TODO = we have a problem since SNMP may change accept mode
 //it can also change priority
 		if (vrrp->saddr.ss_family == AF_INET)
@@ -2236,9 +2236,7 @@ vrrp_complete_instance(vrrp_t * vrrp)
 				vip->ifp = vrrp->ifp;
 			}
 
-			if ((vrrp->version == VRRP_VERSION_3) &&
-			    (vrrp->base_priority != VRRP_PRIO_OWNER) &&
-			    !vrrp->accept) {
+			if (vrrp->base_priority != VRRP_PRIO_OWNER && !vrrp->accept) {
 				if (vip->ifa.ifa_family == AF_INET)
 					global_data->block_ipv4 = true;
 				else
@@ -2509,8 +2507,7 @@ clear_diff_vrrp_vip_list(vrrp_t *vrrp, struct ipt_handle* h, list l, list n)
 		return;
 
 	/* Clear iptable rule to VIP if needed. */
-	if ((vrrp->version == VRRP_VERSION_2) || vrrp->accept ||
-	    (vrrp->base_priority == VRRP_PRIO_OWNER)) {
+	if (vrrp->base_priority == VRRP_PRIO_OWNER || vrrp->accept) {
 		handle_iptable_rule_to_iplist(h, n, IPADDRESS_DEL, IF_NAME(vrrp->ifp), false);
 		vrrp->iptable_rules_set = false;
 	} else


### PR DESCRIPTION
Alexandre (@acassen),

Could you have a look at this and make sure you are happy with this. It alters the default behaviour of keepalived so that packets sent to VIPs are discarded (which is what the RFC says should happen, and is already implemented for VRRPv3).