### PR TITLE
Add no_accept mode for VRRPv2 and standardise VRRPv3 with it

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -280,6 +280,11 @@ vrrp_instance <STRING> {		# VRRP instance declaration
 					#  when using mixed IPv4&IPv6 conf
     state MASTER|BACKUP			# Start-up default state
     interface <STRING>			# Binding interface
+    accept				# Allow a non address-owner to process packets
+					# destined to VIPs and eVIPs. This is the default
+					# unless strict mode is set.
+    no_accept				# Set non-accept mode (default if strict mode)
+					#
     track_interface {			# Interfaces state we monitor
       <STRING>
       <STRING>

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -464,7 +464,11 @@ which will transition together on any state change.
         to 192.168.2.0/24 table 1
     }
 
-    accept    # Allow the non-master owner to process the packets destined to VIP
+    # VRRPv3 has an Accept Mode to allow the virtual router when not the address owner to
+    # receive packets addressed to a VIP. This is the default setting unless strict mode is set.
+    # As an extension, this also works for VRRPv2 (RFC 3768 doesn't define an accept mode). 
+    accept		# Accept packets to non address-owner
+    no_accept		# Drop packets to non address-owner.
 
     # VRRP will normally preempt a lower priority
     # machine when a higher priority machine comes

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -406,6 +406,7 @@ alloc_vrrp(char *iname)
 	memcpy(new->iname, iname, size);
 	new->stats = alloc_vrrp_stats();
 	new->quick_sync = 0;
+	new->accept = -1;
 	new->garp_rep = global_data->vrrp_garp_rep;
 	new->garp_refresh = global_data->vrrp_garp_refresh;
 	new->garp_refresh_rep = global_data->vrrp_garp_refresh_rep;

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -713,6 +713,14 @@ vrrp_accept_handler(__attribute__((unused)) vector_t *strvec)
 }
 
 static void
+vrrp_no_accept_handler(__attribute__((unused)) vector_t *strvec)
+{
+	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+
+	vrrp->accept = false;
+}
+
+static void
 garp_group_handler(__attribute__((unused)) vector_t *strvec)
 {
 	alloc_garp_delay();
@@ -858,6 +866,7 @@ init_vrrp_keywords(bool active)
 	install_keyword("virtual_rules", &vrrp_vrules_handler);
 #endif
 	install_keyword("accept", &vrrp_accept_handler);
+	install_keyword("no_accept", &vrrp_no_accept_handler);
 	install_keyword("skip_check_adv_addr", &vrrp_skip_check_adv_addr_handler);
 	install_keyword("strict_mode", &vrrp_strict_mode_handler);
 	install_keyword("preempt", &vrrp_preempt_handler);


### PR DESCRIPTION
Alexandre, @acassen 

This is an update of my previous pull request for making VRRPv2 not accept packets sent to the VIP/eVIPs unless the vrrp instance is the address owner. The default now, for the reason you pointed out that IPVS and other services running on the VIPs need accept mode as default, is that accept is the default unless strict mode is specified for an instance. Accordingly a `no_accept` keyword has been added to allow vrrp instances to behave in accordance with the RFCs.

I have changed the mode of operation for VRRPv3 so that it is now the same as VRRP2; in other words anyone who was using VRRPv3 and wanted packets addressed to the VIPs to be discarded will now have to add `no_accept` to their configuration.

If you're happy with the above approach, could you please merge it.