### PR TITLE
Fix up the code to compile without lvs

### DIFF
--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -163,7 +163,9 @@ alloc_global_data(void)
 		new->enable_snmp_checker = true;
 #endif
 	}
+#ifdef _WITH_LVS_
 	new->lvs_syncd.syncid = PARAMETER_UNSET;
+#endif
 #ifdef _HAVE_IPVS_SYNCD_ATTRIBUTES_
 	new->lvs_syncd.mcast_group.ss_family = AF_UNSPEC;
 #endif

--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -151,7 +151,11 @@ snmp_scalar(struct variable *vp, oid *name, size_t *length,
 		long_ret = global_data->linkbeat_use_polling?2:1;
 		return (u_char *)&long_ret;
 	case SNMP_LVSFLUSH:
+#ifdef _WITH_LVS_
 		long_ret = global_data->lvs_flush?1:2;
+#else
+                long_ret = 2;
+#endif
 		return (u_char *)&long_ret;
 	case SNMP_IPVS_64BIT_STATS:
 #ifdef _WITH_LVS_64BIT_STATS_

--- a/keepalived/include/snmp.h
+++ b/keepalived/include/snmp.h
@@ -46,9 +46,10 @@ int header_generic(struct variable *, oid *, size_t *, int,
 
 #define SNMP_DEFAULT_NETWORK_SOCKET	"udp:localhost:705"
 
-#define KEEPALIVED_OID 1, 3, 6, 1, 4, 1, 9586, 100, 5
-#define SNMPTRAP_OID 1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0
+#define KEEPALIVED_OID {1, 3, 6, 1, 4, 1, 9586, 100, 5}
+#define SNMPTRAP_OID {1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0}
 #define GLOBAL_OID {KEEPALIVED_OID, 1}
+#define VRRP_OID {KEEPALIVED_OID, 2}
 
 typedef union _long_ret {
 	unsigned long u;

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -107,7 +107,6 @@
 #ifdef _WITH_SNMP_KEEPALIVED_
 /* VRRP SNMP defines */
 enum snmp_vrrp_magic {
-	VRRP_OID KEEPALIVED_OID = 2,
 	VRRP_SNMP_SCRIPT_NAME,
 	VRRP_SNMP_SCRIPT_COMMAND,
 	VRRP_SNMP_SCRIPT_INTERVAL,
@@ -1821,13 +1820,18 @@ vrrp_snmp_instance(struct variable *vp, oid *name, size_t *length,
 		return (u_char *)&long_ret;
 
 	case VRRP_SNMP_INSTANCE_USELVSSYNCDAEMON:
+                long_ret.u = 0;
+#ifdef _WITH_LVS_
 		long_ret.u = (global_data->lvs_syncd.vrrp == rt)?1:2;
+#endif
 		return (u_char *)&long_ret;
 	case VRRP_SNMP_INSTANCE_LVSSYNCINTERFACE:
+#ifdef _WITH_LVS_
 		if (global_data->lvs_syncd.vrrp == rt) {
 			*var_len = strlen(global_data->lvs_syncd.ifname);
 			return (u_char *)global_data->lvs_syncd.ifname;
 		}
+#endif
 		break;
 	case VRRP_SNMP_INSTANCE_SYNCGROUP:
 		if (rt->sync) {
@@ -3860,9 +3864,10 @@ static bool
 vrrp_handles_global_oid(void)
 {
 	if (global_data->enable_snmp_keepalived) {
+#ifdef _WITH_LVS_
 		if (!__test_bit(DAEMON_CHECKERS, &daemon_mode) || !global_data->enable_snmp_checker)
 			return true;
-#ifndef _WITH_LVS_
+#else
 		return true;
 #endif
 	}


### PR DESCRIPTION
A few areas were accessing lvs members of the global_data that had been
#ifdefed out. Corrected this. (This is a quick fix up and I'm not so
sure if I've made sensible changes, in particular in core/snmp.c).
Updated the definitions of the KEEPALIVED_OID, and SNMPTRAP_OID. These
were causing some errors in compiling.
Reintroduced VRRP_OID it'd been copied to vrrp_snmp.c by accident.

Signed-off-by: Anthony Dempsey adempsey@brocade.com
