### PR TITLE
Fix clearing addresses no longer used after a reload

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2526,13 +2526,13 @@ vrrp_exist(vrrp_t *old_vrrp)
 			continue;
 
 #ifndef _HAVE_VRRP_VMAC_
-		if (vrrp->ifp == old_vrrp->ifp)
+		if (vrrp->ifp->ifindex == old_vrrp->ifp->ifindex)
 			return vrrp;
 #else
 		if (__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags) != __test_bit(VRRP_VMAC_BIT, &old_vrrp->vmac_flags))
 			continue;
 		if (!__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags)) {
-			if (vrrp->ifp == old_vrrp->ifp)
+			if (vrrp->ifp->ifindex == old_vrrp->ifp->ifindex)
 				return vrrp;
 			continue;
 		}

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -230,7 +230,6 @@ start_vrrp(void)
 		clear_diff_srules();
 		clear_diff_sroutes();
 #endif
-		clear_diff_vrrp();
 		clear_diff_script();
 	}
 	else {
@@ -255,6 +254,11 @@ start_vrrp(void)
 		stop_vrrp(KEEPALIVED_EXIT_CONFIG);
 		return;
 	}
+
+	/* clear_diff_vrrp must be called after vrrp_complete_init, since the latter
+	 * sets ifa_index on the addresses, which is used for the address comparison */
+	if (reload)
+		clear_diff_vrrp();
 
 #ifdef _HAVE_LIBIPTC_
 	iptables_startup();

--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -525,7 +525,7 @@ clear_diff_address(struct ipt_handle *h, list l, list n)
 {
 	ip_address_t *ipaddr;
 	element e;
-	char *addr_str;
+	char addr_str[INET6_ADDRSTRLEN];
 	void *addr;
 	char *iface_name;
 
@@ -537,13 +537,12 @@ clear_diff_address(struct ipt_handle *h, list l, list n)
 	iface_name = IF_NAME(base_if_get_by_ifindex(ipaddr->ifa.ifa_index));
 	/* All addresses removed */
 	if (LIST_ISEMPTY(n)) {
-		log_message(LOG_INFO, "Removing a VIP and e-VIP block");
+		log_message(LOG_INFO, "Removing a complete VIP or e-VIP block");
 		netlink_iplist(l, IPADDRESS_DEL);
 		handle_iptable_rule_to_iplist(h, l, IPADDRESS_DEL, iface_name, false);
 		return;
 	}
 
-	addr_str = (char *) MALLOC(INET6_ADDRSTRLEN);
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		ipaddr = ELEMENT_DATA(e);
 
@@ -566,8 +565,6 @@ clear_diff_address(struct ipt_handle *h, list l, list n)
 				handle_iptable_rule_to_vip(ipaddr, IPADDRESS_DEL, iface_name, h, false);
 		}
 	}
-
-	FREE(addr_str);
 }
 
 /* Clear static ip address */


### PR DESCRIPTION
The address comparison was including ifa_index, but that wasn't being
set up until after clear_diff_vrrp() was called.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>