### PR TITLE
Use correct interface for iptables/ipset entries when not accept mode

### DIFF
--- a/keepalived/include/vrrp_ipaddress.h
+++ b/keepalived/include/vrrp_ipaddress.h
@@ -94,7 +94,7 @@ struct ipt_handle;	// AAGH - TODO
 extern char *ipaddresstos(char *, ip_address_t *);
 extern int netlink_ipaddress(ip_address_t *, int);
 extern bool netlink_iplist(list, int);
-extern void handle_iptable_rule_to_iplist(struct ipt_handle *, list, int, char *, bool force);
+extern void handle_iptable_rule_to_iplist(struct ipt_handle *, list, int, bool force);
 extern void free_ipaddress(void *);
 extern void dump_ipaddress(void *);
 extern ip_address_t *parse_ipaddress(ip_address_t *, char *, int);

--- a/keepalived/include/vrrp_ipset.h
+++ b/keepalived/include/vrrp_ipset.h
@@ -33,6 +33,6 @@ bool has_ipset_setname(struct ipset_session*, const char *);
 bool ipset_init(void);
 struct ipset_session* ipset_session_start(void);
 void ipset_session_end(struct ipset_session*);
-void ipset_entry(struct ipset_session*, int cmd, const ip_address_t*, const char*);
+void ipset_entry(struct ipset_session*, int cmd, const ip_address_t*);
 
 #endif

--- a/keepalived/include/vrrp_iptables.h
+++ b/keepalived/include/vrrp_iptables.h
@@ -43,6 +43,6 @@ void iptables_startup(bool);
 void iptables_cleanup(void);
 struct ipt_handle *iptables_open(void);
 int iptables_close(struct ipt_handle *h);
-void handle_iptable_rule_to_vip(ip_address_t *, int, char *, struct ipt_handle *, bool);
+void handle_iptable_rule_to_vip(ip_address_t *, int, struct ipt_handle *, bool);
 
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -125,9 +125,9 @@ vrrp_handle_accept_mode(vrrp_t *vrrp, int cmd, bool force)
 #endif
 			/* As accept is false, add iptable rule to drop packets destinated to VIPs and eVIPs */
 			if (!LIST_ISEMPTY(vrrp->vip))
-				handle_iptable_rule_to_iplist(h, vrrp->vip, cmd, IF_NAME(vrrp->ifp), force);
+				handle_iptable_rule_to_iplist(h, vrrp->vip, cmd, force);
 			if (!LIST_ISEMPTY(vrrp->evip))
-				handle_iptable_rule_to_iplist(h, vrrp->evip, cmd, IF_NAME(vrrp->ifp), force);
+				handle_iptable_rule_to_iplist(h, vrrp->evip, cmd, force);
 #ifdef _HAVE_LIBIPTC_
 			res = iptables_close(h);
 		} while (res == EAGAIN && ++tries < IPTABLES_MAX_TRIES);
@@ -2558,7 +2558,7 @@ clear_diff_vrrp_vip_list(vrrp_t *vrrp, struct ipt_handle* h, list l, list n)
 
 	/* Clear iptable rule to VIP if needed. */
 	if (vrrp->base_priority == VRRP_PRIO_OWNER || vrrp->accept) {
-		handle_iptable_rule_to_iplist(h, n, IPADDRESS_DEL, IF_NAME(vrrp->ifp), false);
+		handle_iptable_rule_to_iplist(h, n, IPADDRESS_DEL, false);
 		vrrp->iptable_rules_set = false;
 	} else
 		vrrp->iptable_rules_set = true;

--- a/keepalived/vrrp/vrrp_ipset.c
+++ b/keepalived/vrrp/vrrp_ipset.c
@@ -257,22 +257,21 @@ void ipset_session_end(struct ipset_session* session)
 	ipset_session_fini(session);
 }
 
-void ipset_entry(struct ipset_session* session, int cmd, const ip_address_t* addr, const char* iface)
+void ipset_entry(struct ipset_session* session, int cmd, const ip_address_t* addr)
 {
 	const char* set;
+	char *iface = NULL;
 
 	if (addr->ifa.ifa_family == AF_INET)
 		set = global_data->vrrp_ipset_address;
 	else if (IN6_IS_ADDR_LINKLOCAL(&addr->u.sin6_addr)) {
 		set = global_data->vrrp_ipset_address_iface6;
-#ifndef HAVE_IPSET_ATTR_IFACE
-			iface = NULL;
+#ifdef HAVE_IPSET_ATTR_IFACE
+		iface = addr->ifp->ifname;
 #endif
 	}
 	else
 		set = global_data->vrrp_ipset_address6;
-	if (cmd == IPADDRESS_DEL)
-		do_ipset_cmd(session, IPSET_CMD_DEL, set, addr, 0, iface);
-	else
-		do_ipset_cmd(session, IPSET_CMD_ADD, set, addr, 0, iface);
+
+	do_ipset_cmd(session, (cmd == IPADDRESS_DEL) ? IPSET_CMD_DEL : IPSET_CMD_ADD, set, addr, 0, iface);
 }


### PR DESCRIPTION
If an interface was specified for a VIP/eVIP, the iptables/ipset block
if not in accept mode for link local IPV6 addresses was specifying the
interface the vrrp instance was on rather than the interface the address
was added to.

This commit now makes the iptables/ipset entry specify the interface that
the address has been added to.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>