### PR TITLE
Fix illegal syntax in configure script

### DIFF
--- a/configure
+++ b/configure
@@ -7087,8 +7087,8 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 for flag in RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF RTA_VIA FRA_OIFNAME FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID RTAX_CC_ALGO RTAX_QUICKACK; do
-  decl_var=ac_cv_have_decl_$flag
-  if test ${!decl_var} = yes; then
+  eval decl_var=\$ac_cv_have_decl_$flag
+  if test ${decl_var} = yes; then
     BUILD_OPTIONS="$BUILD_OPTIONS "${flag}
   fi
 done

--- a/configure.ac
+++ b/configure.ac
@@ -422,8 +422,8 @@ AC_CHECK_DECLS([RTA_VIA, FRA_OIFNAME], [], [],
     #include <sys/socket.h>
     #include <linux/fib_rules.h>]])
 for flag in RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF RTA_VIA FRA_OIFNAME FRA_SUPPRESS_PREFIXLEN FRA_SUPPRESS_IFGROUP FRA_TUN_ID RTAX_CC_ALGO RTAX_QUICKACK; do
-  decl_var=ac_cv_have_decl_$flag
-  if test ${!decl_var} = yes; then
+  AS_VAR_COPY([decl_var], [ac_cv_have_decl_$flag])
+  if test ${decl_var} = yes; then
     add_build_opt[${flag}]
   fi
 done


### PR DESCRIPTION
Indirect expansion (`${!foo}`) is a bashism, it's not POSIX-sh
compatible and is not supported by common shells except Bash and ZSH!
Configure script should be portable, hence strictly POSIX compliant.
Moreover it has shebang /bin/sh.