### PR TITLE
Terminate child processes if parent dies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,7 +230,7 @@ AC_SUBST(KA_LIBS)
 # Checks for libraries.
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h syslog.h unistd.h],
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/ioctl.h sys/param.h sys/prctl.h sys/socket.h sys/time.h syslog.h unistd.h],
   [], [AC_MSG_ERROR([Missing/unusable system header file <$ac_header>])])
 
 # check for kernel headers

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -23,6 +23,7 @@
 #include "config.h"
 
 #include <string.h>
+#include <sys/prctl.h>
 
 #include "check_daemon.h"
 #include "check_parser.h"
@@ -307,6 +308,7 @@ start_check_child(void)
 				 pid, RESPAWN_TIMER);
 		return 0;
 	}
+	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
 	if ((instance_name
 #if HAVE_DECL_CLONE_NEWNET

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -23,6 +23,7 @@
 #include "config.h"
 
 #include <string.h>
+#include <sys/prctl.h>
 
 #include "vrrp_daemon.h"
 #include "vrrp_scheduler.h"
@@ -472,6 +473,7 @@ start_vrrp_child(void)
 				 pid, RESPAWN_TIMER);
 		return 0;
 	}
+	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
 	signal_handler_destroy();
 


### PR DESCRIPTION
If the parent keepalived process is killed, the child processes will
be orphaned and can cause problem when attempting to restart
keepalived. This patch makes use of prctl with PR_SET_PDEATHSIG such
that all child processes will receive SIGTERM if the parent process
dies.

Signed-off-by: Ryan O'Hara <rohara@redhat.com>