### PR TITLE
Fix building on Centos 7/RHEL 7 re lightweight tunnel encapsulation

### DIFF
--- a/configure
+++ b/configure
@@ -7093,6 +7093,38 @@ for flag in RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF RTA_VIA FRA_OIFNAME FRA_SU
   fi
 done
 
+ac_fn_c_check_decl "$LINENO" "LWTUNNEL_ENCAP_MPLS" "ac_cv_have_decl_LWTUNNEL_ENCAP_MPLS" "#include <linux/lwtunnel.h>
+"
+if test "x$ac_cv_have_decl_LWTUNNEL_ENCAP_MPLS" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_LWTUNNEL_ENCAP_MPLS $ac_have_decl
+_ACEOF
+ac_fn_c_check_decl "$LINENO" "LWTUNNEL_ENCAP_ILA" "ac_cv_have_decl_LWTUNNEL_ENCAP_ILA" "#include <linux/lwtunnel.h>
+"
+if test "x$ac_cv_have_decl_LWTUNNEL_ENCAP_ILA" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_LWTUNNEL_ENCAP_ILA $ac_have_decl
+_ACEOF
+
+if test ${ac_cv_have_decl_RTA_ENCAP}; then
+  for flag in LWTUNNEL_ENCAP_MPLS LWTUNNEL_ENCAP_ILA; do
+    eval decl_var=\$ac_cv_have_decl_$flag
+    if test ${decl_var} = yes; then
+      BUILD_OPTIONS="$BUILD_OPTIONS "${flag}
+    fi
+  done
+fi
+
 if test $NETLINK_VER -eq 3; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for net/if.h and libnl3/netlink/route/link.h namespace collision" >&5
 $as_echo_n "checking for net/if.h and libnl3/netlink/route/link.h namespace collision... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -428,6 +428,18 @@ for flag in RTA_ENCAP RTA_EXPIRES RTA_NEWDST RTA_PREF RTA_VIA FRA_OIFNAME FRA_SU
   fi
 done
 
+dnl -- RedHat backported ENCAP_IP and ENCAP_IP6 without MPLS and ILA
+AC_CHECK_DECLS([LWTUNNEL_ENCAP_MPLS, LWTUNNEL_ENCAP_ILA], [], [],
+  [[#include <linux/lwtunnel.h>]])
+if test ${ac_cv_have_decl_RTA_ENCAP}; then
+  for flag in LWTUNNEL_ENCAP_MPLS LWTUNNEL_ENCAP_ILA; do
+    AS_VAR_COPY([decl_var], [ac_cv_have_decl_$flag])
+    if test ${decl_var} = yes; then
+      add_build_opt[${flag}]
+    fi
+  done
+fi
+
 dnl ----[Check if have net/if.h and netlink/route/link.h namespace collision]----
 dnl -- Resolved in libnl3-3.2.26 (release 30/3/2015)
 if test $NETLINK_VER -eq 3; then

--- a/keepalived/include/vrrp_ip_rule_route_parser.h
+++ b/keepalived/include/vrrp_ip_rule_route_parser.h
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <linux/rtnetlink.h>
-#if HAVE_DECL_RTA_ENCAP
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 #include "vrrp_iproute.h"
 #endif
 
@@ -37,7 +37,7 @@ extern bool get_u16(uint16_t *, const char *, uint16_t, const char*);
 extern bool get_u64(uint64_t *, const char *, uint64_t, const char*);
 extern bool get_time_rtt(uint32_t *, const char *, bool *);
 extern bool get_addr64(uint64_t *, const char *);
-#if HAVE_DECL_RTA_ENCAP
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 extern bool parse_mpls_address(const char *, encap_mpls_t *);
 #endif
 

--- a/keepalived/include/vrrp_iproute.h
+++ b/keepalived/include/vrrp_iproute.h
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include <arpa/inet.h>
 //#include <linux/rtnetlink.h>
-#if HAVE_DECL_RTA_ENCAP
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 #include <linux/mpls.h>
 #endif
 #include <stdbool.h>
@@ -57,6 +57,7 @@ enum iproute_encap {
 #define	IPROUTE_BIT_ENCAP_TTL		(1<<IPROUTE_ENCAP_TTL)
 #define	IPROUTE_BIT_ENCAP_FLAGS		(1<<IPROUTE_ENCAP_FLAGS)
 
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 #define MAX_MPLS_LABELS	2
 typedef struct mpls_label mpls_labels[MAX_MPLS_LABELS];
 
@@ -64,6 +65,7 @@ typedef struct _encap_mpls {
 	mpls_labels	addr;
 	size_t		num_labels;
 } encap_mpls_t;
+#endif
 
 typedef struct _encap_ip {
 	uint64_t	id;
@@ -74,9 +76,11 @@ typedef struct _encap_ip {
 	uint8_t		ttl;
 } encap_ip_t;
 
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 typedef struct _encap_ila {
 	uint64_t	locator;
 } encap_ila_t;
+#endif
 
 typedef struct _encap_ip6 {
 	uint64_t	id;
@@ -91,9 +95,13 @@ typedef struct _encap {
 	uint16_t	type;
 	uint32_t	flags;
 	union {
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 		encap_mpls_t	mpls;
+#endif
 		encap_ip_t	ip;
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 		encap_ila_t	ila;
+#endif
 		encap_ip6_t	ip6;
 	};
 } encap_t;

--- a/keepalived/vrrp/vrrp_ip_rule_route_parser.c
+++ b/keepalived/vrrp/vrrp_ip_rule_route_parser.c
@@ -254,7 +254,7 @@ get_addr64(uint64_t *ap, const char *cp)
 	return false;
 }
 
-#if HAVE_DECL_RTA_ENCAP
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 bool
 parse_mpls_address(const char *str, encap_mpls_t *mpls)
 {

--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -39,8 +39,12 @@
 #include <linux/rtnetlink.h>
 #if HAVE_DECL_RTA_ENCAP
 #include <linux/lwtunnel.h>
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 #include <linux/mpls_iptunnel.h>
+#endif
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 #include <linux/ila.h>
+#endif
 #endif
 
 /* Buffer sizes for netlink messages. Increase if needed. */
@@ -144,11 +148,13 @@ add_addrfam2rta(struct rtattr *rta, size_t maxlen, unsigned short type, ip_addre
 #endif
 
 #if HAVE_DECL_RTA_ENCAP
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 static void
 add_encap_mpls(struct rtattr *rta, size_t len, const encap_t *encap)
 {
 	rta_addattr_l(rta, len, MPLS_IPTUNNEL_DST, &encap->mpls.addr, encap->mpls.num_labels * sizeof(encap->mpls.addr[0]));
 }
+#endif
 
 static void
 add_encap_ip(struct rtattr *rta, size_t len, const encap_t *encap)
@@ -167,11 +173,13 @@ add_encap_ip(struct rtattr *rta, size_t len, const encap_t *encap)
 		rta_addattr16(rta, len, LWTUNNEL_IP_FLAGS, encap->ip.flags);
 }
 
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 static void
 add_encap_ila(struct rtattr *rta, size_t len, const encap_t *encap)
 {
 	rta_addattr64(rta, len, ILA_ATTR_LOCATOR, encap->ila.locator);
 }
+#endif
 
 static void
 add_encap_ip6(struct rtattr *rta, size_t len, const encap_t *encap)
@@ -197,15 +205,19 @@ add_encap(struct rtattr *rta, size_t len, encap_t *encap)
 
 	nest = rta_nest(rta, len, RTA_ENCAP);
 	switch (encap->type) {
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 	case LWTUNNEL_ENCAP_MPLS:
 		add_encap_mpls(rta, len, encap);
 		break;
+#endif
 	case LWTUNNEL_ENCAP_IP:
 		add_encap_ip(rta, len, encap);
 		break;
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 	case LWTUNNEL_ENCAP_ILA:
 		add_encap_ila(rta, len, encap);
 		break;
+#endif
 	case LWTUNNEL_ENCAP_IP6:
 		add_encap_ip6(rta, len, encap);
 		break;
@@ -563,6 +575,7 @@ free_iproute(void *rt_data)
 }
 
 #if HAVE_DECL_RTA_ENCAP
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 static size_t
 print_encap_mpls(char *op, size_t len, const encap_t* encap)
 {
@@ -576,6 +589,7 @@ print_encap_mpls(char *op, size_t len, const encap_t* encap)
 
 	return (size_t)(op - buf);
 }
+#endif
 
 static size_t
 print_encap_ip(char *op, size_t len, const encap_t* encap)
@@ -601,11 +615,13 @@ print_encap_ip(char *op, size_t len, const encap_t* encap)
 	return (size_t)(op - buf);
 }
 
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 static size_t
 print_encap_ila(char *op, size_t len, const encap_t* encap)
 {
 	return (size_t)snprintf(op, len, " encap ila %" PRIu64, encap->ila.locator);
 }
+#endif
 
 static size_t
 print_encap_ip6(char *op, size_t len, const encap_t* encap)
@@ -635,12 +651,16 @@ static size_t
 print_encap(char *op, size_t len, const encap_t* encap)
 {
 	switch (encap->type) {
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 	case LWTUNNEL_ENCAP_MPLS:
 		return print_encap_mpls(op, len, encap);
+#endif
 	case LWTUNNEL_ENCAP_IP:
 		return print_encap_ip(op, len, encap);
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 	case LWTUNNEL_ENCAP_ILA:
 		return print_encap_ila(op, len, encap);
+#endif
 	case LWTUNNEL_ENCAP_IP6:
 		return print_encap_ip6(op, len, encap);
 	}
@@ -867,6 +887,7 @@ dump_iproute(void *rt_data)
 }
 
 #if HAVE_DECL_RTA_ENCAP
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 static int parse_encap_mpls(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
 {
 	char *str;
@@ -886,6 +907,7 @@ static int parse_encap_mpls(vector_t *strvec, unsigned int *i_ptr, encap_t *enca
 
 	return false;
 }
+#endif
 
 static int parse_encap_ip(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
 {
@@ -963,6 +985,7 @@ err:
 	return true;
 }
 
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 static
 int parse_encap_ila(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
 {
@@ -984,6 +1007,7 @@ int parse_encap_ila(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
 
 	return false;
 }
+#endif
 
 static
 int parse_encap_ip6(vector_t *strvec, unsigned int *i_ptr, encap_t *encap)
@@ -1072,14 +1096,18 @@ parse_encap(vector_t *strvec, unsigned int *i, encap_t *encap)
 
 	str = strvec_slot(strvec, (*i)++);
 
-	if (!strcmp(str, "mpls"))
-		parse_encap_mpls(strvec, i, encap);
-	else if (!strcmp(str, "ip"))
+	if (!strcmp(str, "ip"))
 		parse_encap_ip(strvec, i, encap);
 	else if (!strcmp(str, "ip6"))
 		parse_encap_ip6(strvec, i, encap);
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
+	else if (!strcmp(str, "mpls"))
+		parse_encap_mpls(strvec, i, encap);
+#endif
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 	else if (!strcmp(str, "ila"))
 		parse_encap_ila(strvec, i, encap);
+#endif
 	else {
 		log_message(LOG_INFO, "Unknown encap type - %s", str);
 		return false;

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -1104,7 +1104,9 @@ static u_char*
 vrrp_snmp_encap(struct variable *vp, oid *name, size_t *length,
 		 int exact, size_t *var_len, WriteMethod **write_method)
 {
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 	static char labels[11*MAX_MPLS_LABELS];
+#endif
 	char *op;
 	ip_route_t *route;
 	nexthop_t *nh;
@@ -1134,16 +1136,7 @@ vrrp_snmp_encap(struct variable *vp, oid *name, size_t *length,
 			return (u_char *)&long_ret;
 		}
 
-		if (encap->type == LWTUNNEL_ENCAP_MPLS) {
-			if (vp->magic == VRRP_SNMP_ROUTE_ENCAP_MPLS_LABELS) {
-				op = labels;
-				for (i = 0; i < encap->mpls.num_labels; i++)
-					op += snprintf(op, (size_t)(labels + sizeof(labels) - op), "%s%u", i ? "/" : "", encap->mpls.addr[i].entry);
-				*var_len = strlen(labels);
-				return (u_char *)labels;
-			}
-		}
-		else if (encap->type == LWTUNNEL_ENCAP_IP ||
+		if (encap->type == LWTUNNEL_ENCAP_IP ||
 			 encap->type == LWTUNNEL_ENCAP_IP6) {
 			switch(vp->magic) {
 			case VRRP_SNMP_ROUTE_ENCAP_ID:
@@ -1187,6 +1180,18 @@ vrrp_snmp_encap(struct variable *vp, oid *name, size_t *length,
 				return (u_char *)&long_ret;
 			}
 		}
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
+		else if (encap->type == LWTUNNEL_ENCAP_MPLS) {
+			if (vp->magic == VRRP_SNMP_ROUTE_ENCAP_MPLS_LABELS) {
+				op = labels;
+				for (i = 0; i < encap->mpls.num_labels; i++)
+					op += snprintf(op, (size_t)(labels + sizeof(labels) - op), "%s%u", i ? "/" : "", encap->mpls.addr[i].entry);
+				*var_len = strlen(labels);
+				return (u_char *)labels;
+			}
+		}
+#endif
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 		else if (encap->type == LWTUNNEL_ENCAP_ILA) {
 			if (vp->magic == VRRP_SNMP_ROUTE_ENCAP_ILA_LOCATOR) {
 				*var_len = sizeof(c64);
@@ -1194,6 +1199,7 @@ vrrp_snmp_encap(struct variable *vp, oid *name, size_t *length,
 				return (u_char *)&c64;
 			}
 		}
+#endif
 	}
 
 	/* If we are here, we asked for a non existent data. Try the
@@ -2273,8 +2279,10 @@ static struct variable8 vrrp_vars[] = {
 #if HAVE_DECL_RTA_ENCAP
 	{VRRP_SNMP_ROUTE_ENCAP_TYPE, ASN_INTEGER, RONLY,
 	 vrrp_snmp_encap, 3, {7, 1, 46}},
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 	{VRRP_SNMP_ROUTE_ENCAP_MPLS_LABELS, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_encap, 3, {7, 1, 47}},
+#endif
 	{VRRP_SNMP_ROUTE_ENCAP_ID, ASN_COUNTER64, RONLY,
 	 vrrp_snmp_encap, 3, {7, 1, 48}},
 	{VRRP_SNMP_ROUTE_ENCAP_DST_ADDRESS, ASN_OCTET_STR, RONLY,
@@ -2287,8 +2295,10 @@ static struct variable8 vrrp_vars[] = {
 	 vrrp_snmp_encap, 3, {7, 1, 52}},
 	{VRRP_SNMP_ROUTE_ENCAP_FLAGS, ASN_UNSIGNED, RONLY,
 	 vrrp_snmp_encap, 3, {7, 1, 53}},
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 	{VRRP_SNMP_ROUTE_ENCAP_ILA_LOCATOR, ASN_COUNTER64, RONLY,
 	 vrrp_snmp_encap, 3, {7, 1, 54}},
+#endif
 #endif
 
 	 /* vrrpRuleTable */
@@ -2380,8 +2390,10 @@ static struct variable8 vrrp_vars[] = {
 #if HAVE_DECL_RTA_ENCAP
 	{VRRP_SNMP_ROUTE_NEXT_HOP_ENCAP_TYPE, ASN_INTEGER, RONLY,
 	 vrrp_snmp_encap, 3, {11, 1, 10}},
+#if HAVE_DECL_LWTUNNEL_ENCAP_MPLS
 	{VRRP_SNMP_ROUTE_NEXT_HOP_ENCAP_MPLS_LABELS, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_encap, 3, {11, 1, 11}},
+#endif
 	{VRRP_SNMP_ROUTE_NEXT_HOP_ENCAP_ID, ASN_COUNTER64, RONLY,
 	 vrrp_snmp_encap, 3, {11, 1, 12}},
 	{VRRP_SNMP_ROUTE_NEXT_HOP_ENCAP_DST_ADDRESS, ASN_OCTET_STR, RONLY,
@@ -2394,8 +2406,10 @@ static struct variable8 vrrp_vars[] = {
 	 vrrp_snmp_encap, 3, {11, 1, 16}},
 	{VRRP_SNMP_ROUTE_NEXT_HOP_ENCAP_FLAGS, ASN_UNSIGNED, RONLY,
 	 vrrp_snmp_encap, 3, {11, 1, 17}},
+#if HAVE_DECL_LWTUNNEL_ENCAP_ILA
 	{VRRP_SNMP_ROUTE_NEXT_HOP_ENCAP_ILA_LOCATOR, ASN_COUNTER64, RONLY,
 	 vrrp_snmp_encap, 3, {11, 1, 18}},
+#endif
 #endif
 #endif
 };

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -110,6 +110,14 @@
    0 if you don't. */
 #undef HAVE_DECL_IP_VS_SVC_F_ONEPACKET
 
+/* Define to 1 if you have the declaration of `LWTUNNEL_ENCAP_ILA', and to 0
+   if you don't. */
+#undef HAVE_DECL_LWTUNNEL_ENCAP_ILA
+
+/* Define to 1 if you have the declaration of `LWTUNNEL_ENCAP_MPLS', and to 0
+   if you don't. */
+#undef HAVE_DECL_LWTUNNEL_ENCAP_MPLS
+
 /* Define to 1 if you have the declaration of `MACVLAN_MODE_PRIVATE', and to 0
    if you don't. */
 #undef HAVE_DECL_MACVLAN_MODE_PRIVATE


### PR DESCRIPTION
RedHat have partially backported lightweight tunnel encapsulation
into their kernel, but not included MPLS or ILA. We need to have
conditional compilation for LWTUNNEL_ENCAP_MPLS and LWTUNNEL_ENCAP_ILA
rather than just checking for RTA_ENCAP.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>