### PR TITLE
Issue: #484 Set vrrp script default value to 2 as defined by the documentation in…

### DIFF
--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -43,7 +43,7 @@
 /* VRRP script tracking defaults */
 #define VRRP_SCRIPT_DI 1	/* external script track interval (in sec) */
 #define VRRP_SCRIPT_DT 0	/* external script track timeout (in sec) */
-#define VRRP_SCRIPT_DW 0	/* external script default weight */
+#define VRRP_SCRIPT_DW 2	/* external script default weight */
 
 /* VRRP script tracking results.
  * The result is an integer between 0 and rise-1 to indicate a DOWN state,


### PR DESCRIPTION
… keepalived.conf.SYNOPSIS