### PR TITLE
Fix missing documentation for 4th parameter of notify action

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -309,6 +309,7 @@ and
     # $2 = name of the group or instance
     # $3 = target state of transition
     #     ("MASTER"|"BACKUP"|"FAULT")
+    # $4 = priority value
     notify /path/notify.sh [username [groupname]]
 
     # Send email notification during state transition,


### PR DESCRIPTION
Spent a good while trying to track down why my script wasn't executing (it was checking for 3 parameters and exiting if it didn't receive them).

The `notify_*` action documentation includes the $4 parameter (priority), but it was missing for the catch-all `notify` action.