### PR TITLE
ipwrapper.c: make functions void if return value not used or constant

### DIFF
--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -57,7 +57,7 @@ weigh_live_realservers(virtual_server_t * vs)
 }
 
 /* Remove a realserver IPVS rule */
-static int
+static void
 clear_service_rs(virtual_server_t * vs, list l)
 {
 	element e;
@@ -112,12 +112,10 @@ clear_service_rs(virtual_server_t * vs, list l)
 			}
 		}
 	}
-
-	return 1;
 }
 
 /* Remove a virtualserver IPVS rule */
-static bool
+static void
 clear_service_vs(virtual_server_t * vs)
 {
 	/* Processing real server queue */
@@ -125,15 +123,14 @@ clear_service_vs(virtual_server_t * vs)
 		if (vs->s_svr) {
 			if (ISALIVE(vs->s_svr))
 				ipvs_cmd(LVS_CMD_DEL_DEST, vs, vs->s_svr);
-		} else if (!clear_service_rs(vs, vs->rs))
-			return false;
+		} else
+			clear_service_rs(vs, vs->rs);
 		/* The above will handle Omega case for VS as well. */
 	}
 
 	ipvs_cmd(LVS_CMD_DEL, vs, NULL);
 
 	UNSET_ALIVE(vs);
-	return true;
 }
 
 /* IPVS cleaner processing */
@@ -146,8 +143,7 @@ clear_services(void)
 
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		vs = ELEMENT_DATA(e);
-		if (!clear_service_vs(vs))
-			return;
+		clear_service_vs(vs);
 	}
 }
 
@@ -325,13 +321,11 @@ update_quorum_state(virtual_server_t * vs)
 #endif
 		return;
 	}
-
-	/* If we have just lost quorum for the VS, we need to consider
-	 * VS notify_down and sorry_server cases
-	 */
-	if (vs->quorum_state == UP &&
-	    (!weight_sum || weight_sum < down_threshold)
-	) {
+	else if (vs->quorum_state == UP &&
+		 (!weight_sum || weight_sum < down_threshold)) {
+		/* We have just lost quorum for the VS, we need to consider
+		 * VS notify_down and sorry_server cases
+		 */
 		vs->quorum_state = DOWN;
 		log_message(LOG_INFO, "Lost quorum %u-%u=%ld > %ld for VS %s"
 				    , vs->quorum
@@ -349,21 +343,21 @@ update_quorum_state(virtual_server_t * vs)
 		check_snmp_quorum_trap(vs);
 #endif
 	}
-	if (vs->quorum_state == DOWN) {
-		if (vs->s_svr && !ISALIVE(vs->s_svr)) {
-			log_message(LOG_INFO, "%s sorry server %s to VS %s"
-					    , (vs->s_svr->inhibit ? "Enabling" : "Adding")
-					    , FMT_RS(vs->s_svr)
-					    , FMT_VS(vs));
 
-			/* the sorry server is now up in the pool, we flag it alive */
-			ipvs_cmd(LVS_CMD_ADD_DEST, vs, vs->s_svr);
-			vs->s_svr->alive = true;
+	if (vs->quorum_state == DOWN &&
+	    vs->s_svr &&
+	    !ISALIVE(vs->s_svr)) {
+		log_message(LOG_INFO, "%s sorry server %s to VS %s"
+				    , (vs->s_svr->inhibit ? "Enabling" : "Adding")
+				    , FMT_RS(vs->s_svr)
+				    , FMT_VS(vs));
 
-			/* Remove remaining alive real servers */
-			perform_quorum_state(vs, false);
-		}
-		return;
+		/* the sorry server is now up in the pool, we flag it alive */
+		ipvs_cmd(LVS_CMD_ADD_DEST, vs, vs->s_svr);
+		vs->s_svr->alive = true;
+
+		/* Remove remaining alive real servers */
+		perform_quorum_state(vs, false);
 	}
 }
 
@@ -628,7 +622,7 @@ rs_exist(real_server_t * old_rs, list l)
 }
 
 /* Clear the diff rs of the old vs */
-static int
+static void
 clear_diff_rs(virtual_server_t * old_vs, list new_rs_list)
 {
 	element e;
@@ -637,7 +631,7 @@ clear_diff_rs(virtual_server_t * old_vs, list new_rs_list)
 
 	/* If old vs didn't own rs then nothing return */
 	if (LIST_ISEMPTY(l))
-		return 1;
+		return;
 
 	/* remove RS from old vs which are not found in new vs */
 	list rs_to_remove = alloc_list (NULL, NULL);
@@ -683,31 +677,30 @@ clear_diff_rs(virtual_server_t * old_vs, list new_rs_list)
 			}
 		}
 	}
-	int ret = clear_service_rs (old_vs, rs_to_remove);
+	clear_service_rs (old_vs, rs_to_remove);
 	free_list(&rs_to_remove);
-
-	return ret;
 }
 
 /* clear sorry server, but only if changed */
-int
-clear_diff_s_srv(virtual_server_t * old_vs, real_server_t * new_rs)
+static void
+clear_diff_s_srv(virtual_server_t *old_vs, real_server_t *new_rs)
 {
-	real_server_t * old_rs = old_vs->s_svr;
+	real_server_t *old_rs = old_vs->s_svr;
 
-	if (old_rs && new_rs && RS_ISEQ(old_rs, new_rs)) {
+	if (!old_rs)
+		return;
+
+	if (new_rs && RS_ISEQ(old_rs, new_rs)) {
 		/* which fields are really used on s_svr? */
 		new_rs->alive = old_rs->alive;
 		new_rs->set = old_rs->set;
 		new_rs->weight = old_rs->weight;
 		new_rs->pweight = old_rs->iweight;
 		new_rs->reloaded = true;
-		return 1;
 	}
-	if (old_rs && ISALIVE(old_rs))
+	else if (ISALIVE(old_rs))
 		ipvs_cmd(LVS_CMD_DEL_DEST, old_vs, old_rs);
 
-	return 1;
 }
 
 /* When reloading configuration, remove negative diff entries
@@ -739,8 +732,7 @@ clear_diff_services(void)
 				log_message(LOG_INFO, "Removing Virtual Server %s", FMT_VS(vs));
 
 			/* Clear VS entry */
-			if (!clear_service_vs(vs))
-				return;
+			clear_service_vs(vs);
 		} else {
 			/* copy status fields from old VS */
 			SET_ALIVE(new_vs);
@@ -754,10 +746,8 @@ clear_diff_services(void)
 			/* omega = false must not prevent the notifiers from being called,
 			   because the VS still exists in new configuration */
 			vs->omega = true;
-			if (!clear_diff_rs(vs, new_vs->rs))
-				return;
-			if (!clear_diff_s_srv(vs, new_vs->s_svr))
-				return;
+			clear_diff_rs(vs, new_vs->rs);
+			clear_diff_s_srv(vs, new_vs->s_svr);
 		}
 	}
 }


### PR DESCRIPTION
Several functions in check/ipwrapper.c were always returnung the same
value, and the code calling the functions then checked and returned an
error if the return value was not the value always returned. Also, for
some functions returning a value the return value was never checked in
the calling function.

Making the functions void, and removing the if (...) makes the code easier
to read, and potentially slightly more efficient.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>