### PR TITLE
allow to override build date

### DIFF
--- a/configure
+++ b/configure
@@ -8973,7 +8973,6 @@ fi
 
 echo $INIT_TYPE
 VERSION_DATE=`date +%m/%d,%Y`
-VERSION_YEAR=`date +%Y`
 
 
 cat >>confdefs.h <<_ACEOF
@@ -8982,7 +8981,7 @@ _ACEOF
 
 
 cat >>confdefs.h <<_ACEOF
-#define COPYRIGHT_YEAR "$VERSION_YEAR"
+#define COPYRIGHT_YEAR "2017"
 _ACEOF
 
 

--- a/configure
+++ b/configure
@@ -8972,7 +8972,9 @@ fi
 
 
 echo $INIT_TYPE
-VERSION_DATE=`date +%m/%d,%Y`
+DATE_FMT="+%m/%d,%Y"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+VERSION_DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT")
 
 
 cat >>confdefs.h <<_ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -1066,10 +1066,9 @@ AM_CONDITIONAL([INIT_SYSV], [test $INIT_TYPE = SYSV])
 
 echo $INIT_TYPE
 VERSION_DATE=`date +%m/%d,%Y`
-VERSION_YEAR=`date +%Y`
 
 AC_DEFINE_UNQUOTED([VERSION_DATE], ["$VERSION_DATE"], [Date of build configuration])
-AC_DEFINE_UNQUOTED([COPYRIGHT_YEAR], ["$VERSION_YEAR"], [Year of build configuration])
+AC_DEFINE_UNQUOTED([COPYRIGHT_YEAR], ["2017"], [Year of build configuration])
 AC_DEFINE_UNQUOTED([CONFIGURATION_OPTIONS], ["$BUILD_OPTIONS"], [The configuration and build options from which the package is built])
 
 if test $NETLINK_VER -eq 0; then

--- a/configure.ac
+++ b/configure.ac
@@ -1065,7 +1065,9 @@ AM_CONDITIONAL([INIT_SYSTEMD], [test $INIT_TYPE = systemd])
 AM_CONDITIONAL([INIT_SYSV], [test $INIT_TYPE = SYSV])
 
 echo $INIT_TYPE
-VERSION_DATE=`date +%m/%d,%Y`
+DATE_FMT="+%m/%d,%Y"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+VERSION_DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+$DATE_FMT" 2>/dev/null || date -u "+$DATE_FMT")
 
 AC_DEFINE_UNQUOTED([VERSION_DATE], ["$VERSION_DATE"], [Date of build configuration])
 AC_DEFINE_UNQUOTED([COPYRIGHT_YEAR], ["2017"], [Year of build configuration])


### PR DESCRIPTION
to enable reproducible builds.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

note that the configure part is tested, but the configure.ac part is not
The date call is supposed to work with both GNU date and BSD date.