### PR TITLE
Improved handling  of IPVS with IPv6

### DIFF
--- a/configure
+++ b/configure
@@ -6909,7 +6909,7 @@ if test "x$ac_cv_header_linux_rtnetlink_h" = xyes; then :
 _ACEOF
 
 else
-  as_fn_error $? "Unusable link/rtnetlink.h" "$LINENO" 5
+  as_fn_error $? "Unusable linux/rtnetlink.h" "$LINENO" 5
 fi
 
 done
@@ -10620,3 +10620,9 @@ echo "init type                : ${INIT_TYPE}"
 echo "Build genhash            : ${BUILD_GENHASH}"
 echo "Build documentation      : ${HAVE_SPHINX_BUILD}"
 
+
+if test ${IPVS_SUPPORT} = Yes -a ${IPVS_USE_NL} = No; then
+  echo
+  echo "*** WARNING - this build will not support IPVS with IPv6. Please install libnl/libnl-3 dev libraries to support IPv6 with IPVS."
+  echo
+fi

--- a/configure
+++ b/configure
@@ -809,6 +809,7 @@ enable_vrrp_auth
 enable_routes
 enable_libiptc
 enable_libipset
+enable_libnl
 enable_mem_check
 enable_mem_check_log
 enable_debug
@@ -1473,6 +1474,7 @@ Optional Features:
   --disable-routes        compile without ip rules/routes
   --disable-libiptc       compile without libiptc
   --disable-libipset      compile without libipset
+  --disable-libnl         compile without libnl
   --enable-mem-check      compile with memory alloc checking
   --enable-mem-check-log  compile with memory alloc checking wriging to syslog
   --enable-debug          compile with debugging flags
@@ -3469,6 +3471,11 @@ fi
 # Check whether --enable-libipset was given.
 if test "${enable_libipset+set}" = set; then :
   enableval=$enable_libipset;
+fi
+
+# Check whether --enable-libnl was given.
+if test "${enable_libnl+set}" = set; then :
+  enableval=$enable_libnl;
 fi
 
 # Check whether --enable-mem-check was given.
@@ -6506,7 +6513,8 @@ fi
 
 NETLINK_VER=0
 IPVS_USE_NL=No
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_alloc in -lnl-3" >&5
+if test .${enable_libnl} != .no; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_alloc in -lnl-3" >&5
 $as_echo_n "checking for nl_socket_alloc in -lnl-3... " >&6; }
 if ${ac_cv_lib_nl_3_nl_socket_alloc+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6544,12 +6552,12 @@ fi
 $as_echo "$ac_cv_lib_nl_3_nl_socket_alloc" >&6; }
 if test "x$ac_cv_lib_nl_3_nl_socket_alloc" = xyes; then :
 
-    NETLINK_VER=3
+      NETLINK_VER=3
 
 $as_echo "#define _HAVE_LIBNL3_  1 " >>confdefs.h
 
-    BUILD_OPTIONS="$BUILD_OPTIONS LIBNL3"
-     if test 1 -ge 2; then
+      BUILD_OPTIONS="$BUILD_OPTIONS LIBNL3"
+       if test 1 -ge 2; then
       KA_PKG_PFX=
     else
       KA_PKG_PFX=KA
@@ -6586,7 +6594,7 @@ $as_echo "#define _HAVE_LIBNL3_  1 " >>confdefs.h
 
 
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for genl_connect in -lnl-genl-3" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for genl_connect in -lnl-genl-3" >&5
 $as_echo_n "checking for genl_connect in -lnl-genl-3... " >&6; }
 if ${ac_cv_lib_nl_genl_3_genl_connect+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6633,8 +6641,8 @@ else
   as_fn_error $? "libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3/libnl-genl-3." "$LINENO" 5
 fi
 
-    IPVS_USE_NL=Yes
-     if test 1 -ge 2; then
+      IPVS_USE_NL=Yes
+       if test 1 -ge 2; then
       KA_PKG_PFX=
     else
       KA_PKG_PFX=KA
@@ -6671,7 +6679,7 @@ fi
 
 
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_rtgen_request in -lnl-route-3" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_rtgen_request in -lnl-route-3" >&5
 $as_echo_n "checking for nl_rtgen_request in -lnl-route-3... " >&6; }
 if ${ac_cv_lib_nl_route_3_nl_rtgen_request+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6718,8 +6726,8 @@ else
   as_fn_error $? "libnl-3 is installed but not libnl-route-3. Please, install libnl-route-3." "$LINENO" 5
 fi
 
-    NL3_CFLAGS="$($PKG_CONFIG --cflags libnl-route-3.0)"
-     if test 1 -ge 2; then
+      NL3_CFLAGS="$($PKG_CONFIG --cflags libnl-route-3.0)"
+       if test 1 -ge 2; then
       KA_PKG_PFX=
     else
       KA_PKG_PFX=KA
@@ -6758,7 +6766,7 @@ fi
 
 else
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_modify_cb in -lnl" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nl_socket_modify_cb in -lnl" >&5
 $as_echo_n "checking for nl_socket_modify_cb in -lnl... " >&6; }
 if ${ac_cv_lib_nl_nl_socket_modify_cb+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -6796,12 +6804,12 @@ fi
 $as_echo "$ac_cv_lib_nl_nl_socket_modify_cb" >&6; }
 if test "x$ac_cv_lib_nl_nl_socket_modify_cb" = xyes; then :
 
-        IPVS_USE_NL=Yes
-        NETLINK_VER=1
+          IPVS_USE_NL=Yes
+          NETLINK_VER=1
 
 $as_echo "#define _HAVE_LIBNL1_  1 " >>confdefs.h
 
-         if test 1 -ge 2; then
+           if test 1 -ge 2; then
       KA_PKG_PFX=
     else
       KA_PKG_PFX=KA
@@ -6837,15 +6845,15 @@ $as_echo "#define _HAVE_LIBNL1_  1 " >>confdefs.h
     eval ${KA_PKG_PFX}_LIBS=\"\$${KA_PKG_PFX}_LIBS $ADD_NEW\"
 
 
-        BUILD_OPTIONS="$BUILD_OPTIONS LIBNL1"
+          BUILD_OPTIONS="$BUILD_OPTIONS LIBNL1"
 
 $as_echo "#define FALLBACK_LIBNL1  1 " >>confdefs.h
 
-        BUILD_OPTIONS="$BUILD_OPTIONS FALLBACK_LIBNL1"
+          BUILD_OPTIONS="$BUILD_OPTIONS FALLBACK_LIBNL1"
 
 else
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: keepalived will be built without libnl support." >&5
+          { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: keepalived will be built without libnl support." >&5
 $as_echo "$as_me: WARNING: keepalived will be built without libnl support." >&2;}
 
 fi
@@ -6854,10 +6862,10 @@ fi
 fi
 
 
-if test $NETLINK_VER -ne 0; then
-  SAV_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$CPPFLAGS $kernelinc"
-  for ac_header in libnfnetlink/libnfnetlink.h
+  if test $NETLINK_VER -ne 0; then
+    SAV_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $kernelinc"
+    for ac_header in libnfnetlink/libnfnetlink.h
 do :
   ac_fn_c_check_header_mongrel "$LINENO" "libnfnetlink/libnfnetlink.h" "ac_cv_header_libnfnetlink_libnfnetlink_h" "$ac_includes_default"
 if test "x$ac_cv_header_libnfnetlink_libnfnetlink_h" = xyes; then :
@@ -6867,14 +6875,14 @@ _ACEOF
 
 else
   as_fn_error $? "
-    !!! Please install libnfnetlink headers.              !!!" "$LINENO" 5
+      !!! Please install libnfnetlink headers.              !!!" "$LINENO" 5
 fi
 
 done
 
-  if test $NETLINK_VER -eq 3; then
-    CPPFLAGS="$CPPFLAGS $NL3_CFLAGS"
-    for ac_header in netlink/route/link.h netlink/route/link/inet.h
+    if test $NETLINK_VER -eq 3; then
+      CPPFLAGS="$CPPFLAGS $NL3_CFLAGS"
+      for ac_header in netlink/route/link.h netlink/route/link/inet.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -6889,9 +6897,9 @@ fi
 
 done
 
-  fi
+    fi
 
-  for ac_header in linux/rtnetlink.h
+    for ac_header in linux/rtnetlink.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "linux/rtnetlink.h" "ac_cv_header_linux_rtnetlink_h" "$NETLINK_EXTRA_INCLUDE
 "
@@ -6906,7 +6914,7 @@ fi
 
 done
 
-  for ac_header in libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h
+    for ac_header in libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
@@ -6922,7 +6930,8 @@ fi
 done
 
 
-  CPPFLAGS="$SAV_CPPFLAGS"
+    CPPFLAGS="$SAV_CPPFLAGS"
+  fi
 fi
  if test $NETLINK_VER -eq 1; then
   LIBNL1_TRUE=

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,8 @@ AC_ARG_ENABLE(libiptc,
   [AS_HELP_STRING([--disable-libiptc], [compile without libiptc])])
 AC_ARG_ENABLE(libipset,
   [AS_HELP_STRING([--disable-libipset], [compile without libipset])])
+AC_ARG_ENABLE(libnl,
+  [AS_HELP_STRING([--disable-libnl], [compile without libnl])])
 AC_ARG_ENABLE(mem-check,
   [AS_HELP_STRING([--enable-mem-check], [compile with memory alloc checking])])
 AC_ARG_ENABLE(mem-check-log,
@@ -349,53 +351,55 @@ AM_CONDITIONAL([BUILD_GENHASH], [test $BUILD_GENHASH = Yes])
 dnl ----[ Checks for libraries ]----
 NETLINK_VER=0
 IPVS_USE_NL=No
-AC_CHECK_LIB(nl-3, nl_socket_alloc,
-  [
-    NETLINK_VER=3
-    AC_DEFINE([_HAVE_LIBNL3_], [ 1 ], [Define to 1 if using libnl-3])
-    add_build_opt([LIBNL3])
-    add_pkg_config([libnl-3.0])
-
-    AC_CHECK_LIB(nl-genl-3, genl_connect, [],
-      [AC_MSG_ERROR([libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3/libnl-genl-3.])])
-    IPVS_USE_NL=Yes
-    add_pkg_config([libnl-genl-3.0])
-
-    AC_CHECK_LIB(nl-route-3, nl_rtgen_request, [],
-      [AC_MSG_ERROR([libnl-3 is installed but not libnl-route-3. Please, install libnl-route-3.])])
-    NL3_CFLAGS="$($PKG_CONFIG --cflags libnl-route-3.0)"
-    add_pkg_config([libnl-route-3.0])
-  ],
-  [
-    AC_CHECK_LIB(nl, nl_socket_modify_cb,
-      [
-        IPVS_USE_NL=Yes
-        NETLINK_VER=1
-        AC_DEFINE([_HAVE_LIBNL1_], [ 1 ], [Define to 1 if using libnl-1])
-        add_pkg_config([libnl-1])
-        add_build_opt([LIBNL1])
-        AC_DEFINE([FALLBACK_LIBNL1], [ 1 ], [Define to 1 if using libnl-1])
-        add_build_opt([FALLBACK_LIBNL1])
-      ],
-      [
-        AC_MSG_WARN([keepalived will be built without libnl support.])
-      ])
-  ])
-
-if test $NETLINK_VER -ne 0; then
-  SAV_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$CPPFLAGS $kernelinc"
-  AC_CHECK_HEADERS(libnfnetlink/libnfnetlink.h,,AC_MSG_ERROR([
-    !!! Please install libnfnetlink headers.              !!!]))
-  if test $NETLINK_VER -eq 3; then
-    CPPFLAGS="$CPPFLAGS $NL3_CFLAGS"
-    AC_CHECK_HEADERS([netlink/route/link.h netlink/route/link/inet.h], [], [AC_MSG_ERROR([libnl-3 headers missing])])
+if test .${enable_libnl} != .no; then
+  AC_CHECK_LIB(nl-3, nl_socket_alloc,
+    [
+      NETLINK_VER=3
+      AC_DEFINE([_HAVE_LIBNL3_], [ 1 ], [Define to 1 if using libnl-3])
+      add_build_opt([LIBNL3])
+      add_pkg_config([libnl-3.0])
+  
+      AC_CHECK_LIB(nl-genl-3, genl_connect, [],
+        [AC_MSG_ERROR([libnl-3 is installed but not libnl-gen-3. Please, install libnl-gen-3/libnl-genl-3.])])
+      IPVS_USE_NL=Yes
+      add_pkg_config([libnl-genl-3.0])
+  
+      AC_CHECK_LIB(nl-route-3, nl_rtgen_request, [],
+        [AC_MSG_ERROR([libnl-3 is installed but not libnl-route-3. Please, install libnl-route-3.])])
+      NL3_CFLAGS="$($PKG_CONFIG --cflags libnl-route-3.0)"
+      add_pkg_config([libnl-route-3.0])
+    ],
+    [
+      AC_CHECK_LIB(nl, nl_socket_modify_cb,
+        [
+          IPVS_USE_NL=Yes
+          NETLINK_VER=1
+          AC_DEFINE([_HAVE_LIBNL1_], [ 1 ], [Define to 1 if using libnl-1])
+          add_pkg_config([libnl-1])
+          add_build_opt([LIBNL1])
+          AC_DEFINE([FALLBACK_LIBNL1], [ 1 ], [Define to 1 if using libnl-1])
+          add_build_opt([FALLBACK_LIBNL1])
+        ],
+        [
+          AC_MSG_WARN([keepalived will be built without libnl support.])
+        ])
+    ])
+  
+  if test $NETLINK_VER -ne 0; then
+    SAV_CPPFLAGS="$CPPFLAGS"
+    CPPFLAGS="$CPPFLAGS $kernelinc"
+    AC_CHECK_HEADERS(libnfnetlink/libnfnetlink.h,,AC_MSG_ERROR([
+      !!! Please install libnfnetlink headers.              !!!]))
+    if test $NETLINK_VER -eq 3; then
+      CPPFLAGS="$CPPFLAGS $NL3_CFLAGS"
+      AC_CHECK_HEADERS([netlink/route/link.h netlink/route/link/inet.h], [], [AC_MSG_ERROR([libnl-3 headers missing])])
+    fi
+  
+    AC_CHECK_HEADERS([linux/rtnetlink.h], [], [AC_MSG_ERROR([Unusable link/rtnetlink.h])], [$NETLINK_EXTRA_INCLUDE])
+    AC_CHECK_HEADERS([libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h], [], [AC_MSG_ERROR([netlink headers missing])])
+  
+    CPPFLAGS="$SAV_CPPFLAGS"
   fi
-
-  AC_CHECK_HEADERS([linux/rtnetlink.h], [], [AC_MSG_ERROR([Unusable link/rtnetlink.h])], [$NETLINK_EXTRA_INCLUDE])
-  AC_CHECK_HEADERS([libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h], [], [AC_MSG_ERROR([netlink headers missing])])
-
-  CPPFLAGS="$SAV_CPPFLAGS"
 fi
 AM_CONDITIONAL([LIBNL1], [test $NETLINK_VER -eq 1])
 AM_CONDITIONAL([LIBNL3], [test $NETLINK_VER -eq 3])

--- a/configure.ac
+++ b/configure.ac
@@ -395,7 +395,7 @@ if test .${enable_libnl} != .no; then
       AC_CHECK_HEADERS([netlink/route/link.h netlink/route/link/inet.h], [], [AC_MSG_ERROR([libnl-3 headers missing])])
     fi
   
-    AC_CHECK_HEADERS([linux/rtnetlink.h], [], [AC_MSG_ERROR([Unusable link/rtnetlink.h])], [$NETLINK_EXTRA_INCLUDE])
+    AC_CHECK_HEADERS([linux/rtnetlink.h], [], [AC_MSG_ERROR([Unusable linux/rtnetlink.h])], [$NETLINK_EXTRA_INCLUDE])
     AC_CHECK_HEADERS([libnfnetlink/libnfnetlink.h netlink/genl/ctrl.h netlink/genl/genl.h netlink/netlink.h], [], [AC_MSG_ERROR([netlink headers missing])])
   
     CPPFLAGS="$SAV_CPPFLAGS"
@@ -1136,3 +1136,9 @@ echo "Build genhash            : ${BUILD_GENHASH}"
 echo "Build documentation      : ${HAVE_SPHINX_BUILD}"
 
 dnl ----[ end configure ]---
+
+if test ${IPVS_SUPPORT} = Yes -a ${IPVS_USE_NL} = No; then
+  echo
+  echo "*** WARNING - this build will not support IPVS with IPv6. Please install libnl/libnl-3 dev libraries to support IPv6 with IPVS."
+  echo
+fi

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -110,11 +110,18 @@ dump_vsg_entry(void *data)
 
 	if (vsg_entry->vfwmark)
 		log_message(LOG_INFO, "   FWMARK = %u", vsg_entry->vfwmark);
-	else if (vsg_entry->range)
-		log_message(LOG_INFO, "   VIP Range = %s-%d, VPORT = %d"
-				    , inet_sockaddrtos(&vsg_entry->addr)
-				    , vsg_entry->range
-				    , ntohs(inet_sockaddrport(&vsg_entry->addr)));
+	else if (vsg_entry->range) {
+		if (vsg_entry->addr.ss_family == AF_INET)
+			log_message(LOG_INFO, "   VIP Range = %s-%d, VPORT = %d"
+					    , inet_sockaddrtos(&vsg_entry->addr)
+					    , vsg_entry->range
+					    , ntohs(inet_sockaddrport(&vsg_entry->addr)));
+		else
+			log_message(LOG_INFO, "   VIP Range = %s-%x, VPORT = %d"
+					    , inet_sockaddrtos(&vsg_entry->addr)
+					    , vsg_entry->range
+					    , ntohs(inet_sockaddrport(&vsg_entry->addr)));
+	}
 	else
 		log_message(LOG_INFO, "   VIP = %s, VPORT = %d"
 				    , inet_sockaddrtos(&vsg_entry->addr)

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -85,7 +85,7 @@ static void
 vs_end_handler(void)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
-	if (! vs->af)
+	if (!vs->af)
 		vs->af = AF_INET;
 }
 static void
@@ -96,8 +96,14 @@ ip_family_handler(vector_t *strvec)
 		return;
 	if (0 == strcmp(strvec_slot(strvec, 1), "inet"))
 		vs->af = AF_INET;
-	else if (0 == strcmp(strvec_slot(strvec, 1), "inet6"))
+	else if (0 == strcmp(strvec_slot(strvec, 1), "inet6")) {
+#ifndef IPVS_USE_NL
+		log_message(LOG_INFO, "IPVS with IPv6 is not supported by this build");
+		skip_block();
+		return;
+#endif
 		vs->af = AF_INET6;
+	}
 	else
 		log_message(LOG_INFO, "unknown address family %s", FMT_STR_VSLOT(strvec, 1));
 }

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -97,7 +97,7 @@ ip_family_handler(vector_t *strvec)
 	if (0 == strcmp(strvec_slot(strvec, 1), "inet"))
 		vs->af = AF_INET;
 	else if (0 == strcmp(strvec_slot(strvec, 1), "inet6")) {
-#ifndef IPVS_USE_NL
+#ifndef LIBIPVS_USE_NL
 		log_message(LOG_INFO, "IPVS with IPv6 is not supported by this build");
 		skip_block();
 		return;


### PR DESCRIPTION
When using the socket interface to configure IPVS (rather than the netlink interface), IPv6 isn't supported, so report the issue at configure time, and log an error if IPv6 IPVS configuration is requested at run time.

These commits also ensure that there isn't an attempt to mix IPv4 and IPv6 configuration within a single virtual server, since it isn't supported.