### PR TITLE
Fix build failures with the musl C library

### DIFF
--- a/keepalived/check/libipvs.c
+++ b/keepalived/check/libipvs.c
@@ -26,6 +26,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <stdint.h>
 
 #ifdef LIBIPVS_USE_NL
 #include <netlink/netlink.h>

--- a/keepalived/include/ip_vs.h
+++ b/keepalived/include/ip_vs.h
@@ -36,7 +36,7 @@ typedef struct ip_vs_stats_user ip_vs_stats_t;
 
 struct ip_vs_service_app {
 	struct ip_vs_service_user user;
-	u_int16_t		af;
+	uint16_t		af;
 	union nf_inet_addr	nf_addr;
 #ifdef _HAVE_PE_NAME_
 	char			pe_name[IP_VS_PENAME_MAXLEN];
@@ -45,7 +45,7 @@ struct ip_vs_service_app {
 
 struct ip_vs_dest_app {
 	struct ip_vs_dest_user	user;
-	u_int16_t		af;
+	uint16_t		af;
 	union nf_inet_addr	nf_addr;
 };
 
@@ -53,7 +53,7 @@ struct ip_vs_dest_app {
 struct ip_vs_service_entry_app {
 	struct ip_vs_service_entry user;
 	ip_vs_stats_t		stats;
-	u_int16_t		af;
+	uint16_t		af;
 	union nf_inet_addr	nf_addr;
 #ifdef _HAVE_PE_NAME_
 	char			pe_name[IP_VS_PENAME_MAXLEN];
@@ -64,7 +64,7 @@ struct ip_vs_service_entry_app {
 struct ip_vs_dest_entry_app {
 	struct ip_vs_dest_entry user;
 	ip_vs_stats_t		stats;
-	u_int16_t		af;
+	uint16_t		af;
 	union nf_inet_addr	nf_addr;
 
 };
@@ -84,7 +84,7 @@ struct ip_vs_get_dests_app {
 	struct ip_vs_dest_entry_app	entrytable[0];
 	} user;
 
-	u_int16_t		af;
+	uint16_t		af;
 	union nf_inet_addr	nf_addr;
 };
 
@@ -126,13 +126,13 @@ struct ip_vs_daemon_app {
 	uint16_t		sync_maxlen;
 
 	/* Multicast Port (base) */
-	u_int16_t		mcast_port;
+	uint16_t		mcast_port;
 
 	/* Multicast TTL */
-	u_int8_t		mcast_ttl;
+	uint8_t			mcast_ttl;
 
 	/* Multicast Address Family */
-	u_int16_t		mcast_af;
+	uint16_t		mcast_af;
 
 	/* Multicast Address */
 	union nf_inet_addr	mcast_group;


### PR DESCRIPTION
Hello,

[musl](http://www.musl-libc.org/) is a strictly standards-compliant C library.

It does not define non-standard types (such as the kernel-specific `u_intXX_t`) and its headers do not internally cross-include themselves much.

This two patches fix build issues such as:  
http://autobuild.buildroot.org/results/b61/b61c2cfa949c2a20f0702522857d78651207e6d2/build-end.log

Thanks!

Regards,
Yann E. MORIN.