### PR TITLE
Add option to ensure GARPs are resent after recovering from 2 masters

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -99,6 +99,14 @@ global_defs {				# Block identification
     vrrp_lower_prio_no_advert [<BOOL>]     # If a lower priority advert is received, just discard
 					   # it and don't send another advert. This causes adherence
 					   # to the RFCs.
+    vrrp_higher_prio_send_advert [<BOOL>]  # If we are master and receive a higher priority
+					   # advert, send an advert (which will be lower priority
+					   # than the other master), before we transition to
+					   # backup. This means that if the other master has
+					   # garp_lower_priority_repeat set, it will resend garp
+					   # messages. This is to get around the problem of their
+					   # having been two simultaneous masters, and the last GARP
+					   # messages seen were from us.
     vrrp_version <INTEGER:2..3>            # Default VRRP version (default 2)
     vrrp_iptables [keepalived_in [keepalived_out]]     # default INPUT
 					   # Specifies the iptables chains to add entries to
@@ -372,10 +380,19 @@ vrrp_instance <STRING> {		# VRRP instance declaration
     priority <INTEGER-1..255>		# VRRP PRIO
     advert_int <FLOAT>			# VRRP Advert interval (use default)
 
-    lower_prio_no_advert		# If a lower priority advert is received, don't
-					# don't send another advert. This causes adherence
+    lower_prio_no_advert [<BOOL>]	# If a lower priority advert is received, don't
+					# send another advert. This causes adherence
 					# to the RFCs (defaults to global
 					# vrrp_lower_priority_dont_send_advert).
+
+    higher_prio_send_advert [<BOOL>]	# If we are master and receive a higher priority
+					# advert, send an advert (which will be lower priority
+					# than the other master), before we transition to
+					# backup. This means that if the other master has
+					# garp_lower_priority_repeat set, it will resend garp
+					# messages. This is to get around the problem of their
+					# having been two simultaneous masters, and the last GARP
+					# messages seen were from us.
 
     # Note: authentication was removed from the VRRPv2 specification by RFC3768 in 2004.
     #   Use of this option is non-compliant and can cause problems; avoid using if possible,

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -118,6 +118,13 @@ and
  # adherence to the RFCs. Defaults to false, unless strict_mode is set.
  vrrp_lower_prio_no_advert [<BOOL>]
 
+ # If we are master and receive a higher priority advert, send an advert (which will be
+ # lower priority than the other master), before we transition to backup. This means
+ # that if the other master has garp_lower_priority_repeat set, it will resend garp messages.
+ # This is to get around the problem of their having been two simultaneous masters, and the
+ # last GARP messages seen were from us.
+ vrrp_higher_prio_send_advert [<BOOL>]
+
  # Set the default VRRP version to use
  vrrp_version <2 or 3>        # default version 2
 
@@ -429,6 +436,7 @@ which will transition together on any state change.
     gna_interval 100
 
     lower_prio_no_advert [<BOOL>]
+    higher_prio_send_advert [<BOOL>]
 
     # arbitrary unique number from 0 to 255
     # used to differentiate multiple instances of vrrpd

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -95,6 +95,7 @@ set_vrrp_defaults(data_t * data)
 	data->vrrp_garp_lower_prio_delay = PARAMETER_UNSET;
 	data->vrrp_garp_lower_prio_rep = PARAMETER_UNSET;
 	data->vrrp_lower_prio_no_advert = false;
+	data->vrrp_higher_prio_send_advert = false;
 	data->vrrp_version = VRRP_VERSION_2;
 	strcpy(data->vrrp_iptables_inchain, "INPUT");
 	data->block_ipv4 = false;
@@ -310,6 +311,7 @@ dump_global_data(data_t * data)
 	log_message(LOG_INFO, " Gratuitous ARP lower priority delay = %d", data->vrrp_garp_lower_prio_delay / TIMER_HZ);
 	log_message(LOG_INFO, " Gratuitous ARP lower priority repeat = %d", data->vrrp_garp_lower_prio_rep);
 	log_message(LOG_INFO, " Send advert after receive lower priority advert = %s", data->vrrp_lower_prio_no_advert ? "false" : "true");
+	log_message(LOG_INFO, " Send advert after receive higher priority advert = %s", data->vrrp_higher_prio_send_advert ? "true" : "false");
 	log_message(LOG_INFO, " Gratuitous ARP interval = %d", data->vrrp_garp_interval);
 	log_message(LOG_INFO, " Gratuitous NA interval = %d", data->vrrp_gna_interval);
 	log_message(LOG_INFO, " VRRP default protocol version = %d", data->vrrp_version);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -406,6 +406,21 @@ vrrp_lower_prio_no_advert_handler(vector_t *strvec)
 		global_data->vrrp_lower_prio_no_advert = true;
 }
 static void
+vrrp_higher_prio_send_advert_handler(vector_t *strvec)
+{
+	int res;
+
+	if (vector_size(strvec) >= 2) {
+		res = check_true_false(strvec_slot(strvec,1));
+		if (res < 0)
+			log_message(LOG_INFO, "Invalid value for vrrp_higher_prio_send_advert specified");
+		else
+			global_data->vrrp_higher_prio_send_advert = res;
+	}
+	else
+		global_data->vrrp_higher_prio_send_advert = true;
+}
+static void
 vrrp_iptables_handler(vector_t *strvec)
 {
 	global_data->vrrp_iptables_inchain[0] = '\0';
@@ -791,6 +806,7 @@ init_global_keywords(bool global_active)
 	install_keyword("vrrp_garp_interval", &vrrp_garp_interval_handler);
 	install_keyword("vrrp_gna_interval", &vrrp_gna_interval_handler);
 	install_keyword("vrrp_lower_prio_no_advert", &vrrp_lower_prio_no_advert_handler);
+	install_keyword("vrrp_higher_prio_send_advert", &vrrp_higher_prio_send_advert_handler);
 	install_keyword("vrrp_version", &vrrp_version_handler);
 	install_keyword("vrrp_iptables", &vrrp_iptables_handler);
 #ifdef _HAVE_LIBIPSET_

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -95,6 +95,7 @@ typedef struct _data {
 	unsigned			vrrp_garp_interval;
 	unsigned			vrrp_gna_interval;
 	bool				vrrp_lower_prio_no_advert;
+	bool				vrrp_higher_prio_send_advert;
 	int				vrrp_version;	/* VRRP version (2 or 3) */
 	char				vrrp_iptables_inchain[XT_EXTENSION_MAXNAMELEN];
 	char				vrrp_iptables_outchain[XT_EXTENSION_MAXNAMELEN];

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -183,8 +183,8 @@ typedef struct _vrrp_t {
 	bool			garp_pending;		/* Are there gratuitous ARP messages still to be sent */
 	bool			gna_pending;		/* Are there gratuitous NA messages still to be sent */
 	unsigned		garp_lower_prio_rep;	/* Number of ARP messages to send at a time */
-	unsigned		lower_prio_no_advert;	/* Don't send advert after lower prio
-							 * advert received */
+	unsigned		lower_prio_no_advert;	/* Don't send advert after lower prio advert received */
+	unsigned		higher_prio_send_advert; /* Send advert after higher prio advert received */
 	uint8_t			vrid;			/* virtual id. from 1(!) to 255 */
 	uint8_t			base_priority;		/* configured priority value */
 	uint8_t			effective_priority;	/* effective priority value */

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1622,12 +1622,15 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, ssize_t buflen)
 		return 0;
 	}
 
-	if (hd->priority == 0) {
+	addr_cmp = vrrp_saddr_cmp(&vrrp->pkt_saddr, vrrp);
+
+	if (hd->priority == 0 ||
+	    (vrrp->higher_prio_send_advert &&
+	    (hd->priority > vrrp->effective_priority ||
+	     (hd->priority == vrrp->effective_priority && addr_cmp > 0)))) {
 		vrrp_send_adv(vrrp, vrrp->effective_priority);
 		return 0;
 	}
-
-	addr_cmp = vrrp_saddr_cmp(&vrrp->pkt_saddr, vrrp);
 
 	if (hd->priority == vrrp->effective_priority && addr_cmp == 0)
 		log_message(LOG_INFO, "(%s): WARNING - equal priority advert received from remote host with our IP address.", vrrp->iname);
@@ -2136,6 +2139,19 @@ vrrp_complete_instance(vrrp_t * vrrp)
 		vrrp->garp_lower_prio_delay = vrrp->strict_mode ? 0 : global_data->vrrp_garp_lower_prio_delay;
 	if (vrrp->lower_prio_no_advert == PARAMETER_UNSET)
 		vrrp->lower_prio_no_advert = vrrp->strict_mode ? true : global_data->vrrp_lower_prio_no_advert;
+	if (vrrp->higher_prio_send_advert == PARAMETER_UNSET)
+		vrrp->higher_prio_send_advert = vrrp->strict_mode ? false : global_data->vrrp_higher_prio_send_advert;
+
+	if (vrrp->strict_mode) {
+		if (!vrrp->lower_prio_no_advert) {
+			log_message(LOG_INFO, "(%s): strict mode requires lower_prio_no_advert to be set - setting", vrrp->iname);
+			vrrp->lower_prio_no_advert = true;
+		}
+		if (vrrp->higher_prio_send_advert) {
+			log_message(LOG_INFO, "(%s): strict mode requires higherer_prio_send_advert to be clear - resetting", vrrp->iname);
+			vrrp->higher_prio_send_advert = false;
+		}
+	}
 
 	/* Check that the advertisement interval is valid */
 	if (!vrrp->adver_int)

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1629,7 +1629,9 @@ vrrp_state_master_rx(vrrp_t * vrrp, char *buf, ssize_t buflen)
 	    (hd->priority > vrrp->effective_priority ||
 	     (hd->priority == vrrp->effective_priority && addr_cmp > 0)))) {
 		vrrp_send_adv(vrrp, vrrp->effective_priority);
-		return 0;
+
+		if (hd->priority == 0)
+			return 0;
 	}
 
 	if (hd->priority == vrrp->effective_priority && addr_cmp == 0)

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -276,6 +276,7 @@ dump_vrrp(void *data)
 	log_message(LOG_INFO, "   Gratuitous ARP lower priority delay = %d", vrrp->garp_lower_prio_delay / TIMER_HZ);
 	log_message(LOG_INFO, "   Gratuitous ARP lower priority repeat = %d", vrrp->garp_lower_prio_rep);
 	log_message(LOG_INFO, "   Send advert after receive lower priority advert = %s", vrrp->lower_prio_no_advert ? "false" : "true");
+	log_message(LOG_INFO, "   Send advert after receive higher priority advert = %s", vrrp->higher_prio_send_advert ? "true" : "false");
 	log_message(LOG_INFO, "   Virtual Router ID = %d", vrrp->vrid);
 	log_message(LOG_INFO, "   Priority = %d", vrrp->base_priority);
 	log_message(LOG_INFO, "   Advert interval = %d %s",

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -560,6 +560,24 @@ vrrp_lower_prio_no_advert_handler(vector_t *strvec)
 	}
 }
 
+static void
+vrrp_higher_prio_send_advert_handler(vector_t *strvec)
+{
+	int res;
+
+	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	if (vector_size(strvec) >= 2) {
+		res = check_true_false(strvec_slot(strvec, 1));
+		if (res >= 0)
+			vrrp->higher_prio_send_advert = (unsigned)res;
+		else
+			log_message(LOG_INFO, "(%s): invalid higher_prio_send_advert %s specified", vrrp->iname, FMT_STR_VSLOT(strvec, 1));
+	} else {
+		/* Defaults to true */
+		vrrp->higher_prio_send_advert = true;
+	}
+}
+
 
 #if defined _WITH_VRRP_AUTH_
 static void
@@ -929,6 +947,7 @@ init_vrrp_keywords(bool active)
 	install_keyword("garp_lower_prio_delay", &vrrp_garp_lower_prio_delay_handler);
 	install_keyword("garp_lower_prio_repeat", &vrrp_garp_lower_prio_rep_handler);
 	install_keyword("lower_prio_no_advert", &vrrp_lower_prio_no_advert_handler);
+	install_keyword("higher_prio_send_advert", &vrrp_higher_prio_send_advert_handler);
 #if defined _WITH_VRRP_AUTH_
 	install_keyword("authentication", NULL);
 	install_sublevel();

--- a/keepalived/vrrp/vrrp_print.c
+++ b/keepalived/vrrp/vrrp_print.c
@@ -269,6 +269,7 @@ vrrp_print(FILE *file, void *data)
 	fprintf(file, "   Gratuitous ARP lower priority delay = %u\n", vrrp->garp_lower_prio_delay / TIMER_HZ);
 	fprintf(file, "   Gratuitous ARP lower priority repeat = %u\n", vrrp->garp_lower_prio_rep);
 	fprintf(file, "   Send advert after receive lower priority advert = %s\n", vrrp->lower_prio_no_advert ? "false" : "true");
+	fprintf(file, "   Send advert after receive higher priority advert = %s\n", vrrp->higher_prio_send_advert ? "true" : "false");
 	fprintf(file, "   Virtual Router ID = %d\n", vrrp->vrid);
 	fprintf(file, "   Priority = %d\n", vrrp->base_priority);
 	fprintf(file, "   Advert interval = %d %s\n",


### PR DESCRIPTION
If the situation had developed where two vrrp instances had become master (for example due to network isolation), it is possible that the ARP caches on some hosts may point to the lower priority master. This commit adds the option higher_prio_send_advert to force the lower priority master to send an advert when it transitions to backup. If lower_prio_garp_rep is set on the higher priority master, it will then send GARP messages, and the ARP caches on hosts should recover.