### PR TITLE
Fix typo

### DIFF
--- a/doc/samples/keepalived.conf.IPv6
+++ b/doc/samples/keepalived.conf.IPv6
@@ -49,7 +49,7 @@ virtual_server ae00::1 80 {
 #            nb_get_retry 3
 #            delay_before_retry 3
 #        }
-#    }
+    }
 
 
 }

--- a/doc/samples/keepalived.conf.track_interface
+++ b/doc/samples/keepalived.conf.track_interface
@@ -4,7 +4,7 @@ global_defs {
    router_id LVS_DEVEL
 }
 
-static_route {
+static_routes {
     192.168.210.0/24 via 192.168.200.254 dev eth0
     192.168.211.0/24 via 192.168.200.254 dev eth0
     192.168.212.0/24 dev eth3


### PR DESCRIPTION
Hi,

I found typo in configs under the doc/samples directory, and fixed it.

(I using [gokc](https://github.com/yuuki/gokc). It's golang based keepalived.conf syntax checker)

Regards,
Masaya Yamamoto