### PR TITLE
In case of consecutive vrrp state notification, need to make sure that state is notified in correct order. To maintain the  order and synchronize the notification adding wait before gi- -ving control back to parent process.

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1501,7 +1501,7 @@ vrrp_state_backup(vrrp_t * vrrp, char *buf, ssize_t buflen)
 #ifdef _WITH_SNMP_RFCV3_
 		vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PRIORITY;
 #endif
-	} else if ((vrrp->nopreempt || vrrp->effective_priority != VRRP_PRIO_OWNER)
+	} else if ((vrrp->nopreempt &&  vrrp->effective_priority != VRRP_PRIO_OWNER) ||
 		   hd->priority >= vrrp->effective_priority ||
 		   (vrrp->preempt_delay &&
 		    (!vrrp->preempt_time.tv_sec ||

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1501,7 +1501,7 @@ vrrp_state_backup(vrrp_t * vrrp, char *buf, ssize_t buflen)
 #ifdef _WITH_SNMP_RFCV3_
 		vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PRIORITY;
 #endif
-	} else if (vrrp->nopreempt ||
+	} else if ((vrrp->nopreempt || vrrp->effective_priority != VRRP_PRIO_OWNER)
 		   hd->priority >= vrrp->effective_priority ||
 		   (vrrp->preempt_delay &&
 		    (!vrrp->preempt_time.tv_sec ||

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1501,7 +1501,7 @@ vrrp_state_backup(vrrp_t * vrrp, char *buf, ssize_t buflen)
 #ifdef _WITH_SNMP_RFCV3_
 		vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PRIORITY;
 #endif
-	} else if ((vrrp->nopreempt &&  vrrp->effective_priority != VRRP_PRIO_OWNER) ||
+	} else if ((vrrp->nopreempt || vrrp->effective_priority != VRRP_PRIO_OWNER)
 		   hd->priority >= vrrp->effective_priority ||
 		   (vrrp->preempt_delay &&
 		    (!vrrp->preempt_time.tv_sec ||

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1501,7 +1501,7 @@ vrrp_state_backup(vrrp_t * vrrp, char *buf, ssize_t buflen)
 #ifdef _WITH_SNMP_RFCV3_
 		vrrp->stats->master_reason = VRRPV3_MASTER_REASON_PRIORITY;
 #endif
-	} else if ((vrrp->nopreempt || vrrp->effective_priority != VRRP_PRIO_OWNER)
+	} else if (vrrp->nopreempt ||
 		   hd->priority >= vrrp->effective_priority ||
 		   (vrrp->preempt_delay &&
 		    (!vrrp->preempt_time.tv_sec ||

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -111,7 +111,8 @@ script_setup(void)
 int
 notify_exec(const notify_script_t *script)
 {
-	pid_t pid;
+	pid_t pid, cpid;
+	int status = 0;
 
 	pid = fork();
 
@@ -121,9 +122,15 @@ notify_exec(const notify_script_t *script)
 		return -1;
 	}
 
-	/* In case of this is parent process */
-	if (pid)
+	/* In case of parent process, wait for the exit status of child, this is
+        * to synchronize consecutive status update.
+        */
+	if (pid) {
+                while ((cpid = wait(&status)) > 0) {
+                     log_message(LOG_INFO,"Exit status to invoke %s from %d was %d \n",cmd, (int)cpid, status);
+                }
 		return 0;
+        }
 
 #ifdef _MEM_CHECK_
 	skip_mem_dump();


### PR DESCRIPTION
On changing priority we are seeing state update is not synchronized and wrong state update process is getting called causing mismatch in actual VRRP state in KA and remote module learning from the notify scripts.

Parent process should wait till notify script completes its execution, this is to avoid context switch causing mismatch in state update. 