### PR TITLE
Don't complaint if user keepalived_script doesn't exist it not needed

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -568,12 +568,14 @@ virtual_server group <STRING>      {	# VS group declaration
         weight <INTEGER>		# weight to use (default: 1)
         inhibit_on_failure		# Set weight to 0 on healthchecker
 					#  failure
-        notify_up <STRING>|<QUOTED-STRING> # Script to launch when
-					   #  healthchecker consider service
-					   #  as up.
-        notify_down <STRING>|<QUOTED-STRING> # Script to launch when
-					     #  healthchecker consider service
-					     #  as down.
+        notify_up <STRING>|<QUOTED-STRING> [username [groupname]]
+					# Script to launch when
+					#  healthchecker consider service
+					#  as up.
+        notify_down <STRING>|<QUOTED-STRING> [username [groupname]]
+					# Script to launch when
+					#  healthchecker consider service
+					#  as down.
 
         HTTP_GET|SSL_GET {		# HTTP and SSL healthcheckers
             url {			# A set of url to test
@@ -603,8 +605,8 @@ virtual_server group <STRING>      {	# VS group declaration
     real_server <IP ADDRESS> <PORT> {	# Idem
         weight <INTEGER>		# Idem
         inhibit_on_failure		# Idem
-        notify_up <STRING>|<QUOTED-STRING> # Idem
-        notify_down <STRING>|<QUOTED-STRING> # Idem
+        notify_up <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
+        notify_down <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
 
         TCP_CHECK {			# TCP healthchecker
             connect_ip <IP ADDRESS> # IP address to connect
@@ -620,8 +622,8 @@ virtual_server group <STRING>      {	# VS group declaration
     real_server <IP ADDRESS> <PORT> {	# Idem
         weight <INTEGER>		# Idem
         inhibit_on_failure		# Idem
-        notify_up <STRING>|<QUOTED-STRING> # Idem
-        notify_down <STRING>|<QUOTED-STRING> # Idem
+        notify_up <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
+        notify_down <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
 
         SMTP_CHECK {                   # SMTP healthchecker
             connect_ip <IP ADDRESS>     # Optional IP address to connect to
@@ -658,8 +660,8 @@ virtual_server group <STRING>      {	# VS group declaration
     real_server <IP ADDRESS> <PORT> {	# Idem
         weight <INTEGER>		# Idem
         inhibit_on_failure		# Idem
-        notify_up <STRING>|<QUOTED-STRING> # Idem
-        notify_down <STRING>|<QUOTED-STRING> # Idem
+        notify_up <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
+        notify_down <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
 
         DNS_CHECK {                     # DNS healthchecker
             connect_ip <IP ADDRESS>     # Optional IP address to connect to
@@ -677,8 +679,8 @@ virtual_server group <STRING>      {	# VS group declaration
     real_server <IP ADDRESS> <PORT> {	# Idem
         weight <INTEGER>		# Idem
         inhibit_on_failure		# Idem
-        notify_up <STRING>|<QUOTED-STRING> # Idem
-        notify_down <STRING>|<QUOTED-STRING> # Idem
+        notify_up <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
+        notify_down <STRING>|<QUOTED-STRING> [username [groupname]] # Idem
 
         MISC_CHECK {				# MISC healthchecker
             misc_path <STRING>|<QUOTED-STRING>	# External system script or program

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -711,10 +711,10 @@ A virtual_server can be a declaration of one of
 
            # Script to execute when healthchecker
            # considers service as up.
-           notify_up <STRING>|<QUOTED-STRING>
+           notify_up <STRING>|<QUOTED-STRING> [username [groupname]]
            # Script to execute when healthchecker
            # considers service as down.
-           notify_down <STRING>|<QUOTED-STRING>
+           notify_down <STRING>|<QUOTED-STRING> [username [groupname]]
 
            uthreshold <INTEGER> # maximum number of connections to server
            lthreshold <INTEGER> # minimum number of connections to server

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -192,7 +192,7 @@ check_misc_script_security(void)
 
 		script_flags |= (flags = check_script_secure(&script, global_data->script_security, false));
 
-		/* The script path may have been updated if it wan't an absolute path */
+		/* The script path may have been updated if it wasn't an absolute path */
 		misc_script->path = script.name;
 
 		/* Mark not to run if needs inhibiting */
@@ -201,7 +201,7 @@ check_misc_script_security(void)
 			misc_script->insecure = true;
 		}
 		else if (flags & SC_NOTFOUND) {
-			log_message(LOG_INFO, "Disabling misc script %s since not found", misc_script->path);
+			log_message(LOG_INFO, "Disabling misc script %s since not found/accessible", misc_script->path);
 			misc_script->insecure = true;
 		}
 		else if (!(flags & SC_EXECUTABLE))

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -135,7 +135,6 @@ misc_end_handler(void)
 
 	if (!script_user_set)
 	{
-log_message(LOG_INFO, "remove_script 1 %d", remove_script);
 		if ( set_default_script_user(NULL, NULL, global_data->script_security)) {
 			log_message(LOG_INFO, "Unable to set default user for misc script %s - removing", misck_checker->path);
 			FREE(misck_checker);
@@ -143,7 +142,6 @@ log_message(LOG_INFO, "remove_script 1 %d", remove_script);
 			return;
 		}
 
-log_message(LOG_INFO, "Setting uid.gid");
 		misck_checker->uid = default_script_uid;
 		misck_checker->gid = default_script_gid;
 	}
@@ -151,7 +149,6 @@ log_message(LOG_INFO, "Setting uid.gid");
 	/* queue new checker */
 	queue_checker(free_misc_check, dump_misc_check, misc_check_thread, misck_checker, NULL);
 	misck_checker = NULL;
-log_message(LOG_INFO, "Leaving misc_end_handler");
 }
 
 void

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -44,6 +44,11 @@ static int misc_check_thread(thread_t *);
 static int misc_check_child_thread(thread_t *);
 static int misc_check_child_timeout_thread(thread_t *);
 
+static bool script_user_set;
+static bool remove_script;
+static misc_checker_t *misck_checker;
+
+
 /* Configuration stream handling */
 static void
 free_misc_check(void *data)
@@ -70,49 +75,83 @@ dump_misc_check(void *data)
 static void
 misc_check_handler(__attribute__((unused)) vector_t *strvec)
 {
-	misc_checker_t *misck_checker = (misc_checker_t *) MALLOC(sizeof (misc_checker_t));
+	misck_checker = (misc_checker_t *) MALLOC(sizeof (misc_checker_t));
 
-	misck_checker->uid = default_script_uid;
-	misck_checker->gid = default_script_gid;
-
-	/* queue new checker */
-	queue_checker(free_misc_check, dump_misc_check, misc_check_thread,
-		      misck_checker, NULL);
+	script_user_set = false;
 }
 
 static void
 misc_path_handler(vector_t *strvec)
 {
-	misc_checker_t *misck_checker = CHECKER_GET();
+	if (!misck_checker)
+		return;
+
 	misck_checker->path = CHECKER_VALUE_STRING(strvec);
 }
 
 static void
 misc_timeout_handler(vector_t *strvec)
 {
-	misc_checker_t *misck_checker = CHECKER_GET();
+	if (!misck_checker)
+		return;
+
 	misck_checker->timeout = CHECKER_VALUE_UINT(strvec) * TIMER_HZ;
 }
 
 static void
 misc_dynamic_handler(__attribute__((unused)) vector_t *strvec)
 {
-	misc_checker_t *misck_checker = CHECKER_GET();
+	if (!misck_checker)
+		return;
+
 	misck_checker->dynamic = true;
 }
 
 static void
 misc_user_handler(vector_t *strvec)
 {
-	misc_checker_t *misck_checker = CHECKER_GET();
+	if (!misck_checker)
+		return;
 
 	if (vector_size(strvec) < 2) {
 		log_message(LOG_INFO, "No user specified for misc checker script %s", misck_checker->path);
 		return;
 	}
 
-	if (set_script_uid_gid(strvec, 1, &misck_checker->uid, &misck_checker->gid))
-		log_message(LOG_INFO, "Failed to set uid/gid for misc checker script %s", misck_checker->path);
+	if (set_script_uid_gid(strvec, 1, &misck_checker->uid, &misck_checker->gid)) {
+		log_message(LOG_INFO, "Failed to set uid/gid for misc checker script %s - removing", misck_checker->path);
+		FREE(misck_checker);
+		misck_checker = NULL;
+	}
+	else
+		script_user_set = true;
+}
+
+static void
+misc_end_handler(void)
+{
+	if (!misck_checker)
+		return;
+
+	if (!script_user_set)
+	{
+log_message(LOG_INFO, "remove_script 1 %d", remove_script);
+		if ( set_default_script_user(NULL, NULL, global_data->script_security)) {
+			log_message(LOG_INFO, "Unable to set default user for misc script %s - removing", misck_checker->path);
+			FREE(misck_checker);
+			misck_checker = NULL;
+			return;
+		}
+
+log_message(LOG_INFO, "Setting uid.gid");
+		misck_checker->uid = default_script_uid;
+		misck_checker->gid = default_script_gid;
+	}
+
+	/* queue new checker */
+	queue_checker(free_misc_check, dump_misc_check, misc_check_thread, misck_checker, NULL);
+	misck_checker = NULL;
+log_message(LOG_INFO, "Leaving misc_end_handler");
 }
 
 void
@@ -125,6 +164,7 @@ install_misc_check_keyword(void)
 	install_keyword("misc_dynamic", &misc_dynamic_handler);
 	install_keyword("warmup", &warmup_handler);
 	install_keyword("user", &misc_user_handler);
+	install_sublevel_end_handler(&misc_end_handler);
 	install_sublevel_end();
 }
 

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -322,14 +322,7 @@ inhibit_handler(__attribute__((unused)) vector_t *strvec)
 static inline notify_script_t*
 set_check_notify_script(vector_t *strvec)
 {
-	notify_script_t *script = notify_script_init(strvec, default_script_uid, default_script_gid);
-
-	if (vector_size(strvec) > 2 ) {
-		if (set_script_uid_gid(strvec, 2, &script->uid, &script->gid))
-			log_message(LOG_INFO, "Invalid user/group for quorum/notify script %s", script->name);
-	}
-
-	return script;
+	return notify_script_init(strvec, "quorum/notify", global_data->script_security);
 }
 static void
 notify_up_handler(vector_t *strvec)

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -329,6 +329,10 @@ notify_up_handler(vector_t *strvec)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
 	real_server_t *rs = LIST_TAIL_DATA(vs->rs);
+	if (rs->notify_up) {
+		log_message(LOG_INFO, "(%s): notify_up script already specified - ignoring %s", vs->vsgname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	rs->notify_up = set_check_notify_script(strvec);
 }
 static void
@@ -336,6 +340,10 @@ notify_down_handler(vector_t *strvec)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
 	real_server_t *rs = LIST_TAIL_DATA(vs->rs);
+	if (rs->notify_down) {
+		log_message(LOG_INFO, "(%s): notify_down script already specified - ignoring %s", vs->vsgname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	rs->notify_down = set_check_notify_script(strvec);
 }
 static void

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -363,12 +363,20 @@ static void
 quorum_up_handler(vector_t *strvec)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
+	if (vs->quorum_up) {
+		log_message(LOG_INFO, "(%s): quorum_up script already specified - ignoring %s", vs->vsgname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vs->quorum_up = set_check_notify_script(strvec);
 }
 static void
 quorum_down_handler(vector_t *strvec)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
+	if (vs->quorum_down) {
+		log_message(LOG_INFO, "(%s): quorum_down script already specified - ignoring %s", vs->vsgname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vs->quorum_down = set_check_notify_script(strvec);
 }
 static void

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -701,53 +701,6 @@ use_pid_dir_handler(__attribute__((unused)) vector_t *strvec)
 	use_pid_dir = true;
 }
 
-bool
-set_script_uid_gid(vector_t *strvec, unsigned keyword_offset, uid_t *uid_p, gid_t *gid_p)
-{
-	char *username;
-	char *groupname;
-	uid_t uid;
-	gid_t gid;
-	struct passwd pwd;
-	struct passwd *pwd_p;
-	struct group grp;
-	struct group *grp_p;
-	int ret;
-	char buf[getpwnam_buf_len];
-
-	username = strvec_slot(strvec, keyword_offset);
-
-	if ((ret = getpwnam_r(username, &pwd, buf, sizeof(buf), &pwd_p))) {
-		log_message(LOG_INFO, "Unable to resolve script username '%s' - ignoring", username);
-		return true;
-	}
-	if (!pwd_p) {
-		log_message(LOG_INFO, "Script user '%s' does not exist", username);
-		return true;
-	}
-
-	uid = pwd.pw_uid;
-	gid = pwd.pw_gid;
-
-	if (vector_size(strvec) > keyword_offset + 1) {
-		groupname = strvec_slot(strvec, keyword_offset + 1);
-		if ((ret = getgrnam_r(groupname, &grp, buf, sizeof(buf), &grp_p))) {
-			log_message(LOG_INFO, "Unable to resolve script group name '%s' - ignoring", groupname);
-			return true;
-		}
-		if (!grp_p) {
-			log_message(LOG_INFO, "Script group '%s' does not exist", groupname);
-			return true;
-		}
-		gid = grp.gr_gid;
-	}
-
-	*uid_p = uid;
-	*gid_p = gid;
-
-	return false;
-}
-
 static void
 script_user_handler(vector_t *strvec)
 {
@@ -756,7 +709,7 @@ script_user_handler(vector_t *strvec)
 		return;
 	}
 
-	if (set_script_uid_gid(strvec, 1, &default_script_uid, &default_script_gid))
+	if (set_default_script_user(strvec_slot(strvec, 1), vector_size(strvec) > 2 ? strvec_slot(strvec, 2) : NULL, true))
 		log_message(LOG_INFO, "Error setting global script uid/gid");
 }
 

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -81,8 +81,7 @@ const char *snmp_socket;				/* Socket to use for SNMP agent */
 static char *syslog_ident;				/* syslog ident if not default */
 char *instance_name;					/* keepalived instance name */
 bool use_pid_dir;					/* Put pid files in /var/run/keepalived or @localstatedir@/run/keepalived */
-uid_t default_script_uid;				/* Default user/group for script execution */
-gid_t default_script_gid;
+
 unsigned os_major;					/* Kernel version */
 unsigned os_minor;
 unsigned os_release;
@@ -768,7 +767,6 @@ keepalived_main(int argc, char **argv)
 	bool report_stopped = true;
 	struct utsname uname_buf;
 	char *end;
-	long buf_len;
 
 	/* Init debugging level */
 	debug = 0;
@@ -816,17 +814,6 @@ keepalived_main(int argc, char **argv)
 	core_dump_init();
 
 	netlink_set_recv_buf_size();
-
-	/* Get buffer length needed for getpwnam_r/getgrnam_r */
-	if ((buf_len = sysconf(_SC_GETPW_R_SIZE_MAX)) == -1)
-		getpwnam_buf_len = 1024;	/* A safe default if no value is returned */
-	else
-		getpwnam_buf_len = (size_t)buf_len;
-	if ((buf_len = sysconf(_SC_GETGR_R_SIZE_MAX)) != -1 &&
-	    (size_t)buf_len > getpwnam_buf_len)
-		getpwnam_buf_len = (size_t)buf_len;
-
-	set_default_script_user(&default_script_uid, &default_script_gid);
 
 	/* Some functionality depends on kernel version, so get the version here */
 	if (uname(&uname_buf))

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -73,8 +73,6 @@ extern bool namespace_with_ipsets;	/* override for namespaces with ipsets on Lin
 #endif
 extern char *instance_name;		/* keepalived instance name */
 extern bool use_pid_dir;		/* pid files in /var/run/keepalived */
-extern uid_t default_script_uid;	/* Default user/group for script execution */
-extern gid_t default_script_gid;
 extern unsigned os_major;		/* Kernel version */
 extern unsigned os_minor;
 extern unsigned os_release;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -166,7 +166,7 @@ check_track_script_secure(tracked_sc_t *script)
 
 	flags = check_script_secure(&ns, global_data->script_security, false);
 
-	/* The script path may have been updated if it wan't an absolute path */
+	/* The script path may have been updated if it wasn't an absolute path */
 	script->scr->script = ns.name;
 
 	/* Mark not to run if needs inhibiting */
@@ -175,7 +175,7 @@ check_track_script_secure(tracked_sc_t *script)
 		script->scr->insecure = true;
 	}
 	else if (flags & SC_NOTFOUND) {
-		log_message(LOG_INFO, "Disabling track script %s since not found", script->scr->sname);
+		log_message(LOG_INFO, "Disabling track script %s since not found/accessible", script->scr->sname);
 		script->scr->insecure = true;
 	}
 	else if (!(flags & SC_EXECUTABLE))

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -160,8 +160,7 @@ dump_vscript(void *data)
 		str = (vscript->result >= vscript->rise) ? "GOOD" : "BAD";
 	}
 	log_message(LOG_INFO, "   Status = %s", str);
-	if (vscript->uid || vscript->gid)
-		log_message(LOG_INFO, "   Script uid:gid = %d:%d", vscript->uid, vscript->gid);
+	log_message(LOG_INFO, "   Script uid:gid = %d:%d", vscript->uid, vscript->gid);
 
 }
 

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -130,6 +130,10 @@ static void
 vrrp_gnotify_backup_handler(vector_t *strvec)
 {
 	vrrp_sgroup_t *vgroup = LIST_TAIL_DATA(vrrp_data->vrrp_sync_group);
+	if (vgroup->script_backup) {
+		log_message(LOG_INFO, "vrrp group %s: notify_backup script already specified - ignoring %s", vgroup->gname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vgroup->script_backup = set_vrrp_notify_script(strvec);
 	vgroup->notify_exec = true;
 }
@@ -137,6 +141,10 @@ static void
 vrrp_gnotify_master_handler(vector_t *strvec)
 {
 	vrrp_sgroup_t *vgroup = LIST_TAIL_DATA(vrrp_data->vrrp_sync_group);
+	if (vgroup->script_master) {
+		log_message(LOG_INFO, "vrrp group %s: notify_master script already specified - ignoring %s", vgroup->gname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vgroup->script_master = set_vrrp_notify_script(strvec);
 	vgroup->notify_exec = true;
 }
@@ -144,6 +152,10 @@ static void
 vrrp_gnotify_fault_handler(vector_t *strvec)
 {
 	vrrp_sgroup_t *vgroup = LIST_TAIL_DATA(vrrp_data->vrrp_sync_group);
+	if (vgroup->script_fault) {
+		log_message(LOG_INFO, "vrrp group %s: notify_fault script already specified - ignoring %s", vgroup->gname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vgroup->script_fault = set_vrrp_notify_script(strvec);
 	vgroup->notify_exec = true;
 }
@@ -151,6 +163,10 @@ static void
 vrrp_gnotify_handler(vector_t *strvec)
 {
 	vrrp_sgroup_t *vgroup = LIST_TAIL_DATA(vrrp_data->vrrp_sync_group);
+	if (vgroup->script) {
+		log_message(LOG_INFO, "vrrp group %s: notify script already specified - ignoring %s", vgroup->gname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vgroup->script = set_vrrp_notify_script(strvec);
 	vgroup->notify_exec = true;
 }
@@ -433,6 +449,10 @@ static void
 vrrp_notify_backup_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	if (vrrp->script_backup) {
+		log_message(LOG_INFO, "(%s): notify_backup script already specified - ignoring %s", vrrp->iname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vrrp->script_backup = set_vrrp_notify_script(strvec);
 	vrrp->notify_exec = true;
 }
@@ -440,6 +460,10 @@ static void
 vrrp_notify_master_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	if (vrrp->script_master) {
+		log_message(LOG_INFO, "(%s): notify_master script already specified - ignoring %s", vrrp->iname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vrrp->script_master = set_vrrp_notify_script(strvec);
 	vrrp->notify_exec = true;
 }
@@ -447,6 +471,10 @@ static void
 vrrp_notify_fault_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	if (vrrp->script_fault) {
+		log_message(LOG_INFO, "(%s): notify_fault script already specified - ignoring %s", vrrp->iname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vrrp->script_fault = set_vrrp_notify_script(strvec);
 	vrrp->notify_exec = true;
 }
@@ -454,6 +482,10 @@ static void
 vrrp_notify_stop_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	if (vrrp->script_stop) {
+		log_message(LOG_INFO, "(%s): notify_stop script already specified - ignoring %s", vrrp->iname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vrrp->script_stop = set_vrrp_notify_script(strvec);
 	vrrp->notify_exec = true;
 }
@@ -461,6 +493,10 @@ static void
 vrrp_notify_handler(vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	if (vrrp->script) {
+		log_message(LOG_INFO, "(%s): notify script already specified - ignoring %s", vrrp->iname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
 	vrrp->script = set_vrrp_notify_script(strvec);
 	vrrp->notify_exec = true;
 }

--- a/keepalived/vrrp/vrrp_print.c
+++ b/keepalived/vrrp/vrrp_print.c
@@ -92,6 +92,7 @@ vscript_print(FILE *file, void *data)
 	fprintf(file, "   Rise = %d\n", vscript->rise);
 	fprintf(file, "   Full = %d\n", vscript->fall);
 	fprintf(file, "   Insecure = %s\n", vscript->insecure ? "yes" : "no");
+	fprintf(file, "   uid:gid = %d:%d\n", vscript->uid, vscript->gid);
 
 	switch (vscript->result) {
 	case VRRP_SCRIPT_STATUS_INIT:

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -417,7 +417,7 @@ exit:
 
 exit1:
 	if (space)
-		*space = 0;
+		*space = ' ';
 
 	/* We tried every element and none of them worked. */
 	if (got_eacces) {

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -56,7 +56,8 @@ free_notify_script(notify_script_t **script)
 }
 
 /* Global variables */
-extern size_t getpwnam_buf_len;		/* Buffer length needed for getpwnam_r/getgrnam_r */
+extern uid_t default_script_uid;        /* Default user/group for script execution */
+extern gid_t default_script_gid;
 
 /* prototypes */
 extern int system_call_script(thread_master_t *, int (*) (thread_t *), void *, unsigned long, const char*, uid_t, gid_t);
@@ -64,7 +65,7 @@ extern int notify_exec(const notify_script_t *);
 extern void script_killall(thread_master_t *, int);
 extern int check_script_secure(notify_script_t *, bool, bool);
 extern int check_notify_script_secure(notify_script_t **, bool, bool);
-extern void set_default_script_user(uid_t *, gid_t *);
-extern notify_script_t* notify_script_init(vector_t *, uid_t, gid_t);
+extern bool set_default_script_user(const char *, const char *, bool);
+extern notify_script_t* notify_script_init(vector_t *, const char *, bool);
 
 #endif


### PR DESCRIPTION
The message about the default script user keepalived_script not existing was getting tedious.

The commit cause the warning to only be output if there is a script that would use keepalived_script.

There are various other script handling improvements.