### PR TITLE
Fix missing PARAMETER_UNSET for vrrp_higher_prio_send_advert

### DIFF
--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -425,6 +425,7 @@ alloc_vrrp(char *iname)
 	new->garp_lower_prio_delay = PARAMETER_UNSET;
 	new->garp_lower_prio_rep = PARAMETER_UNSET;
 	new->lower_prio_no_advert = PARAMETER_UNSET;
+	new->higher_prio_send_advert = PARAMETER_UNSET;
 
 	new->skip_check_adv_addr = global_data->vrrp_skip_check_adv_addr;
 	new->strict_mode = PARAMETER_UNSET;


### PR DESCRIPTION
There was no PARAMETER_UNSET value assigned to higher_prio_send_advert.
This caused the global value was not used for each VRRP instance.