### PR TITLE
Add notify FIFO, and some minor changes

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -182,8 +182,8 @@ linkbeat_use_polling			   # Use media link failure detection polling fashion
 
 static_ipaddress {			# block identification
 					# If no dev element is specified, it defaults to the default_interface (default eth0)
-    <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE>
-    <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE>
+    <IP ADDRESS>[/<MASK>] [brd <IP ADDRESS>] [dev <STRING>] [scope <SCOPE>] [label <LABEL>] [home] [-nodad] [mngtmpaddr] [noprefixroute] [autojoin]
+    <IP ADDRESS>[/<MASK>] ...
     ...
 }
 
@@ -402,16 +402,16 @@ vrrp_instance <STRING> {		# VRRP instance declaration
         auth_pass <STRING>		# Password string (up to 8 characters)
     }
     virtual_ipaddress {			# VRRP IP addres block
-        <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE> label <LABEL>
-        <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE> label <LABEL>
+        <IP ADDRESS>[/<MASK>] [brd <IP ADDRESS>] [dev <STRING>] [scope <SCOPE>] [label <LABEL>] [home] [-nodad] [mngtmpaddr] [noprefixroute] [autojoin]
+        <IP ADDRESS>[/<MASK>] ...
         ...
     }
-    virtual_ipaddress_excluded {       	# VRRP IP excluded from VRRP
-        <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE>	# packets
-        <IP ADDRESS>/<MASK> brd <IP ADDRESS> dev <STRING> scope <SCOPE>
+    virtual_ipaddress_excluded {       	# VRRP IP excluded from VRRP packets
+        <IP ADDRESS>[/<MASK>] [brd <IP ADDRESS>] [dev <STRING>] [scope <SCOPE>] [label <LABEL>] [home] [-nodad] [mngtmpaddr] [noprefixroute] [autojoin]
+        <IP ADDRESS>[/<MASK>] ...
         ...
     }
-    prompte_secondaries			# Set the promote_secondaries flag on the interface to stop other
+    promote_secondaries			# Set the promote_secondaries flag on the interface to stop other
 					# addresses in the same CIDR being removed when 1 of them is removed
     virtual_routes {			# VRRP virtual routes
 					# The syntax is the same as static_routes

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -155,6 +155,13 @@ global_defs {				# Block identification
 					   # if that user exists, otherwise root.
     enable_script_security		   # Don't run scripts configured to be run as root if any part of the path
 					   # is writable by a non-root user.
+    vrrp_notify_fifo FIFO_NAME		   # FIFO to write notify events to
+					   # The string written will be a line of the form: INSTANCE "VI_1" MASTER 100
+					   # and will be terminated with a new line character.
+					   # For further details of the output, see the description under vrrp_sync_group
+					   # and doc/samples/sample_notify_fifo.sh for sample usage.
+    vrrp_notify_fifo_script STRING [username [groupname]]
+					   # script to be run by keepalived to process notify events
 }
 
 net_namespace NAME			   # Set the network namespace to run in
@@ -286,11 +293,12 @@ vrrp_sync_group <STRING> {	# VRRP sync group declaration
 
     $1 = A string indicating whether it's a "GROUP" or an "INSTANCE"
     $2 = The name of said group or instance
-    $3 = The state it's transitioning to ("MASTER", "BACKUP" or "FAULT")
+    $3 = The state it's transitioning to ("MASTER", "BACKUP", "FAULT" or "STOP")
     $4 = The priority value
 
     $1 and $3 are ALWAYS sent in uppercase, and the possible strings sent are the
-    same ones listed above ("GROUP"/"INSTANCE", "MASTER"/"BACKUP"/"FAULT").
+    same ones listed above ("GROUP"/"INSTANCE", "MASTER"/"BACKUP"/"FAULT"/"STOP")
+    (note: STOP is only applicable to instances)
 
 Important: for a SYNC group to run reliably, it is vital that all instances in
 	   the group are MASTER or that they are all either BACKUP or FAULT. A

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -93,9 +93,9 @@ global_defs {				# Block identification
     vrrp_garp_master_refresh <INTEGER>	   # Periodic delay in seconds sending
 					   #  gratuitous ARP while in MASTER state
 					   #  Default: 0 (no refreshing)
-    vrrp_garp_master_refresh_repeat <INTEGER> # how many gratuitous ARP messages shoule be sent
+    vrrp_garp_master_refresh_repeat <INTEGER> # how many gratuitous ARP messages should be sent
 					   #  at each periodic repeat
-					   #  Default: once (per period)
+					   #  Default: one (per period)
     vrrp_lower_prio_no_advert [<BOOL>]     # If a lower priority advert is received, just discard
 					   # it and don't send another advert. This causes adherence
 					   # to the RFCs.
@@ -338,8 +338,8 @@ vrrp_instance <STRING> {		# VRRP instance declaration
     version <INTEGER:2..3>              # VRRP version to use
     vmac_xmit_base			# Send/Recv VRRP messages from base
 					#  interface instead of VMAC interface
-    native_ipv6				# Force instance to use IPv6
-					#  when using mixed IPv4&IPv6 conf
+    native_ipv6				# Force instance to use IPv6 (this option is deprecated since
+					#   the virtual addresses determine whether IPv4 or IPv6 is used)
     state MASTER|BACKUP			# Start-up default state
     interface <STRING>			# Binding interface
     accept				# Allow a non address-owner to process packets

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -382,7 +382,7 @@ which will transition together on any state change.
     # VMAC interface
     vmac_xmit_base
 
-    native_ipv6         # force instance to use IPv6 (when mixed IPv4 and IPv6 config).
+    native_ipv6         # force instance to use IPv6 (this option is deprecated since the virtual ip addresses determine whether IPv4 or IPv6 is used).
 
     # Ignore VRRP interface faults (default unset)
     dont_track_primary

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -198,6 +198,14 @@ and
  script_user username [groupname] # If groupname is not specified, it defaults to the user's group
  enable_script_security       # Don't run scripts configured to be run as root if any part of the path
                               #   is writable by a non-root user.
+
+ # Rather than using notify scripts, specifying a fifo allows more efficient processing of notify events, and guarantees that they will be delivered in the correct sequence.
+ vrrp_notify_fifo FIFO_NAME   # FIFO to write notify events to
+                              # The string written will be a line of the form: INSTANCE "VI_1" MASTER 100
+                              # and will be terminated with a new line character.
+                              # For further details of the output, see the description under vrrp_sync_group
+ vrrp_notify_fifo_script SCRIPT_PATH [username [groupname]]
+                              # script to be run by keepalived to process notify events
  }
 
  # For running keepalived in a separate network namespace
@@ -315,8 +323,8 @@ and
     # arguments
     # $1 = "GROUP"|"INSTANCE"
     # $2 = name of the group or instance
-    # $3 = target state of transition
-    #     ("MASTER"|"BACKUP"|"FAULT")
+    # $3 = target state of transition (stop only applies to instances)
+    #     ("MASTER"|"BACKUP"|"FAULT"|"STOP")
     # $4 = priority value
     notify /path/notify.sh [username [groupname]]
 

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -233,6 +233,7 @@ is specified, it defaults to default_interface (default eth0).
 .PP
  static_ipaddress
  {
+ <IPADDR>[/<MASK>] [brd <IPADDR>] [dev <STRING>] [scope <SCOPE>] [label <LABEL>] [home] [-nodad] [mngtmpaddr] [noprefixroute] [autojoin]
  192.168.1.1/24 dev eth0 scope global
  ...
  }
@@ -468,7 +469,7 @@ which will transition together on any state change.
     #With the same entries on other machines,
     #the opposite transition will be occurring.
     virtual_ipaddress {
-        <IPADDR>/<MASK> brd <IPADDR> dev <STRING> scope <SCOPE> label <LABEL>
+	<IPADDR>[/<MASK>] [brd <IPADDR>] [dev <STRING>] [scope <SCOPE>] [label <LABEL>] [home] [-nodad] [mngtmpaddr] [noprefixroute] [autojoin]
         192.168.200.17/24 dev eth1
         192.168.200.18/24 dev eth2 label eth2:1
     }
@@ -485,8 +486,8 @@ which will transition together on any state change.
     # addresses in virtual_ipaddress must be of the
     # same family.
     virtual_ipaddress_excluded {
-     <IPADDR>/<MASK> brd <IPADDR> dev <STRING> scope <SCOPE>
-     <IPADDR>/<MASK> brd <IPADDR> dev <STRING> scope <SCOPE>
+	<IPADDR>[/<MASK>] [brd <IPADDR>] [dev <STRING>] [scope <SCOPE>] [label <LABEL>] [home] [-nodad] [mngtmpaddr] [noprefixroute] [autojoin]
+        <IPADDR>[/<MASK>] ...
         ...
     }
 

--- a/doc/samples/sample_notify_fifo.sh
+++ b/doc/samples/sample_notify_fifo.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# To use this script, copy it to directory /etc/keepalived/scripts
+# and add the following to the keepalived configuration file in the
+# global_defs section:
+#     vrrp_notify_fifo /tmp/notify_fifo
+# This script will then need to be executed.
+# 
+# As an alternative to executing this script manually, add the following
+# in the global_defs section of the config:
+#     vrrp_notify_fifo_script /etc/keepalived/scripts/sample_notify_fifo.sh
+# If this approach is used, comment out the lines 'mkfifo $FIFO' and trap ...
+# below, since keepalived can create the FIFO.
+
+FIFO=/tmp/notify_fifo
+CREATED_FIFO=0
+
+trap "{ [[ $CREATED_FIFO -eq 1 ]] && rm -f $FIFO; exit 0; }" HUP INT QUIT USR1 USR2 PIPE TERM
+
+[[ ! -p $FIFO ]] && mkfifo $FIFO && CREATED_FIFO=1
+
+# If keepalived terminates, the FIFO will be closed, so
+# read the FIFO in a loop. It keepalived hasn't opened the
+# FIFO, the script will be blocked until it has been opened.
+while [ 1 ]
+do
+	[[ ! -p $FIFO ]] && echo FIFO $FIFO missing && exit 1
+
+	while read line; do
+		set $line
+		TYPE=$1
+		VRRP_INST=${2//\"/}
+		STATE=$3
+		PRIORITY=$4
+
+		# Now take whatever action is required
+		echo $TYPE $VRRP_INST $STATE $PRIORITY >>/tmp/fifo.log
+	done < $FIFO
+done

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -147,6 +147,7 @@ alloc_global_data(void)
 #ifdef _WITH_VRRP_
 	set_default_mcast_group(new);
 	set_vrrp_defaults(new);
+	new->vrrp_notify_fifo_fd = -1;
 #endif
 
 #ifdef _WITH_SNMP_
@@ -229,6 +230,10 @@ free_global_data(data_t * data)
 	FREE_PTR(data->lvs_syncd.ifname);
 	FREE_PTR(data->lvs_syncd.vrrp_name);
 #endif
+#ifdef _WITH_VRRP_
+	FREE_PTR(data->vrrp_notify_fifo_name);
+	free_notify_script(&data->vrrp_notify_fifo_script);
+#endif
 #if HAVE_DECL_CLONE_NEWNET
 	if (!reload)
 		FREE_PTR(network_namespace);
@@ -287,6 +292,14 @@ dump_global_data(data_t * data)
 		if (data->lvs_syncd.mcast_ttl)
 			log_message(LOG_INFO, " LVS syncd mcast ttl = %u", data->lvs_syncd.mcast_ttl);
 #endif
+	}
+	if (data->vrrp_notify_fifo_name) {
+		log_message(LOG_INFO, " VRRP notify fifo = %s", data->vrrp_notify_fifo_name);
+		if (data->vrrp_notify_fifo_script)
+			log_message(LOG_INFO, " VRRP notify fifo script = %s uid:gid %d:%d",
+				    data->vrrp_notify_fifo_script->name,
+				    data->vrrp_notify_fifo_script->uid,
+				    data->vrrp_notify_fifo_script->gid);
 	}
 #endif
 	log_message(LOG_INFO, " LVS flush = %s", data->lvs_flush ? "true" : "false");

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -538,6 +538,37 @@ vrrp_no_swap_handler(__attribute__((unused)) vector_t *strvec)
 {
 	global_data->vrrp_no_swap = true;
 }
+static void
+vrrp_notify_fifo(vector_t *strvec)
+{
+	if (vector_size(strvec) < 2) {
+		log_message(LOG_INFO, "No vrrp_notify_fifo name specified");
+		return;
+	}
+
+	if (global_data->vrrp_notify_fifo_name) {
+		log_message(LOG_INFO, "vrrp_notify_fifo already specified - ignoring %s", FMT_STR_VSLOT(strvec,1));
+		return;
+	}
+
+	global_data->vrrp_notify_fifo_name = MALLOC(strlen(strvec_slot(strvec, 1) + 1));
+	strcpy(global_data->vrrp_notify_fifo_name, strvec_slot(strvec, 1));
+}
+static void
+vrrp_notify_fifo_script(vector_t *strvec)
+{
+	if (vector_size(strvec) < 2) {
+		log_message(LOG_INFO, "No vrrp_notify_fifo_script specified");
+		return;
+	}
+
+	if (global_data->vrrp_notify_fifo_script) {
+		log_message(LOG_INFO, "vrrp_notify_fifo_script already specified - ignoring %s", FMT_STR_VSLOT(strvec,1));
+		return;
+	}
+
+	global_data->vrrp_notify_fifo_script = notify_script_init(strvec, "notify_fifo", global_data->script_security);
+}
 #endif
 #ifdef _WITH_LVS_
 static void
@@ -770,6 +801,8 @@ init_global_keywords(bool global_active)
 	install_keyword("vrrp_strict", &vrrp_strict_handler);
 	install_keyword("vrrp_priority", &vrrp_prio_handler);
 	install_keyword("vrrp_no_swap", &vrrp_no_swap_handler);
+	install_keyword("vrrp_notify_fifo", &vrrp_notify_fifo);
+	install_keyword("vrrp_notify_fifo_script", &vrrp_notify_fifo_script);
 #endif
 #ifdef _WITH_LVS_
 	install_keyword("checker_priority", &checker_prio_handler);

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -563,7 +563,10 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 		return -1;
 
 #ifdef _WITH_VRRP_
-	if (prog_type == PROG_TYPE_VRRP) {
+#ifndef DEBUG
+	if (prog_type == PROG_TYPE_VRRP)
+#endif
+	{
 		/* Fetch interface_t */
 		ifp = if_get_by_ifindex(ifa->ifa_index);
 		if (!ifp)
@@ -581,7 +584,9 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 #endif
 
 #ifdef _WITH_LVS_
+#ifndef DEBUG
 	if (prog_type == PROG_TYPE_CHECKER)
+#endif
 	{
 		/* Refresh checkers state */
 		update_checker_activity(ifa->ifa_family, addr,
@@ -701,7 +706,11 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
 
 #ifdef _WITH_VRRP_
 			/* Skip unsolicited messages from cmd channel */
-			if (prog_type == PROG_TYPE_VRRP && nl != &nl_cmd && h->nlmsg_pid == nl_cmd.nl_pid)
+			if (
+#ifndef DEBUG
+			    prog_type == PROG_TYPE_VRRP &&
+#endif
+			    nl != &nl_cmd && h->nlmsg_pid == nl_cmd.nl_pid)
 				continue;
 #endif
 
@@ -1145,6 +1154,13 @@ kernel_netlink_init(void)
 	 * subscribtion. We subscribe to LINK and ADDR
 	 * netlink broadcast messages.
 	 */
+#ifdef DEBUG
+#ifdef _WITH_VRRP_
+	netlink_socket(&nl_kernel, SOCK_NONBLOCK, RTNLGRP_LINK, RTNLGRP_IPV4_IFADDR, RTNLGRP_IPV6_IFADDR, 0);
+#else
+	netlink_socket(&nl_kernel, SOCK_NONBLOCK, RTNLGRP_IPV4_IFADDR, RTNLGRP_IPV6_IFADDR, 0);
+#endif
+#else
 #ifdef _WITH_VRRP_
 	if (prog_type == PROG_TYPE_VRRP)
 		netlink_socket(&nl_kernel, SOCK_NONBLOCK, RTNLGRP_LINK, RTNLGRP_IPV4_IFADDR, RTNLGRP_IPV6_IFADDR, 0);
@@ -1152,6 +1168,7 @@ kernel_netlink_init(void)
 #ifdef _WITH_LVS_
 	if (prog_type == PROG_TYPE_CHECKER)
 		netlink_socket(&nl_kernel, SOCK_NONBLOCK, RTNLGRP_IPV4_IFADDR, RTNLGRP_IPV6_IFADDR, 0);
+#endif
 #endif
 
 	if (nl_kernel.fd > 0) {
@@ -1162,7 +1179,10 @@ kernel_netlink_init(void)
 		log_message(LOG_INFO, "Error while registering Kernel netlink reflector channel");
 
 #ifdef _WITH_VRRP_
-	if (prog_type == PROG_TYPE_VRRP) {
+#ifndef DEBUG
+	if (prog_type == PROG_TYPE_VRRP)
+#endif
+	{
 		/* Prepare netlink command channel. */
 		netlink_socket(&nl_cmd, SOCK_NONBLOCK, 0);
 		if (nl_cmd.fd > 0)
@@ -1178,7 +1198,9 @@ kernel_netlink_close(void)
 {
 	netlink_close(&nl_kernel);
 #ifdef _WITH_VRRP_
+#ifndef DEBUG
 	if (prog_type == PROG_TYPE_VRRP)
+#endif
 		netlink_close(&nl_cmd);
 #endif
 }

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -772,7 +772,9 @@ keepalived_main(int argc, char **argv)
 	debug = 0;
 
 	/* We are the parent process */
+#ifndef DEBUG
 	prog_type = PROG_TYPE_PARENT;
+#endif
 
 	/* Initialise pointer to child finding function */
 	set_child_finder(find_keepalived_child);

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -99,6 +99,10 @@ typedef struct _data {
 	int				vrrp_version;	/* VRRP version (2 or 3) */
 	char				vrrp_iptables_inchain[XT_EXTENSION_MAXNAMELEN];
 	char				vrrp_iptables_outchain[XT_EXTENSION_MAXNAMELEN];
+	char				*vrrp_notify_fifo_name;
+	int				vrrp_notify_fifo_fd;
+	bool				vrrp_created_notify_fifo;
+	notify_script_t			*vrrp_notify_fifo_script;
 #ifdef _HAVE_LIBIPSET_
 	bool				using_ipsets;
 	char				vrrp_ipset_address[IPSET_MAXNAMELEN];

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -269,6 +269,7 @@ typedef struct _vrrp_t {
 #define VRRP_STATE_MAST			2	/* rfc2338.6.4.3 */
 #define VRRP_STATE_FAULT		3	/* internal */
 #define VRRP_STATE_GOTO_MASTER		4	/* internal */
+#define VRRP_STATE_STOP			97	/* internal */
 #define VRRP_STATE_GOTO_FAULT		98	/* internal */
 #define VRRP_DISPATCHER			99	/* internal */
 #define VRRP_MCAST_RETRY		10	/* internal */

--- a/keepalived/include/vrrp_ipaddress.h
+++ b/keepalived/include/vrrp_ipaddress.h
@@ -55,6 +55,8 @@ typedef struct _ip_address {
 
 	interface_t		*ifp;			/* Interface owning IP address */
 	char			*label;			/* Alias name, e.g. eth0:1 */
+	int			flags;			/* Address flags */
+	int			flagmask;		/* Bitmaps of flags set */
 	bool			set;			/* TRUE if addr is set */
 	bool			iptable_rule_set;	/* TRUE if iptable drop rule
 							 * set to addr */

--- a/keepalived/include/vrrp_notify.h
+++ b/keepalived/include/vrrp_notify.h
@@ -29,5 +29,6 @@
 
 extern int notify_instance_exec(vrrp_t *, int);
 extern int notify_group_exec(vrrp_sgroup_t *, int);
+extern void notify_instance_fifo(const vrrp_t *, int);
 
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -331,7 +331,7 @@ vrrp_in_chk_ipsecah(vrrp_t * vrrp, char *buffer)
 		vrrp->ipsecah_counter->seq_number = ntohl(ah->seq_number);
 	} else {
 		log_message(LOG_INFO, "VRRP_Instance(%s) IPSEC-AH : sequence number %d"
-					" already proceeded. Packet dropped. Local(%d)",
+					" already processed. Packet dropped. Local(%d)",
 					vrrp->iname, ntohl(ah->seq_number),
 					vrrp->ipsecah_counter->seq_number);
 		++vrrp->stats->auth_failure;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -224,6 +224,9 @@ check_vrrp_script_security(void)
 		}
 	}
 
+	if (global_data->vrrp_notify_fifo_script)
+		script_flags |= check_notify_script_secure(&global_data->vrrp_notify_fifo_script, global_data->script_security, false);
+
 	if (!global_data->script_security && script_flags & SC_ISSCRIPT) {
 		log_message(LOG_INFO, "SECURITY VIOLATION - scripts are being executed but script_security not enabled.%s",
 				script_flags & SC_INSECURE ? " There are insecure scripts." : "");
@@ -1957,6 +1960,9 @@ shutdown_vrrp_instances(void)
 		/* Run stop script */
 		if (vrrp->script_stop)
 			notify_exec(vrrp->script_stop);
+
+		if (global_data->vrrp_notify_fifo_fd != -1)
+			notify_instance_fifo(vrrp, VRRP_STATE_STOP);
 
 #ifdef _WITH_LVS_
 		/*

--- a/keepalived/vrrp/vrrp_notify.c
+++ b/keepalived/vrrp/vrrp_notify.c
@@ -98,7 +98,7 @@ static bool
 script_open_literal(char *script)
 {
 	log_message(LOG_DEBUG, "Opening script file %s",script);
-	FILE *fOut = fopen(script, "r");;
+	FILE *fOut = fopen(script, "r");
 	if (!fOut) {
 		log_message(LOG_INFO, "Can't open %s (errno %d %s)", script,
 		       errno, strerror(errno));
@@ -121,6 +121,46 @@ script_open(notify_script_t *script)
 	FREE(name);
 
 	return ret;
+}
+
+static void
+notify_fifo(const char *name, int state_num, bool group, int priority)
+{
+	char *state = "{UNKNOWN}";
+	size_t size;
+	char *line;
+	char *type;
+
+	switch (state_num) {
+		case VRRP_STATE_MAST  : state = "MASTER" ; break;
+		case VRRP_STATE_BACK  : state = "BACKUP" ; break;
+		case VRRP_STATE_FAULT : state = "FAULT" ; break;
+		case VRRP_STATE_STOP  : state = "STOP" ; break;
+	}
+
+	type = group ? "GROUP" : "INSTANCE";
+
+	size = strlen(type) + strlen(state) + strlen(name) + 10;
+	line = MALLOC(size);
+	if (!line)
+		return;
+
+	snprintf(line, size, "%s \"%s\" %s %d\n", type, name, state, priority);
+	write(global_data->vrrp_notify_fifo_fd, line, strlen(line));
+
+	FREE(line);
+}
+
+void
+notify_instance_fifo(const vrrp_t *vrrp, int state_num)
+{
+	notify_fifo(vrrp->iname, state_num, false, vrrp->effective_priority);
+}
+
+static void
+notify_group_fifo(const vrrp_sgroup_t *vgroup, int state_num)
+{
+	notify_fifo(vgroup->gname, state_num, true, 0);
 }
 
 static void
@@ -199,6 +239,9 @@ notify_instance_exec(vrrp_t * vrrp, int state)
 		ret = 1;
 	}
 
+	if (global_data->vrrp_notify_fifo_fd != -1)
+		notify_instance_fifo(vrrp, state);
+
 #ifdef _WITH_DBUS_
 	if (global_data->enable_dbus)
 		dbus_send_state_signal(vrrp); // send signal to all subscribers
@@ -225,6 +268,9 @@ notify_group_exec(vrrp_sgroup_t * vgroup, int state)
 		notify_script_exec(gscript, "GROUP", state, vgroup->gname, 0);
 		ret = 1;
 	}
+
+	if (global_data->vrrp_notify_fifo_fd != -1)
+		notify_group_fifo(vgroup, state);
 
 	return ret;
 }

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -61,6 +61,7 @@ extern gid_t default_script_gid;
 
 /* prototypes */
 extern int system_call_script(thread_master_t *, int (*) (thread_t *), void *, unsigned long, const char*, uid_t, gid_t);
+extern pid_t notify_fifo_exec(thread_master_t *, int (*func) (thread_t *), void *, const notify_script_t *);
 extern int notify_exec(const notify_script_t *);
 extern void script_killall(thread_master_t *, int);
 extern int check_script_secure(notify_script_t *, bool, bool);

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -532,7 +532,7 @@ read_line(char *buf, size_t size)
 				}
 
 				/* Remove the @config_id from start of line */
-				memmove(buf, buf_start + 1, strlen(buf_start));
+				memset(buf, ' ', buf_start - buf);
 			}
 		}
 		else

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -50,7 +50,9 @@
 
 /* global vars */
 thread_master_t *master = NULL;
+#ifndef DEBUG
 prog_type_t prog_type;		/* Parent/VRRP/Checker process */
+#endif
 
 #ifdef _WITH_LVS_
 #include "../keepalived/include/check_daemon.h"
@@ -101,7 +103,7 @@ report_child_status(int status, pid_t pid, char const *prog_name)
 		}
 
 		if (exit_status != EXIT_SUCCESS
-#ifdef _WITH_LVS_
+#if defined _WITH_LVS_ && !defined DEBUG
 					        && prog_type != PROG_TYPE_CHECKER
 #endif
 										 )

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -117,7 +117,9 @@ typedef enum {
 
 /* global vars exported */
 extern thread_master_t *master;
+#ifndef DEBUG
 extern prog_type_t prog_type;		/* Parent/VRRP/Checker process */
+#endif
 
 /* Prototypes. */
 extern void set_child_finder(bool (*)(pid_t, char const **));


### PR DESCRIPTION
The notify FIFO is designed to resolve the problem of notify scripts potentially processing notify events in the wrong order, as identified in pull requests #568 and #587 and issue #584.