### PR TITLE
Add FIFO notifies for LVS notification, and sundry fixes

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -162,6 +162,7 @@ global_defs {				# Block identification
 					   # and doc/samples/sample_notify_fifo.sh for sample usage.
     vrrp_notify_fifo_script STRING [username [groupname]]
 					   # script to be run by keepalived to process notify events
+					   # The FIFO name will be passed to the script as the last parameter
 }
 
 net_namespace NAME			   # Set the network namespace to run in

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -155,13 +155,28 @@ global_defs {				# Block identification
 					   # if that user exists, otherwise root.
     enable_script_security		   # Don't run scripts configured to be run as root if any part of the path
 					   # is writable by a non-root user.
-    vrrp_notify_fifo FIFO_NAME		   # FIFO to write notify events to
+    notify_fifo FIFO_NAME		   # FIFO to write notify events to
+					   # See vrrp_notify_fifo and lvs_notify_fifo for format of output
+					   # For further details, see the description under vrrp_sync_group see 
+					   # doc/samples/sample_notify_fifo.sh for sample usage.
+    notify_fifo_script STRING [username [groupname]]
+					   # script to be run by keepalived to process notify events
+					   # The FIFO name will be passed to the script as the last parameter
+    vrrp_notify_fifo FIFO_NAME		   # FIFO to write vrrp notify events to (must be different from other FIFO names)
 					   # The string written will be a line of the form: INSTANCE "VI_1" MASTER 100
 					   # and will be terminated with a new line character.
 					   # For further details of the output, see the description under vrrp_sync_group
 					   # and doc/samples/sample_notify_fifo.sh for sample usage.
     vrrp_notify_fifo_script STRING [username [groupname]]
-					   # script to be run by keepalived to process notify events
+					   # script to be run by keepalived to process vrrp notify events
+					   # The FIFO name will be passed to the script as the last parameter
+    lvs_notify_fifo FIFO_NAME		   # FIFO to write notify healthchecker events to (must be different from other FIFO names)
+					   # The string written will be a line of the form:
+					   #   VS [192.168.201.15]:tcp:80 {UP|DOWN}
+					   #   RS [1.2.3.4]:tcp:80 [192.168.201.15]:tcp:80 {UP|DOWN}
+					   # and will be terminated with a new line character.
+    lvs_notify_fifo_script STRING [username [groupname]]
+					   # script to be run by keepalived to process healthchecher notify events
 					   # The FIFO name will be passed to the script as the last parameter
 }
 

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -206,6 +206,7 @@ and
                               # For further details of the output, see the description under vrrp_sync_group
  vrrp_notify_fifo_script SCRIPT_PATH [username [groupname]]
                               # script to be run by keepalived to process notify events
+                              # The FIFO name will be passed to the script as the last parameter
  }
 
  # For running keepalived in a separate network namespace

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -200,12 +200,29 @@ and
                               #   is writable by a non-root user.
 
  # Rather than using notify scripts, specifying a fifo allows more efficient processing of notify events, and guarantees that they will be delivered in the correct sequence.
- vrrp_notify_fifo FIFO_NAME   # FIFO to write notify events to
+ # NOTE: the FIFO names must all be different
+ notify_fifo FIFO_NAME        # FIFO to write notify events to
+                              # See vrrp_notify_fifo and lvs_notify_fifo for format of output
+                              # For further details, see the description under vrrp_sync_group see 
+                              # doc/samples/sample_notify_fifo.sh for sample usage.
+ notify_fifo_script STRING [username [groupname]]
+                              # script to be run by keepalived to process notify events
+                              # The FIFO name will be passed to the script as the last parameter
+ vrrp_notify_fifo FIFO_NAME   # FIFO to write vrrp notify events to
                               # The string written will be a line of the form: INSTANCE "VI_1" MASTER 100
                               # and will be terminated with a new line character.
                               # For further details of the output, see the description under vrrp_sync_group
- vrrp_notify_fifo_script SCRIPT_PATH [username [groupname]]
-                              # script to be run by keepalived to process notify events
+                              # and doc/samples/sample_notify_fifo.sh for sample usage.
+ vrrp_notify_fifo_script STRING [username [groupname]]
+                              # script to be run by keepalived to process vrrp notify events
+                              # The FIFO name will be passed to the script as the last parameter
+ lvs_notify_fifo FIFO_NAME    # FIFO to write notify healthchecker events to
+                              # The string written will be a line of the form:
+                              #   VS [192.168.201.15]:tcp:80 {UP|DOWN}
+                              #   RS [1.2.3.4]:tcp:80 [192.168.201.15]:tcp:80 {UP|DOWN}
+                              # and will be terminated with a new line character.
+ lvs_notify_fifo_script STRING [username [groupname]]
+                              # script to be run by keepalived to process healthchecher notify events
                               # The FIFO name will be passed to the script as the last parameter
  }
 

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -55,6 +55,15 @@ bool using_ha_suspend;
 /* local variables */
 static char *check_syslog_ident;
 
+static int
+lvs_notify_fifo_script_exit(__attribute__((unused)) thread_t *thread)
+{
+        log_message(LOG_INFO, "lvs notify fifo script terminated");
+ 
+        return 0;
+}
+
+
 /* Daemon stop sequence */
 static void
 stop_check(int status)
@@ -64,6 +73,9 @@ stop_check(int status)
 
 	/* Terminate all script process */
 	script_killall(master, SIGTERM);
+
+        /* Remove the notify fifo */
+        notify_fifo_close(&global_data->notify_fifo, &global_data->lvs_notify_fifo);
 
 	/* Destroy master thread */
 	signal_handler_destroy();
@@ -146,6 +158,10 @@ start_check(void)
 		return;
 	}
 
+        /* Create a notify FIFO if needed, and open it */
+        if (global_data->lvs_notify_fifo.name)
+                notify_fifo_open(&global_data->notify_fifo, &global_data->lvs_notify_fifo, lvs_notify_fifo_script_exit, "lvs_");
+
 	/* Get current active addresses, and start update process */
 	if (using_ha_suspend || __test_bit(LOG_ADDRESS_CHANGES, &debug))
 		kernel_netlink_init();
@@ -227,6 +243,9 @@ reload_check_thread(__attribute__((unused)) thread_t * thread)
 
 	/* Terminate all script process */
 	script_killall(master, SIGTERM);
+
+        /* Remove the notify fifo - we don't know if it will be the same after a reload */
+        notify_fifo_close(&global_data->notify_fifo, &global_data->lvs_notify_fifo);
 
 	/* Destroy master thread */
 	if (using_ha_suspend)

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -552,6 +552,11 @@ check_check_script_security(void)
 		}
 	}
 
+	if (global_data->notify_fifo.script)
+		script_flags |= check_notify_script_secure(&global_data->notify_fifo.script, global_data->script_security, false);
+	if (global_data->lvs_notify_fifo.script)
+		script_flags |= check_notify_script_secure(&global_data->lvs_notify_fifo.script, global_data->script_security, false);
+
 	if (!global_data->script_security && script_flags & SC_ISSCRIPT) {
 		log_message(LOG_INFO, "SECURITY VIOLATION - check scripts are being executed but script_security not enabled.%s",
 				script_flags & SC_INSECURE ? " There are insecure scripts." : "");

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -250,7 +250,7 @@ init_global_data(data_t * data)
 #ifdef _WITH_LVS_
 	/* If the global and LVS notify FIFOs are the same, then data will be
 	 * duplicated on the FIFO */
-#ifndef _WITH_DEBUG_
+#ifndef _DEBUG_
 	if (prog_type == PROG_TYPE_CHECKER)
 #endif
 	{

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -147,7 +147,13 @@ alloc_global_data(void)
 #ifdef _WITH_VRRP_
 	set_default_mcast_group(new);
 	set_vrrp_defaults(new);
-	new->vrrp_notify_fifo_fd = -1;
+#endif
+	new->notify_fifo.fd = -1;
+#ifdef _WITH_VRRP_
+	new->vrrp_notify_fifo.fd = -1;
+#endif
+#ifdef _WITH_LVS_
+	new->lvs_notify_fifo.fd = -1;
 #endif
 
 #ifdef _WITH_SNMP_
@@ -224,6 +230,60 @@ init_global_data(data_t * data)
 		}
 	}
 
+	/* Check that there aren't conflicts with the notify FIFOs */
+#ifdef _WITH_VRRP_
+	/* If the global and vrrp notify FIFOs are the same, then data will be
+	 * duplicated on the FIFO */
+	if (
+#ifndef _DEBUG_
+	    prog_type == PROG_TYPE_VRRP &&
+#endif
+	    data->notify_fifo.name && data->vrrp_notify_fifo.name &&
+	    !strcmp(data->notify_fifo.name, data->vrrp_notify_fifo.name)) {
+		log_message(LOG_INFO, "notify FIFO %s has been specified for global and vrrp FIFO - ignoring vrrp FIFO", data->vrrp_notify_fifo.name);
+		FREE_PTR(data->vrrp_notify_fifo.name);
+		data->vrrp_notify_fifo.name = NULL;
+		FREE_PTR(data->vrrp_notify_fifo.script);
+		data->vrrp_notify_fifo.script = NULL;
+	}
+#endif
+#ifdef _WITH_LVS_
+	/* If the global and LVS notify FIFOs are the same, then data will be
+	 * duplicated on the FIFO */
+#ifndef _WITH_DEBUG_
+	if (prog_type == PROG_TYPE_CHECKER)
+#endif
+	{
+		if (data->notify_fifo.name && data->lvs_notify_fifo.name &&
+		    !strcmp(data->notify_fifo.name, data->lvs_notify_fifo.name)) {
+			log_message(LOG_INFO, "notify FIFO %s has been specified for global and LVS FIFO - ignoring LVS FIFO", data->lvs_notify_fifo.name);
+			FREE_PTR(data->lvs_notify_fifo.name);
+			data->lvs_notify_fifo.name = NULL;
+			FREE_PTR(data->lvs_notify_fifo.script);
+			data->lvs_notify_fifo.script = NULL;
+		}
+
+#ifdef _WITH_VRRP_
+		/* If LVS and VRRP use the same FIFO, they cannot both have a script for the FIFO.
+		 * Use the VRRP script and ignore the LVS script */
+		if (data->lvs_notify_fifo.name && data->vrrp_notify_fifo.name &&
+		    !strcmp(data->lvs_notify_fifo.name, data->vrrp_notify_fifo.name) &&
+		    data->lvs_notify_fifo.script &&
+		    data->vrrp_notify_fifo.script) {
+			log_message(LOG_INFO, "LVS notify FIFO and vrrp FIFO are the same both with scripts - ignoring LVS FIFO script");
+			FREE_PTR(data->lvs_notify_fifo.script);
+			data->lvs_notify_fifo.script = NULL;
+		}
+
+		/* If there is a script for global notify FIFO, it must only be run once, so let VRRP run it */
+		if (data->notify_fifo.script) {
+			FREE_PTR(data->notify_fifo.script);
+			data->notify_fifo.script = NULL;
+		}
+#endif
+	}
+#endif
+
 	FREE_PTR(local_name);
 }
 
@@ -241,9 +301,15 @@ free_global_data(data_t * data)
 	FREE_PTR(data->lvs_syncd.ifname);
 	FREE_PTR(data->lvs_syncd.vrrp_name);
 #endif
+	FREE_PTR(data->notify_fifo.name);
+	free_notify_script(&data->notify_fifo.script);
 #ifdef _WITH_VRRP_
-	FREE_PTR(data->vrrp_notify_fifo_name);
-	free_notify_script(&data->vrrp_notify_fifo_script);
+	FREE_PTR(data->vrrp_notify_fifo.name);
+	free_notify_script(&data->vrrp_notify_fifo.script);
+#endif
+#ifdef _WITH_LVS_
+	FREE_PTR(data->lvs_notify_fifo.name);
+	free_notify_script(&data->lvs_notify_fifo.script);
 #endif
 #if HAVE_DECL_CLONE_NEWNET
 	if (!reload)
@@ -304,16 +370,36 @@ dump_global_data(data_t * data)
 			log_message(LOG_INFO, " LVS syncd mcast ttl = %u", data->lvs_syncd.mcast_ttl);
 #endif
 	}
-	if (data->vrrp_notify_fifo_name) {
-		log_message(LOG_INFO, " VRRP notify fifo = %s", data->vrrp_notify_fifo_name);
-		if (data->vrrp_notify_fifo_script)
-			log_message(LOG_INFO, " VRRP notify fifo script = %s uid:gid %d:%d",
-				    data->vrrp_notify_fifo_script->name,
-				    data->vrrp_notify_fifo_script->uid,
-				    data->vrrp_notify_fifo_script->gid);
-	}
 #endif
 	log_message(LOG_INFO, " LVS flush = %s", data->lvs_flush ? "true" : "false");
+#endif
+	if (data->notify_fifo.name) {
+		log_message(LOG_INFO, " Global notify fifo = %s", data->notify_fifo.name);
+		if (data->notify_fifo.script)
+			log_message(LOG_INFO, " Global notify fifo script = %s uid:gid %d:%d",
+				    data->notify_fifo.script->name,
+				    data->notify_fifo.script->uid,
+				    data->notify_fifo.script->gid);
+	}
+#ifdef _WITH_VRRP_
+	if (data->vrrp_notify_fifo.name) {
+		log_message(LOG_INFO, " VRRP notify fifo = %s", data->vrrp_notify_fifo.name);
+		if (data->vrrp_notify_fifo.script)
+			log_message(LOG_INFO, " VRRP notify fifo script = %s uid:gid %d:%d",
+				    data->vrrp_notify_fifo.script->name,
+				    data->vrrp_notify_fifo.script->uid,
+				    data->vrrp_notify_fifo.script->gid);
+	}
+#endif
+#ifdef _WITH_LVS_
+	if (data->lvs_notify_fifo.name) {
+		log_message(LOG_INFO, " LVS notify fifo = %s", data->lvs_notify_fifo.name);
+		if (data->lvs_notify_fifo.script)
+			log_message(LOG_INFO, " LVS notify fifo script = %s uid:gid %d:%d",
+				    data->lvs_notify_fifo.script->name,
+				    data->lvs_notify_fifo.script->uid,
+				    data->lvs_notify_fifo.script->gid);
+	}
 #endif
 #ifdef _WITH_VRRP_
 	if (data->vrrp_mcast_group4.ss_family) {

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -563,7 +563,7 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 		return -1;
 
 #ifdef _WITH_VRRP_
-#ifndef DEBUG
+#ifndef _DEBUG_
 	if (prog_type == PROG_TYPE_VRRP)
 #endif
 	{
@@ -584,7 +584,7 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 #endif
 
 #ifdef _WITH_LVS_
-#ifndef DEBUG
+#ifndef _DEBUG_
 	if (prog_type == PROG_TYPE_CHECKER)
 #endif
 	{
@@ -707,7 +707,7 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
 #ifdef _WITH_VRRP_
 			/* Skip unsolicited messages from cmd channel */
 			if (
-#ifndef DEBUG
+#ifndef _DEBUG_
 			    prog_type == PROG_TYPE_VRRP &&
 #endif
 			    nl != &nl_cmd && h->nlmsg_pid == nl_cmd.nl_pid)
@@ -1154,7 +1154,7 @@ kernel_netlink_init(void)
 	 * subscribtion. We subscribe to LINK and ADDR
 	 * netlink broadcast messages.
 	 */
-#ifdef DEBUG
+#ifdef _DEBUG_
 #ifdef _WITH_VRRP_
 	netlink_socket(&nl_kernel, SOCK_NONBLOCK, RTNLGRP_LINK, RTNLGRP_IPV4_IFADDR, RTNLGRP_IPV6_IFADDR, 0);
 #else
@@ -1179,7 +1179,7 @@ kernel_netlink_init(void)
 		log_message(LOG_INFO, "Error while registering Kernel netlink reflector channel");
 
 #ifdef _WITH_VRRP_
-#ifndef DEBUG
+#ifndef _DEBUG_
 	if (prog_type == PROG_TYPE_VRRP)
 #endif
 	{
@@ -1198,7 +1198,7 @@ kernel_netlink_close(void)
 {
 	netlink_close(&nl_kernel);
 #ifdef _WITH_VRRP_
-#ifndef DEBUG
+#ifndef _DEBUG_
 	if (prog_type == PROG_TYPE_VRRP)
 #endif
 		netlink_close(&nl_cmd);

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -772,7 +772,7 @@ keepalived_main(int argc, char **argv)
 	debug = 0;
 
 	/* We are the parent process */
-#ifndef DEBUG
+#ifndef _DEBUG_
 	prog_type = PROG_TYPE_PARENT;
 #endif
 

--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -98,6 +98,7 @@ enum snmp_global_magic {
 	SNMP_MAIL_SMTPSERVERTIMEOUT,
 	SNMP_MAIL_EMAILFROM,
 	SNMP_MAIL_EMAILADDRESS,
+	SNMP_MAIL_SMTPSERVERPORT,
 	SNMP_TRAPS,
 	SNMP_LINKBEAT,
 	SNMP_LVSFLUSH,
@@ -137,6 +138,9 @@ snmp_scalar(struct variable *vp, oid *name, size_t *length,
 			return (u_char *)&addr4->sin_addr;
 		}
 		return NULL;
+	case SNMP_MAIL_SMTPSERVERPORT:
+		long_ret = ntohs(inet_sockaddrport(&global_data->smtp_server));
+		return (u_char *)&long_ret;
 	case SNMP_MAIL_SMTPSERVERTIMEOUT:
 		long_ret = global_data->smtp_connection_to / TIMER_HZ;
 		return (u_char *)&long_ret;
@@ -219,6 +223,8 @@ static struct variable8 global_vars[] = {
 	{SNMP_MAIL_EMAILFROM, ASN_OCTET_STR, RONLY, snmp_scalar, 2, {3, 4}},
 	/* emailTable */
 	{SNMP_MAIL_EMAILADDRESS, ASN_OCTET_STR, RONLY, snmp_mail, 4, {3, 5, 1, 2}},
+	/* SMTP server port */
+	{SNMP_MAIL_SMTPSERVERPORT, ASN_UNSIGNED, RONLY, snmp_scalar, 2, {3, 6}},
 	/* trapEnable */
 	{SNMP_TRAPS, ASN_INTEGER, RONLY, snmp_scalar, 1, {4}},
 	/* linkBeat */

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -48,6 +48,7 @@
 #ifdef _WITH_LVS_
 #include "ipvswrapper.h"
 #endif
+#include "notify.h"
 
 #ifndef _HAVE_LIBIPTC_
 #define	XT_EXTENSION_MAXNAMELEN		29
@@ -99,10 +100,6 @@ typedef struct _data {
 	int				vrrp_version;	/* VRRP version (2 or 3) */
 	char				vrrp_iptables_inchain[XT_EXTENSION_MAXNAMELEN];
 	char				vrrp_iptables_outchain[XT_EXTENSION_MAXNAMELEN];
-	char				*vrrp_notify_fifo_name;
-	int				vrrp_notify_fifo_fd;
-	bool				vrrp_created_notify_fifo;
-	notify_script_t			*vrrp_notify_fifo_script;
 #ifdef _HAVE_LIBIPSET_
 	bool				using_ipsets;
 	char				vrrp_ipset_address[IPSET_MAXNAMELEN];
@@ -118,6 +115,13 @@ typedef struct _data {
 #ifdef _WITH_LVS_
 	char				checker_process_priority;
 	bool				checker_no_swap;
+#endif
+	notify_fifo_t			notify_fifo;
+#ifdef _WITH_VRRP_
+	notify_fifo_t			vrrp_notify_fifo;
+#endif
+#ifdef _WITH_LVS_
+	notify_fifo_t			lvs_notify_fifo;
 #endif
 #ifdef _WITH_SNMP_
 	bool				enable_traps;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -224,8 +224,10 @@ check_vrrp_script_security(void)
 		}
 	}
 
-	if (global_data->vrrp_notify_fifo_script)
-		script_flags |= check_notify_script_secure(&global_data->vrrp_notify_fifo_script, global_data->script_security, false);
+	if (global_data->notify_fifo.script)
+		script_flags |= check_notify_script_secure(&global_data->notify_fifo.script, global_data->script_security, false);
+	if (global_data->vrrp_notify_fifo.script)
+		script_flags |= check_notify_script_secure(&global_data->vrrp_notify_fifo.script, global_data->script_security, false);
 
 	if (!global_data->script_security && script_flags & SC_ISSCRIPT) {
 		log_message(LOG_INFO, "SECURITY VIOLATION - scripts are being executed but script_security not enabled.%s",
@@ -1383,8 +1385,7 @@ vrrp_restore_interface(vrrp_t * vrrp, bool advF, bool force)
 	if (advF) {
 		vrrp_send_adv(vrrp, VRRP_PRIO_STOP);
 		++vrrp->stats->pri_zero_sent;
-		syslog(LOG_INFO, "VRRP_Instance(%s) sent 0 priority",
-		       vrrp->iname);
+		log_message(LOG_INFO, "VRRP_Instance(%s) sent 0 priority", vrrp->iname);
 	}
 
 #ifdef _HAVE_FIB_ROUTING_
@@ -1961,8 +1962,7 @@ shutdown_vrrp_instances(void)
 		if (vrrp->script_stop)
 			notify_exec(vrrp->script_stop);
 
-		if (global_data->vrrp_notify_fifo_fd != -1)
-			notify_instance_fifo(vrrp, VRRP_STATE_STOP);
+		notify_instance_fifo(vrrp, VRRP_STATE_STOP);
 
 #ifdef _WITH_LVS_
 		/*

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -306,7 +306,7 @@ start_vrrp(void)
 		if (!sav_errno || sav_errno == EEXIST) {
 			/* Run the notify script if there is one */
 			if (global_data->vrrp_notify_fifo_script)
-				notify_fifo_exec(master, notify_fifo_script_exit, NULL, global_data->vrrp_notify_fifo_script);
+				notify_fifo_exec(master, notify_fifo_script_exit, NULL, global_data->vrrp_notify_fifo_script, global_data->vrrp_notify_fifo_name);
 
 			/* Now open the fifo */
 			if ((global_data->vrrp_notify_fifo_fd = open(global_data->vrrp_notify_fifo_name, O_RDWR | O_CLOEXEC | O_NONBLOCK)) == -1) {

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -156,7 +156,12 @@ notify_fifo_exec(thread_master_t *m, int (*func) (thread_t *), void * arg, const
 
 	execl(script->name, script->name, NULL);
 
-	/* unreached */
+	if (errno == EACCES)
+		log_message(LOG_INFO, "FIFO notify script %s is not executable", script->name);
+	else
+		log_message(LOG_INFO, "Unable to execute FIFO notify script %s - errno %d", script->name, errno);
+
+	/* unreached unless error */
 	exit(0);
 }
 

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -128,7 +128,7 @@ script_setup(void)
 
 /* Execute external script/program */
 pid_t
-notify_fifo_exec(thread_master_t *m, int (*func) (thread_t *), void * arg, const notify_script_t *script)
+notify_fifo_exec(thread_master_t *m, int (*func) (thread_t *), void *arg, const notify_script_t *script, const char *fifo_name)
 {
 	pid_t pid;
 
@@ -154,7 +154,7 @@ notify_fifo_exec(thread_master_t *m, int (*func) (thread_t *), void * arg, const
 	set_privileges(script->uid, script->gid);
 	script_setup();
 
-	execl(script->name, script->name, NULL);
+	execl(script->name, script->name, fifo_name, NULL);
 
 	if (errno == EACCES)
 		log_message(LOG_INFO, "FIFO notify script %s is not executable", script->name);

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -154,7 +154,7 @@ notify_fifo_exec(thread_master_t *m, int (*func) (thread_t *), void * arg, const
 	set_privileges(script->uid, script->gid);
 	script_setup();
 
-	execlp(script->name, script->name, NULL);
+	execl(script->name, script->name, NULL);
 
 	/* unreached */
 	exit(0);

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -56,6 +56,77 @@ static char *path;
 static bool path_is_malloced;
 static size_t getpwnam_buf_len;				/* Buffer length needed for getpwnam_r/getgrname_r */
 
+static void
+fifo_open(notify_fifo_t* fifo, int (*script_exit)(thread_t *), const char *type)
+{
+	int ret;
+	int sav_errno;
+
+	if (fifo->name) {
+		sav_errno = 0;
+
+		if (!(ret = mkfifo(fifo->name, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)))
+			fifo->created_fifo = true;
+		else {
+			sav_errno = errno;
+
+			if (sav_errno != EEXIST)
+				log_message(LOG_INFO, "Unable to create %snotify fifo %s", type, fifo->name);
+		}
+
+		if (!sav_errno || sav_errno == EEXIST) {
+			/* Run the notify script if there is one */
+			if (fifo->script)
+				notify_fifo_exec(master, script_exit, NULL, fifo->script, fifo->name);
+
+			/* Now open the fifo */
+			if ((fifo->fd = open(fifo->name, O_RDWR | O_CLOEXEC | O_NONBLOCK)) == -1) {
+				log_message(LOG_INFO, "Unable to open %snotify fifo %s - errno %d", type, fifo->name, errno);
+				if (fifo->created_fifo) {
+					unlink(fifo->name);
+					fifo->created_fifo = false;
+				}
+			}
+		}
+
+		if (fifo->fd == -1) {
+			FREE(fifo->name);
+			fifo->name = NULL;
+		}
+	}
+}
+
+void
+notify_fifo_open(notify_fifo_t* global_fifo, notify_fifo_t* fifo, int (*script_exit)(thread_t *), const char *type)
+{
+	/* Open the global FIFO if specified */
+	if (global_fifo->name)
+		fifo_open(global_fifo, script_exit, "");
+
+	/* Now the specific FIFO */
+	fifo_open(fifo, script_exit, type);
+}
+
+static void
+fifo_close(notify_fifo_t* fifo)
+{
+	if (fifo->fd != -1) {
+		close(fifo->fd);
+		fifo->fd = -1;
+	}
+	if (fifo->created_fifo)
+		unlink(fifo->name);
+}
+
+void
+notify_fifo_close(notify_fifo_t* global_fifo, notify_fifo_t* fifo)
+{
+	if (global_fifo->fd != -1)
+		fifo_close(global_fifo);
+
+	fifo_close(fifo);
+}
+
 /* perform a system call */
 static bool
 set_privileges(uid_t uid, gid_t gid)
@@ -126,7 +197,7 @@ script_setup(void)
 	set_std_fd(false);
 }
 
-/* Execute external script/program */
+/* Execute external script/program to process FIFO */
 pid_t
 notify_fifo_exec(thread_master_t *m, int (*func) (thread_t *), void *arg, const notify_script_t *script, const char *fifo_name)
 {

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -61,7 +61,7 @@ extern gid_t default_script_gid;
 
 /* prototypes */
 extern int system_call_script(thread_master_t *, int (*) (thread_t *), void *, unsigned long, const char*, uid_t, gid_t);
-extern pid_t notify_fifo_exec(thread_master_t *, int (*func) (thread_t *), void *, const notify_script_t *);
+extern pid_t notify_fifo_exec(thread_master_t *, int (*func) (thread_t *), void *, const notify_script_t *, const char *);
 extern int notify_exec(const notify_script_t *);
 extern void script_killall(thread_master_t *, int);
 extern int check_script_secure(notify_script_t *, bool, bool);

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -46,6 +46,14 @@ typedef struct _notify_script {
 	bool	executable;	/* script is executable for uid:gid */
 } notify_script_t;
 
+/* notify_fifo details */
+typedef struct _notify_fifo {
+	char	*name;
+	int 	fd;
+	bool	created_fifo;	/* We created the FIFO */
+	notify_script_t *script; /* Script to run to process FIFO */
+} notify_fifo_t;
+
 static inline void
 free_notify_script(notify_script_t **script)
 {
@@ -60,7 +68,9 @@ extern uid_t default_script_uid;        /* Default user/group for script executi
 extern gid_t default_script_gid;
 
 /* prototypes */
-extern int system_call_script(thread_master_t *, int (*) (thread_t *), void *, unsigned long, const char*, uid_t, gid_t);
+extern void notify_fifo_open(notify_fifo_t*, notify_fifo_t*, int (*)(thread_t *), const char *);
+extern void notify_fifo_close(notify_fifo_t*, notify_fifo_t*);
+extern int system_call_script(thread_master_t *, int (*)(thread_t *), void *, unsigned long, const char*, uid_t, gid_t);
 extern pid_t notify_fifo_exec(thread_master_t *, int (*func) (thread_t *), void *, const notify_script_t *, const char *);
 extern int notify_exec(const notify_script_t *);
 extern void script_killall(thread_master_t *, int);

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -50,7 +50,7 @@
 
 /* global vars */
 thread_master_t *master = NULL;
-#ifndef DEBUG
+#ifndef _DEBUG_
 prog_type_t prog_type;		/* Parent/VRRP/Checker process */
 #endif
 
@@ -103,7 +103,7 @@ report_child_status(int status, pid_t pid, char const *prog_name)
 		}
 
 		if (exit_status != EXIT_SUCCESS
-#if defined _WITH_LVS_ && !defined DEBUG
+#if defined _WITH_LVS_ && !defined _DEBUG_
 					        && prog_type != PROG_TYPE_CHECKER
 #endif
 										 )

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -90,6 +90,7 @@ typedef struct _thread_master {
 #define THREAD_TERMINATE	10
 #define THREAD_READY_FD		11
 
+#ifndef _DEBUG__
 typedef enum {
 	PROG_TYPE_PARENT,
 #ifdef _WITH_VRRP_
@@ -99,6 +100,7 @@ typedef enum {
 	PROG_TYPE_CHECKER,
 #endif
 } prog_type_t;
+#endif
 
 /* MICRO SEC def */
 #define BOOTSTRAP_DELAY TIMER_HZ
@@ -117,7 +119,7 @@ typedef enum {
 
 /* global vars exported */
 extern thread_master_t *master;
-#ifndef DEBUG
+#ifndef _DEBUG_
 extern prog_type_t prog_type;		/* Parent/VRRP/Checker process */
 #endif
 


### PR DESCRIPTION
Issue #588 identified that keepalived could segfault if no router_id specified. Add a patch that should protect against this, although it appears that the problem would only occur if keepalived cannot get the hostname.

smtpServerPort wasn't being notified via SNMP

FIFO notify enhancements
