### PR TITLE
Fix incorrect expression in clear_services()

### DIFF
--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -224,16 +224,8 @@ clear_services(void)
 		vs = ELEMENT_DATA(e);
 		if (vs->vsg) {
 			/* Only clear the first virtual server for a virtual server group */
-			if (vs->addr.ss_family == AF_INET6) {
-				if (vs->addr.ss_family == AF_INET6) {
-					if (!((struct sockaddr_in6 *)&vs->addr)->sin6_port)
-						continue;
-				}
-				else {
-					if (!((struct sockaddr_in *)&vs->addr)->sin_port)
-						continue;
-				}
-			}
+			if (ntohs(inet_sockaddrport(&vs->addr)))
+				continue;
 		}
 		clear_service_vs(vs, false);
 	}

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -918,9 +918,9 @@ link_vsg_to_vs(void)
 
 			if (!strcmp(vs->vsgname, vsg->gname)) {
 				if (vs->addr.ss_family == AF_INET6)
-					((struct sockaddr_in6 *)&vs->addr)->sin6_port = ntohs(vsg_member_no);
+					((struct sockaddr_in6 *)&vs->addr)->sin6_port = htons(vsg_member_no);
 				else
-					((struct sockaddr_in *)&vs->addr)->sin_port = ntohs(vsg_member_no);
+					((struct sockaddr_in *)&vs->addr)->sin_port = htons(vsg_member_no);
 				vsg_member_no++;
 			}
 		}


### PR DESCRIPTION
Hi,

I found a code that seems to be a mistake in the process of clearing the IPVS service.

+ I think the first if statement of check the address family is mistake.
+ Unlike comments, it seems to be skipping only when the member number of vsg is 0.

I registered 3 entries in vsg and tested it.

```
Fri Jun  2 19:06:40 2017: Starting Keepalived v1.3.5 (06/02,2017), git commit v1.2.23-544-g7326bd8+
Fri Jun  2 19:06:40 2017: Opening file '/etc/keepalived/keepalived.conf'.
Fri Jun  2 19:06:40 2017: Starting Healthcheck child process, pid=38639
Fri Jun  2 19:06:40 2017: Opening file '/etc/keepalived/keepalived.conf'.
Fri Jun  2 19:06:40 2017: Initializing ipvs
Fri Jun  2 19:06:40 2017: Initing vs [sample]:0, vsg sample
Fri Jun  2 19:06:40 2017: Adding rs [192.168.2.1]:tcp:80
Fri Jun  2 19:06:40 2017: Adding rs [192.168.2.2]:tcp:80
Fri Jun  2 19:06:40 2017: Initing vs [sample]:1, vsg sample
Fri Jun  2 19:06:40 2017: Adding rs [192.168.3.1]:tcp:80
Fri Jun  2 19:06:40 2017: Adding rs [192.168.3.2]:tcp:80
Fri Jun  2 19:06:40 2017: Initing vs [sample]:2, vsg sample
Fri Jun  2 19:06:40 2017: Adding rs [192.168.4.1]:tcp:80
Fri Jun  2 19:06:40 2017: Adding rs [192.168.4.2]:tcp:80

(...snip...)
```

In the original code, clear_service_vs() is called by the number of entries.

```
Fri Jun  2 19:05:32 2017: Stopping
clear_service_vs(false) with [sample]:0
clear_service_vs(false) with [sample]:1
clear_service_vs(false) with [sample]:2
Fri Jun  2 19:05:32 2017: Stopped
Fri Jun  2 19:05:37 2017: Stopped Keepalived v1.3.5 (06/02,2017), git commit v1.2.23-544-g7326bd8+
```

In the case of deleted the first if statement.

```
Fri Jun  2 19:06:49 2017: Stopping
clear_service_vs(false) with [sample]:1
clear_service_vs(false) with [sample]:2
Fri Jun  2 19:06:49 2017: Stopped
Fri Jun  2 19:06:49 2017: Stopped Keepalived v1.3.5 (06/02,2017), git commit v1.2.23-544-g7326bd8+
```

In the case of this pull request code.

```
Fri Jun  2 19:08:59 2017: Stopping
clear_service_vs(false) with [sample]:0
Fri Jun  2 19:08:59 2017: Stopped
Fri Jun  2 19:08:59 2017: Stopped Keepalived v1.3.5 (06/02,2017), git commit v1.2.23-544-g7326bd8+
```

Even if `clear_service_vs()` is called more than once, `ipvs_group_cmd()` is unlikely to call `ipvs_talk()`. Therefore, the problem does not occur in the current code too, but I fixed as intended in comments.

Also, as a trivial thing, I modified to use `htons()` instead of `ntohs()`.

Regards,