### PR TITLE
Fix bad file descriptor error at reload with no virtual servers

### DIFF
--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -152,7 +152,7 @@ start_check(void)
 #endif
 
 	/* Initialize sub-system if any virtual servers are configured */
-	if (!LIST_ISEMPTY(check_data->vs) &&
+	if ((!LIST_ISEMPTY(check_data->vs) || (reload && !LIST_ISEMPTY(old_check_data->vs))) &&
 	    ipvs_start() != IPVS_SUCCESS) {
 		stop_check(KEEPALIVED_EXIT_FATAL);
 		return;


### PR DESCRIPTION
Hi,

I fixed the problem that "Bad file descriptor" error occurs at reloading.

This problem occurs when there is no virtual_server (or no real_server in the virtual_server) in the config when reloading.

*Original code*
```
Wed Jun  7 18:42:45 2017: Opening file '/etc/keepalived/keepalived.conf'.
Wed Jun  7 18:42:45 2017: Got SIGHUP, reloading checker configuration
Wed Jun  7 18:42:45 2017: Opening file '/etc/keepalived/keepalived.conf'.
Wed Jun  7 18:42:45 2017: Virtual server [sample]:0 has no real servers - ignoring
Wed Jun  7 18:42:45 2017: Removing Virtual Server Group [sample]
Wed Jun  7 18:42:45 2017: IPVS (cmd 1160, errno 9): Bad file descriptor
Wed Jun  7 18:42:45 2017: IPVS (cmd 1156, errno 9): Bad file descriptor
```

*This pull request code*
```
Wed Jun  7 19:08:14 2017: Opening file '/etc/keepalived/keepalived.conf'.
Wed Jun  7 19:08:14 2017: Got SIGHUP, reloading checker configuration
Wed Jun  7 19:08:14 2017: Opening file '/etc/keepalived/keepalived.conf'.
Wed Jun  7 19:08:14 2017: Virtual server [sample]:0 has no real servers - ignoring
Wed Jun  7 19:08:14 2017: Initializing ipvs
Wed Jun  7 19:08:14 2017: Removing Virtual Server Group [sample]
```

Regards,