### PR TITLE
Delete disabled inhibit servers at reload

### DIFF
--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -800,8 +800,12 @@ clear_diff_s_srv(virtual_server_t *old_vs, real_server_t *new_rs)
 				SET_ALIVE(old_rs);
 			old_rs->inhibit = 0;
 		}
-		if (ISALIVE(old_rs))
+		if (ISALIVE(old_rs)) {
+			log_message(LOG_INFO, "Removing sorry server %s from VS %s"
+					    , FMT_RS(old_rs, old_vs)
+					    , FMT_VS(old_vs));
 			ipvs_cmd(LVS_CMD_DEL_DEST, old_vs, old_rs);
+		}
 	}
 
 }

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -734,7 +734,11 @@ clear_diff_rs(virtual_server_t * old_vs, list new_rs_list)
 			/* Reset inhibit flag to delete inhibit entries */
 			log_message(LOG_INFO, "service %s no longer exist"
 					    , FMT_RS(rs, old_vs));
-			rs->inhibit = 0;
+			if (rs->inhibit) {
+				if (!ISALIVE(rs) && rs->set)
+					SET_ALIVE(rs);
+				rs->inhibit = 0;
+			}
 			list_add (rs_to_remove, rs);
 		} else {
 			/*
@@ -790,8 +794,15 @@ clear_diff_s_srv(virtual_server_t *old_vs, real_server_t *new_rs)
 		new_rs->pweight = old_rs->iweight;
 		new_rs->reloaded = true;
 	}
-	else if (ISALIVE(old_rs))
-		ipvs_cmd(LVS_CMD_DEL_DEST, old_vs, old_rs);
+	else {
+		if (old_rs->inhibit) {
+			if (!ISALIVE(old_rs) && old_rs->set)
+				SET_ALIVE(old_rs);
+			old_rs->inhibit = 0;
+		}
+		if (ISALIVE(old_rs))
+			ipvs_cmd(LVS_CMD_DEL_DEST, old_vs, old_rs);
+	}
 
 }
 


### PR DESCRIPTION
Hi,

I fixed a problem that some server removed from the new configuration will not be deleted at reload.

(I think that this pull request solves issue of #492)

+ current state

  ```
  # ipvsadm -L
  IP Virtual Server version 1.2.1 (size=4096)
  Prot LocalAddress:Port Scheduler Flags
    -> RemoteAddress:Port     Forward Weight ActiveConn InActConn
  TCP  192.168.100.1:http lc
    -> 192.168.2.2            Masq    0      0          0         
    -> 192.168.2.3            Masq    1      0          0     
  ```

  Inhibit_on_failure is set in 192.168.2.2

+ delete realserver `192.168.2.2` from virtualserver & reload

  ```
  # ipvsadm -L
  IP Virtual Server version 1.2.1 (size=4096)
  Prot LocalAddress:Port Scheduler Flags
    -> RemoteAddress:Port     Forward Weight ActiveConn InActConn
  TCP  192.168.100.1:http lc
    -> 192.168.2.2            Masq    0      0          0         
    -> 192.168.2.3            Masq    1      0          0     
  ```

  `192.168.2.2` has been deleted from the new configuration, but it remains in the IPVS entry after reloading.

  If the weight is not 0 (that's alive), it's deleted from the IPVS entry after reloading.

  ```
  # ipvsadm -L
  IP Virtual Server version 1.2.1 (size=4096)
  Prot LocalAddress:Port Scheduler Flags
    -> RemoteAddress:Port     Forward Weight ActiveConn InActConn
  TCP  192.168.100.1:http lc
    -> 192.168.2.3            Masq    1      0          0     
  ```

    In this case, it will be deleted regardless of the ActiveConn.

I think that it's better to delete non alived servers as well.

We can delete it after confirming that there is no active connection, but it seems to very troublesome.

(If I have not overlooked something...)

Regards, 