### PR TITLE
Fix thread_cancel() for timed out threads

### DIFF
--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -502,6 +502,8 @@ thread_cancel(thread_t * thread)
 		break;
 	case THREAD_READY:
 	case THREAD_READY_FD:
+	case THREAD_READ_TIMEOUT:
+	case THREAD_WRITE_TIMEOUT:
 		thread_list_delete(&thread->master->ready, thread);
 		break;
 	default:


### PR DESCRIPTION
If a thread times out, then it will move to the ready list and either
READ_TIMEOUT or WRITE_TIMEOUT.  If we then cancel this thread, it doesn't
get cleaned up and gets stuck back on the unused list for reuse.