### PR TITLE
Set sorry_server's fowarding_method

### DIFF
--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -373,6 +373,7 @@ alloc_ssvr(char *ip, char *port)
 	vs->s_svr = (real_server_t *) MALLOC(sizeof(real_server_t));
 	vs->s_svr->weight = 1;
 	vs->s_svr->iweight = 1;
+	vs->s_svr->forwarding_method = vs->forwarding_method;
 	inet_stosockaddr(ip, port, &vs->s_svr->addr);
 
 	if (!vs->af)


### PR DESCRIPTION
Hi,

I have fixed an issue where forwarding_method was not set for sorry_server.

When `lb_kind` is DR:
```
# ipvsadm -L
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  192.168.100.1:http lc
  -> 192.168.2.2:http             Route   0      0          0         
  -> 192.168.2.254:http           Masq    1      0          0   
```
sorry_server(192.168.2.254)'s Forward should be `Route`, but  it was set `Masq`.

This problem seems to be occurring at the https://github.com/acassen/keepalived/commit/b54589ae32406c2ea9f7bc523b27c66570c0d082.

For sorry_server, copying forwarding_method from virtual_server solved the problem.
```
# ipvsadm -L
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  192.168.100.1:http lc
  -> 192.168.2.2:http             Route   0      0          0         
  -> 192.168.2.254:http           Route   1      0          0  
```

Regards,