### PR TITLE
[WIP] Migrate failed checkers at reload

### DIFF
--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -42,8 +42,9 @@
 #include "check_dns.h"
 
 /* Global vars */
-static checker_id_t ncheckers = 0;
+checker_id_t ncheckers = 0;
 list checkers_queue;
+list old_checkers_queue;
 
 /* free checker data */
 static void
@@ -80,6 +81,7 @@ dump_conn_opts(void *data)
 void
 queue_checker(void (*free_func) (void *), void (*dump_func) (void *)
 	      , int (*launch) (thread_t *)
+	      , int (*compare) (void *, void *)
 	      , void *data
 	      , conn_opts_t *co)
 {
@@ -96,6 +98,7 @@ queue_checker(void (*free_func) (void *), void (*dump_func) (void *)
 	checker->free_func = free_func;
 	checker->dump_func = dump_func;
 	checker->launch = launch;
+	checker->compare = compare;
 	checker->vs = vs;
 	checker->rs = rs;
 	checker->data = data;
@@ -115,6 +118,30 @@ queue_checker(void (*free_func) (void *), void (*dump_func) (void *)
 		*id = checker->id;
 		list_add (fc, id);
 	}
+}
+
+int
+compare_conn_opts(conn_opts_t *a, conn_opts_t *b)
+{
+	if (a == b)
+		return 0;
+
+	if (!a || !b)
+		goto err;
+	if (!sockstorage_equal(&a->dst, &b->dst))
+		goto err;
+	if (!sockstorage_equal(&a->bindto, &b->bindto))
+		goto err;
+	//if (a->connection_to != b->connection_to)
+	//	goto err;
+#ifdef _WITH_SO_MARK_
+	if (a->fwmark != b->fwmark)
+		goto err;
+#endif
+
+	return  0;
+err:
+	return -1;
 }
 
 static void

--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -81,7 +81,7 @@ dump_conn_opts(void *data)
 void
 queue_checker(void (*free_func) (void *), void (*dump_func) (void *)
 	      , int (*launch) (thread_t *)
-	      , int (*compare) (void *, void *)
+	      , bool (*compare) (void *, void *)
 	      , void *data
 	      , conn_opts_t *co)
 {
@@ -120,28 +120,26 @@ queue_checker(void (*free_func) (void *), void (*dump_func) (void *)
 	}
 }
 
-int
+bool
 compare_conn_opts(conn_opts_t *a, conn_opts_t *b)
 {
 	if (a == b)
-		return 0;
+		return true;
 
 	if (!a || !b)
-		goto err;
+		return false;
 	if (!sockstorage_equal(&a->dst, &b->dst))
-		goto err;
+		return false;
 	if (!sockstorage_equal(&a->bindto, &b->bindto))
-		goto err;
-	//if (a->connection_to != b->connection_to)
-	//	goto err;
+		return false;
+	if (a->connection_to != b->connection_to)
+		return false;
 #ifdef _WITH_SO_MARK_
 	if (a->fwmark != b->fwmark)
-		goto err;
+		return false;
 #endif
 
-	return  0;
-err:
-	return -1;
+	return true;
 }
 
 static void

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -253,7 +253,11 @@ reload_check_thread(__attribute__((unused)) thread_t * thread)
 	thread_cleanup_master(master);
 	free_global_data(global_data);
 
-	free_checkers_queue();
+	/* Save previous checker data */
+	old_checkers_queue = checkers_queue;
+	checkers_queue = NULL;
+	ncheckers = 0;
+
 	free_ssl();
 	ipvs_stop();
 
@@ -266,6 +270,7 @@ reload_check_thread(__attribute__((unused)) thread_t * thread)
 
 	/* free backup data */
 	free_check_data(old_check_data);
+	free_list(&old_checkers_queue);
 	UNSET_RELOAD;
 
 	return 0;

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -388,6 +388,26 @@ dns_dump(void *data)
 	log_message(LOG_INFO, "   Name = %s", dns_check->name);
 }
 
+static int
+dns_compare(void *a, void *b)
+{
+	dns_check_t *old = CHECKER_DATA(a);
+	dns_check_t *new = CHECKER_DATA(b);
+
+	if (compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)) != 0)
+		goto err;
+	if (old->retry != new->retry)
+		goto err;
+	if (strcmp(old->type, new->type) != 0)
+		goto err;
+	if (strcmp(old->name, new->name) != 0)
+		goto err;
+
+	return  0;
+err:
+	return -1;
+}
+
 static void
 dns_check_handler(__attribute__((unused)) vector_t * strvec)
 {
@@ -396,8 +416,8 @@ dns_check_handler(__attribute__((unused)) vector_t * strvec)
 	dns_check->attempts = 0;
 	dns_check->type = DNS_DEFAULT_TYPE;
 	dns_check->name = DNS_DEFAULT_NAME;
-	queue_checker(dns_free, dns_dump, dns_connect_thread, dns_check,
-		      CHECKER_NEW_CO());
+	queue_checker(dns_free, dns_dump, dns_connect_thread,
+		      dns_compare, dns_check, CHECKER_NEW_CO());
 }
 
 static void

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -396,8 +396,6 @@ dns_check_compare(void *a, void *b)
 
 	if (!compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)))
 		return false;
-	if (old->retry != new->retry)
-		return false;
 	if (strcmp(old->type, new->type) != 0)
 		return false;
 	if (strcmp(old->name, new->name) != 0)

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -388,24 +388,22 @@ dns_dump(void *data)
 	log_message(LOG_INFO, "   Name = %s", dns_check->name);
 }
 
-static int
-dns_compare(void *a, void *b)
+static bool 
+dns_check_compare(void *a, void *b)
 {
 	dns_check_t *old = CHECKER_DATA(a);
 	dns_check_t *new = CHECKER_DATA(b);
 
-	if (compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)) != 0)
-		goto err;
+	if (!compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)))
+		return false;
 	if (old->retry != new->retry)
-		goto err;
+		return false;
 	if (strcmp(old->type, new->type) != 0)
-		goto err;
+		return false;
 	if (strcmp(old->name, new->name) != 0)
-		goto err;
+		return false;
 
-	return  0;
-err:
-	return -1;
+	return true;
 }
 
 static void
@@ -417,7 +415,7 @@ dns_check_handler(__attribute__((unused)) vector_t * strvec)
 	dns_check->type = DNS_DEFAULT_TYPE;
 	dns_check->name = DNS_DEFAULT_NAME;
 	queue_checker(dns_free, dns_dump, dns_connect_thread,
-		      dns_compare, dns_check, CHECKER_NEW_CO());
+		      dns_check_compare, dns_check, CHECKER_NEW_CO());
 }
 
 static void

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -133,10 +133,6 @@ http_get_check_compare(void *a, void *b)
 
 	if (!compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)))
 		return false;
-	if (old->nb_get_retry != new->nb_get_retry)
-		return false;
-	if (old->delay_before_retry != new->delay_before_retry)
-		return false;
 	if (LIST_SIZE(old->url) != LIST_SIZE(new->url))
 		return false;
 	for (n = 0; n < LIST_SIZE(new->url); n++) {

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -123,36 +123,34 @@ alloc_http_get(char *proto)
 	return http_get_chk;
 }
 
-static int
-compare_http_get_check(void *a, void *b)
+static bool
+http_get_check_compare(void *a, void *b)
 {
 	http_checker_t *old = CHECKER_DATA(a);
 	http_checker_t *new = CHECKER_DATA(b);
 	size_t n;
 	url_t *u1, *u2;
 
-	if (compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)) != 0)
-		goto err;
+	if (!compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)))
+		return false;
 	if (old->nb_get_retry != new->nb_get_retry)
-		goto err;
+		return false;
 	if (old->delay_before_retry != new->delay_before_retry)
-		goto err;
+		return false;
 	if (LIST_SIZE(old->url) != LIST_SIZE(new->url))
-		goto err;
+		return false;
 	for (n = 0; n < LIST_SIZE(new->url); n++) {
 		u1 = (url_t *)list_element(old->url, n);
 		u2 = (url_t *)list_element(new->url, n);
 		if (strcmp(u1->path, u2->path) != 0)
-			goto err;
+			return false;
 		if (strcmp(u1->digest, u2->digest) != 0)
-			goto err;
+			return false;
 		if (u1->status_code != u2->status_code)
-			goto err;
+			return false;
 	}
 
-	return  0;
-err:
-	return -1;
+	return true;
 }
 
 static void
@@ -164,7 +162,7 @@ http_get_handler(vector_t *strvec)
 	/* queue new checker */
 	http_get_chk = alloc_http_get(str);
 	queue_checker(free_http_get_check, dump_http_get_check,
-		      http_connect_thread, compare_http_get_check,
+		      http_connect_thread, http_get_check_compare,
 		      http_get_chk, CHECKER_NEW_CO());
 }
 

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -79,12 +79,6 @@ misc_check_compare(void *a, void *b)
 
 	if (strcmp(old->path, new->path) != 0)
 		return false;
-	if (old->timeout != new->timeout)
-		return false;
-	if (old->dynamic != new->dynamic)
-		return false;
-	if (old->uid != new->uid || new->gid != new->gid)
-		return false;
 
 	return true;
 }

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -71,24 +71,22 @@ dump_misc_check(void *data)
 	log_message(LOG_INFO, "   insecure = %s", misck_checker->insecure ? "Yes" : "No");
 }
 
-static int
-compare_misc_check(void *a, void *b)
+static bool
+misc_check_compare(void *a, void *b)
 {
 	misc_checker_t *old = CHECKER_DATA(a);
 	misc_checker_t *new = CHECKER_DATA(b);
 
 	if (strcmp(old->path, new->path) != 0)
-		goto err;
+		return false;
 	if (old->timeout != new->timeout)
-		goto err;
+		return false;
 	if (old->dynamic != new->dynamic)
-		goto err;
+		return false;
 	if (old->uid != new->uid || new->gid != new->gid)
-		goto err;
+		return false;
 
-	return  0;
-err:
-	return -1;
+	return true;
 }
 
 static void
@@ -166,7 +164,7 @@ misc_end_handler(void)
 	}
 
 	/* queue new checker */
-	queue_checker(free_misc_check, dump_misc_check, misc_check_thread, compare_misc_check, misck_checker, NULL);
+	queue_checker(free_misc_check, dump_misc_check, misc_check_thread, misc_check_compare, misck_checker, NULL);
 	misck_checker = NULL;
 }
 

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -71,6 +71,26 @@ dump_misc_check(void *data)
 	log_message(LOG_INFO, "   insecure = %s", misck_checker->insecure ? "Yes" : "No");
 }
 
+static int
+compare_misc_check(void *a, void *b)
+{
+	misc_checker_t *old = CHECKER_DATA(a);
+	misc_checker_t *new = CHECKER_DATA(b);
+
+	if (strcmp(old->path, new->path) != 0)
+		goto err;
+	if (old->timeout != new->timeout)
+		goto err;
+	if (old->dynamic != new->dynamic)
+		goto err;
+	if (old->uid != new->uid || new->gid != new->gid)
+		goto err;
+
+	return  0;
+err:
+	return -1;
+}
+
 static void
 misc_check_handler(__attribute__((unused)) vector_t *strvec)
 {
@@ -146,7 +166,7 @@ misc_end_handler(void)
 	}
 
 	/* queue new checker */
-	queue_checker(free_misc_check, dump_misc_check, misc_check_thread, misck_checker, NULL);
+	queue_checker(free_misc_check, dump_misc_check, misc_check_thread, compare_misc_check, misck_checker, NULL);
 	misck_checker = NULL;
 }
 

--- a/keepalived/check/check_smtp.c
+++ b/keepalived/check/check_smtp.c
@@ -82,6 +82,37 @@ dump_smtp_check(void *data)
 	dump_list(smtp_checker->host);
 }
 
+static int
+compare_smtp_check(void *a, void *b)
+{
+	smtp_checker_t *old = CHECKER_DATA(a);
+	smtp_checker_t *new = CHECKER_DATA(b);
+	size_t n;
+	smtp_host_t *h1, *h2;
+
+	if (strcmp(old->helo_name, new->helo_name) != 0)
+		goto err;
+	if (old->retry != new->retry)
+		goto err;
+	if (old->db_retry != new->db_retry)
+		goto err;
+	if (compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)) != 0)
+		goto err;
+	if (LIST_SIZE(old->host) != LIST_SIZE(new->host))
+		goto err;
+	for (n = 0; n < LIST_SIZE(new->host); n++) {
+		h1 = (smtp_host_t *)list_element(old->host, n);
+		h2 = (smtp_host_t *)list_element(new->host, n);
+		if (compare_conn_opts(h1, h2) != 0) {
+			goto err;
+		}
+	}
+
+	return  0;
+err:
+	return -1;
+}
+
 /* Allocates a default host structure */
 static smtp_host_t *
 smtp_alloc_host(void)
@@ -136,7 +167,7 @@ smtp_check_handler(__attribute__((unused)) vector_t *strvec)
 	 *               void *data, conn_opts_t *)
 	 */
 	queue_checker(free_smtp_check, dump_smtp_check, smtp_connect_thread,
-		      smtp_checker, smtp_checker->default_co);
+		      compare_smtp_check, smtp_checker, smtp_checker->default_co);
 
 	/*
 	 * Last, allocate the list that will hold all the per host

--- a/keepalived/check/check_smtp.c
+++ b/keepalived/check/check_smtp.c
@@ -92,10 +92,6 @@ smtp_check_compare(void *a, void *b)
 
 	if (strcmp(old->helo_name, new->helo_name) != 0)
 		return false;
-	if (old->retry != new->retry)
-		return false;
-	if (old->db_retry != new->db_retry)
-		return false;
 	if (!compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)))
 		return false;
 	if (LIST_SIZE(old->host) != LIST_SIZE(new->host))

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -70,10 +70,6 @@ tcp_check_compare(void *a, void *b)
 
 	if (!compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)))
 		return false;
-	if (old->n_retry != new->n_retry)
-		return false;
-	if (old->delay_before_retry != new->delay_before_retry)
-		return false;
 
 	return true;
 }

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -62,22 +62,20 @@ dump_tcp_check(void *data)
 	}
 }
 
-static int
-compare_tcp_check(void *a, void *b)
+static bool
+tcp_check_compare(void *a, void *b)
 {
 	tcp_check_t *old = CHECKER_DATA(a);
 	tcp_check_t *new = CHECKER_DATA(b);
 
-	if (compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)) != 0)
-		goto err;
+	if (!compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)))
+		return false;
 	if (old->n_retry != new->n_retry)
-		goto err;
+		return false;
 	if (old->delay_before_retry != new->delay_before_retry)
-		goto err;
+		return false;
 
-	return  0;
-err:
-	return -1;
+	return true;
 }
 
 static void
@@ -91,7 +89,7 @@ tcp_check_handler(__attribute__((unused)) vector_t *strvec)
 
 	/* queue new checker */
 	queue_checker(free_tcp_check, dump_tcp_check, tcp_connect_thread,
-		      compare_tcp_check, tcp_check, CHECKER_NEW_CO());
+		      tcp_check_compare, tcp_check, CHECKER_NEW_CO());
 }
 
 static void

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -62,6 +62,24 @@ dump_tcp_check(void *data)
 	}
 }
 
+static int
+compare_tcp_check(void *a, void *b)
+{
+	tcp_check_t *old = CHECKER_DATA(a);
+	tcp_check_t *new = CHECKER_DATA(b);
+
+	if (compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b)) != 0)
+		goto err;
+	if (old->n_retry != new->n_retry)
+		goto err;
+	if (old->delay_before_retry != new->delay_before_retry)
+		goto err;
+
+	return  0;
+err:
+	return -1;
+}
+
 static void
 tcp_check_handler(__attribute__((unused)) vector_t *strvec)
 {
@@ -72,8 +90,8 @@ tcp_check_handler(__attribute__((unused)) vector_t *strvec)
 	tcp_check->delay_before_retry = 1 * TIMER_HZ;
 
 	/* queue new checker */
-	queue_checker(free_tcp_check, dump_tcp_check, tcp_connect_thread
-		      ,tcp_check, CHECKER_NEW_CO());
+	queue_checker(free_tcp_check, dump_tcp_check, tcp_connect_thread,
+		      compare_tcp_check, tcp_check, CHECKER_NEW_CO());
 }
 
 static void

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -741,7 +741,7 @@ migrate_failed_checkers(real_server_t *old_rs, real_server_t *new_rs)
 			if (old_c->compare == new_c->compare && new_c->compare(old_c, new_c) == 0) {
 				if (svr_checker_up(old_c->id, old_rs) == 0) {
 					id = (checker_id_t *) MALLOC(sizeof(checker_id_t));
-					*id = old_c->id;
+					*id = new_c->id;
 					list_add(new_rs->failed_checkers, id);
 				}
 				break;

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -748,6 +748,9 @@ migrate_failed_checkers(real_server_t *old_rs, real_server_t *new_rs)
 			}
 		}
 	}
+
+	if (LIST_ISEMPTY(new_rs->failed_checkers))
+		SET_ALIVE(new_rs);
 end:
 	free_list(&l);
 }

--- a/keepalived/include/check_api.h
+++ b/keepalived/include/check_api.h
@@ -36,7 +36,7 @@ typedef struct _checker {
 	void				(*free_func) (void *);
 	void				(*dump_func) (void *);
 	int				(*launch) (struct _thread *);
-	int				(*compare) (void *, void *);
+	bool				(*compare) (void *, void *);
 	virtual_server_t		*vs;	/* pointer to the checker thread virtualserver */
 	real_server_t			*rs;	/* pointer to the checker thread realserver */
 	void				*data;
@@ -72,10 +72,10 @@ extern void free_vs_checkers(virtual_server_t *);
 extern void dump_conn_opts(void *);
 extern void queue_checker(void (*free_func) (void *), void (*dump_func) (void *)
 			  , int (*launch) (thread_t *)
-			  , int (*compare) (void *, void *)
+			  , bool (*compare) (void *, void *)
 			  , void *
 			  , conn_opts_t *);
-extern int  compare_conn_opts(conn_opts_t *, conn_opts_t *);
+extern bool compare_conn_opts(conn_opts_t *, conn_opts_t *);
 extern void dump_checkers_queue(void);
 extern void free_checkers_queue(void);
 extern void register_checkers_thread(void);

--- a/keepalived/include/check_api.h
+++ b/keepalived/include/check_api.h
@@ -36,6 +36,7 @@ typedef struct _checker {
 	void				(*free_func) (void *);
 	void				(*dump_func) (void *);
 	int				(*launch) (struct _thread *);
+	int				(*compare) (void *, void *);
 	virtual_server_t		*vs;	/* pointer to the checker thread virtualserver */
 	real_server_t			*rs;	/* pointer to the checker thread realserver */
 	void				*data;
@@ -46,7 +47,9 @@ typedef struct _checker {
 } checker_t;
 
 /* Checkers queue */
+extern checker_id_t ncheckers;
 extern list checkers_queue;
+extern list old_checkers_queue;
 
 /* utility macro */
 #define CHECKER_ARG(X) ((X)->data)
@@ -69,8 +72,10 @@ extern void free_vs_checkers(virtual_server_t *);
 extern void dump_conn_opts(void *);
 extern void queue_checker(void (*free_func) (void *), void (*dump_func) (void *)
 			  , int (*launch) (thread_t *)
+			  , int (*compare) (void *, void *)
 			  , void *
 			  , conn_opts_t *);
+extern int  compare_conn_opts(conn_opts_t *, conn_opts_t *);
 extern void dump_checkers_queue(void);
 extern void free_checkers_queue(void);
 extern void register_checkers_thread(void);


### PR DESCRIPTION
This patch is a proposal to #608.

As pointed out by issue, there is a problem that inconsistency will occur in the checker_id before and after reload.

Between the old_rs and the new_rs, it is necessary to correctly migrate the checker_id stored in failed_checkers.

However, comparing the definitions of the checkers and confirming the identity takes time and effort. So, as a provisional implementation, if realserver is not alived I tried to handled all checkers as failed.

After this, I trying to implement the comparison of all health checkers.