### PR TITLE
Various build fixes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,8 +80,12 @@ AC_DEFUN([get_lib_name],
     LIBS="$SAV_LIBS"
   ])
 
+m4_ifndef([AS_VAR_COPY],
+[m4_define([AS_VAR_COPY],
+[AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
+
 dnl ----[ Process this file with autoconf to produce a configure script ]----
-AC_PREREQ([2.65])
+AC_PREREQ([2.63])
 AC_INIT([Keepalived], [1.3.5], [keepalived-devel@lists.sourceforge.net], [], [http://www.keepalived.org/])
 AM_INIT_AUTOMAKE([-Wall -Werror -Woverride foreign])
 

--- a/genhash/Makefile.am
+++ b/genhash/Makefile.am
@@ -6,14 +6,14 @@
 
 AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
-AM_LDFLAGS		= $(KA_LDFLAGS) $(GENHASH_LIBS) $(DEBUG_LDFLAGS)
+AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBTOOLFLAGS	= $(KA_LIBTOOLFLAGS)
 
 bin_PROGRAMS		= genhash
 AM_CPPFLAGS		+= -I$(srcdir)/../lib
 
 genhash_SOURCES		= main.c sock.c layer4.c http.c ssl.c
-genhash_LDADD		= ../lib/liblib.a $(KA_LIBS)
+genhash_LDADD		= ../lib/liblib.a $(KA_LIBS) $(GENHASH_LIBS)
 
 noinst_HEADERS		= $(srcdir)/include/*.h
 


### PR DESCRIPTION
Notably, downgrade autoconf dependency to the one used on Cent OS6, and fix genhash link phase by moving libraries to link to in appropriate place.