### PR TITLE
Fix build error at when _HAVE_IPV4_DEVCONF_ was undefined

### DIFF
--- a/keepalived/vrrp/vrrp_if_config.c
+++ b/keepalived/vrrp/vrrp_if_config.c
@@ -74,15 +74,15 @@
 #include <limits.h>
 #include <unistd.h>
 
+#ifdef _HAVE_VRRP_VMAC_
+static int all_rp_filter = -1;
+static int default_rp_filter = -1;
+#endif
+
 #ifdef _HAVE_IPV4_DEVCONF_
 
 #ifdef _LIBNL_DYNAMIC_
 #include "libnl_link.h"
-#endif
-
-#ifdef _HAVE_VRRP_VMAC_
-static int all_rp_filter = -1;
-static int default_rp_filter = -1;
 #endif
 
 static inline int


### PR DESCRIPTION
```
$ make

... (snip) ...

  CC       vrrp_if_config.o
vrrp_if_config.c: In function ‘clear_rp_filter’:
vrrp_if_config.c:536:3: warning: implicit declaration of function ‘log_message’ [-Wimplicit-function-declaration]
   log_message(LOG_INFO, "Unable to read sysctl net.ipv4.conf.all.rp_filter");
   ^
vrrp_if_config.c:544:2: error: ‘all_rp_filter’ undeclared (first use in this function)
  all_rp_filter = rp_filter;
  ^
vrrp_if_config.c:544:2: note: each undeclared identifier is reported only once for each function it appears in
vrrp_if_config.c:551:3: error: ‘default_rp_filter’ undeclared (first use in this function)
   default_rp_filter = rp_filter;
   ^
vrrp_if_config.c: In function ‘restore_rp_filter’:
vrrp_if_config.c:585:6: error: ‘all_rp_filter’ undeclared (first use in this function)
  if (all_rp_filter == -1)
      ^
vrrp_if_config.c:594:6: error: ‘default_rp_filter’ undeclared (first use in this function)
  if (default_rp_filter != -1) {
      ^
vrrp_if_config.c: In function ‘set_interface_parameters’:
vrrp_if_config.c:624:6: error: ‘all_rp_filter’ undeclared (first use in this function)
  if (all_rp_filter == -1)
      ^
Makefile:386: recipe for target 'vrrp_if_config.o' failed
make[2]: *** [vrrp_if_config.o] Error 1
make[2]: Leaving directory '/home/pandax381/LOCAL/src/keepalived/keepalived/vrrp'
Makefile:564: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/pandax381/LOCAL/src/keepalived/keepalived'
Makefile:355: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```