### PR TITLE
Fix typo in help

### DIFF
--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -560,7 +560,7 @@ usage(const char *prog)
 #ifdef _MEM_CHECK_LOG_
 	fprintf(stderr, "  -L, --mem-check-log          Log malloc/frees to syslog\n");
 #endif
-	fprintf(stderr, "  -i, --config_id id           Skip any configuration lines beginning '@' that don't match id\n");
+	fprintf(stderr, "  -i, --config-id id           Skip any configuration lines beginning '@' that don't match id\n");
 	fprintf(stderr, "  -v, --version                Display the version number\n");
 	fprintf(stderr, "  -h, --help                   Display this help message\n");
 }


### PR DESCRIPTION
The correct name of the parameter is "--config-id" instead "--config_id".