### PR TITLE
Allow custom DBus service name

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -148,6 +148,8 @@ global_defs {				# Block identification
     enable_traps			   # enable SNMP trap generation
 					   #
     enable_dbus				   # enable the DBus interface
+    dbus_service_name SERVICE_NAME	   # Name of DBus service (default org.keepalived.Vrrp1)
+					   # Useful if you want to run multiple keepalived processes with DBus enabled
 					   #
     script_user USERNAME [GROUPNAME]	   # Specify the default username/groupname to run scripts under
 					   # If groupname is not specified, the group of the user is used.

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -189,8 +189,10 @@ and
  enable_snmp_rfcv3            # enable SNMP handling of RFC6527 VRRP MIB
  enable_traps                 # enable SNMP traps
 
- # If Keepalived has been build with DBus support, the following keyword is available
- enable_dbus                  # enable the DBus interface
+ # If Keepalived has been build with DBus support, the following keywords are available
+ enable_dbus                       # enable the DBus interface
+ dbus_service_name SERVICE_NAME    # Name of DBus service (default org.keepalived.Vrrp1)
+                                   # Useful if you want to run multiple keepalived processes with DBus enabled
 
  # Specify the default username/groupname to run scripts under.
  # If this option is not specified, the user defaults to keepalived_script

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -468,6 +468,7 @@ dump_global_data(data_t * data)
 #endif
 #ifdef _WITH_DBUS_
 	log_message(LOG_INFO, " DBus %s", data->enable_dbus ? "enabled" : "disabled");
+	log_message(LOG_INFO, " DBus service name = %s", data->dbus_service_name);
 #endif
 	log_message(LOG_INFO, " Script security %s", data->script_security ? "enabled" : "disabled");
 	log_message(LOG_INFO, " Default script uid:gid %d:%d", default_script_uid, default_script_gid);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -752,6 +752,13 @@ enable_dbus_handler(__attribute__((unused)) vector_t *strvec)
 {
 	global_data->enable_dbus = true;
 }
+
+static void
+dbus_service_name_handler(vector_t *strvec)
+{
+	FREE_PTR(global_data->dbus_service_name);
+	global_data->dbus_service_name = set_value(strvec);
+}
 #endif
 
 static void
@@ -878,6 +885,7 @@ init_global_keywords(bool global_active)
 #endif
 #ifdef _WITH_DBUS_
 	install_keyword("enable_dbus", &enable_dbus_handler);
+	install_keyword("dbus_service_name", &dbus_service_name_handler);
 #endif
 	install_keyword("script_user", &script_user_handler);
 	install_keyword("enable_script_security", &script_security_handler);

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -137,6 +137,7 @@ typedef struct _data {
 #endif
 #ifdef _WITH_DBUS_
 	bool				enable_dbus;
+	char				*dbus_service_name;
 #endif
 	bool				script_security;
 } data_t;

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -55,6 +55,7 @@
 #include "vrrp_data.h"
 #include "vrrp_if.h"
 #include "vrrp_print.h"
+#include "global_data.h"
 #include "main.h"
 #include "memory.h"
 #include "logger.h"
@@ -578,6 +579,7 @@ dbus_main(__attribute__ ((unused)) void *unused)
 {
 	gchar *introspection_xml;
 	guint owner_id;
+	const char *service_name;
 
 	objects = g_hash_table_new(g_str_hash, g_str_equal);
 
@@ -613,8 +615,9 @@ dbus_main(__attribute__ ((unused)) void *unused)
 		return NULL;
 	}
 
+	service_name = global_data->dbus_service_name ? global_data->dbus_service_name : DBUS_SERVICE_NAME;
 	owner_id = g_bus_own_name(G_BUS_TYPE_SYSTEM,
-				  DBUS_SERVICE_NAME,
+				  service_name,
 				  G_BUS_NAME_OWNER_FLAGS_NONE,
 				  on_bus_acquired,
 				  on_name_acquired,

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -451,6 +451,7 @@ static int
 dbus_create_object_params(char *instance_name, const char *interface_name, int vrid, sa_family_t family, bool log_success)
 {
 	gchar *object_path;
+	GError *local_error = NULL;
 
 	if (g_hash_table_lookup(objects, instance_name)) {
 		log_message(LOG_INFO, "An object for instance %s already exists", instance_name);
@@ -461,7 +462,12 @@ dbus_create_object_params(char *instance_name, const char *interface_name, int v
 
 	guint instance = g_dbus_connection_register_object(global_connection, object_path,
 						vrrp_instance_introspection_data->interfaces[0],
-						&interface_vtable, NULL, NULL, NULL);
+						&interface_vtable, NULL, NULL, &local_error);
+	if (local_error != NULL) {
+		log_message(LOG_INFO, "Registering DBus object on %s failed: %s",
+			    object_path, local_error->message);
+		g_clear_error(&local_error);
+	}
 
 	if (instance) {
 		g_hash_table_insert(objects, instance_name, GUINT_TO_POINTER(instance));
@@ -477,6 +483,27 @@ static void
 dbus_create_object(vrrp_t *vrrp)
 {
 	dbus_create_object_params(vrrp->iname, IF_NAME(IF_BASE_IFP(vrrp->ifp)), vrrp->vrid, vrrp->family, false);
+}
+
+static bool
+dbus_emit_signal(GDBusConnection *connection,
+		 const gchar *object_path,
+		 const gchar *interface_name,
+		 const gchar *signal_name,
+		 GVariant *parameters)
+{
+	GError *local_error = NULL;
+
+	g_dbus_connection_emit_signal(connection, NULL, object_path, interface_name, signal_name, parameters,
+				      &local_error);
+
+	if (local_error != NULL) {
+		log_message(LOG_INFO, "Emitting DBus signal %s.%s on %s failed: %s",
+			    interface_name, signal_name, object_path, local_error->message);
+		g_clear_error(&local_error);
+		return false;
+	}
+	return true;
 }
 
 /* first function to be run when trying to own bus,
@@ -497,9 +524,14 @@ on_bus_acquired(GDBusConnection *connection,
 	path = dbus_object_create_path_vrrp();
 	guint vrrp = g_dbus_connection_register_object(connection, path,
 							 vrrp_introspection_data->interfaces[0],
-							 &interface_vtable, NULL, NULL, NULL);
+							 &interface_vtable, NULL, NULL, &local_error);
 	g_hash_table_insert(objects, "__Vrrp__", GUINT_TO_POINTER(vrrp));
 	g_free(path);
+	if (local_error != NULL) {
+		log_message(LOG_INFO, "Registering VRRP object on %s failed: %s",
+			    path, local_error->message);
+		g_clear_error(&local_error);
+	}
 
 	/* for each available VRRP instance, register an object */
 	if (LIST_ISEMPTY(vrrp_data->vrrp))
@@ -512,8 +544,7 @@ on_bus_acquired(GDBusConnection *connection,
 
 	/* Send a signal to say we have started */
 	path = dbus_object_create_path_vrrp();
-	g_dbus_connection_emit_signal(global_connection, NULL, path,
-				      DBUS_VRRP_INTERFACE, "VrrpStarted", NULL, &local_error);
+	dbus_emit_signal(global_connection, path, DBUS_VRRP_INTERFACE, "VrrpStarted", NULL);
 	g_free(path);
 
 	/* Notify DBus of the state of our instances */
@@ -592,7 +623,7 @@ dbus_main(__attribute__ ((unused)) void *unused)
 #ifdef DBUS_NEED_G_TYPE_INIT
 	g_type_init();
 #endif
-	GError *error;
+	GError *error = NULL;
 
 	/* read service interface data from xml files */
 	introspection_xml = read_file(DBUS_VRRP_INTERFACE_FILE_PATH);
@@ -600,8 +631,10 @@ dbus_main(__attribute__ ((unused)) void *unused)
 		return NULL;
 	vrrp_introspection_data = g_dbus_node_info_new_for_xml(introspection_xml, &error);
 	free(introspection_xml);
-	if (!vrrp_introspection_data) {
-		log_message(LOG_INFO, "%s", error->message);
+	if (error != NULL) {
+		log_message(LOG_INFO, "Parsing DBus interface %s from file %s failed: %s",
+			    DBUS_VRRP_INTERFACE, DBUS_VRRP_INTERFACE_FILE_PATH, error->message);
+		g_clear_error(&error);
 		return NULL;
 	}
 
@@ -610,8 +643,10 @@ dbus_main(__attribute__ ((unused)) void *unused)
 		return NULL;
 	vrrp_instance_introspection_data = g_dbus_node_info_new_for_xml(introspection_xml, &error);
 	free(introspection_xml);
-	if (!vrrp_instance_introspection_data) {
-		log_message(LOG_INFO, "%s", error->message);
+	if (error != NULL) {
+		log_message(LOG_INFO, "Parsing DBus interface %s from file %s failed: %s",
+			    DBUS_VRRP_INSTANCE_INTERFACE, DBUS_VRRP_INSTANCE_INTERFACE_FILE_PATH, error->message);
+		g_clear_error(&error);
 		return NULL;
 	}
 
@@ -644,7 +679,6 @@ dbus_main(__attribute__ ((unused)) void *unused)
 void
 dbus_send_state_signal(vrrp_t *vrrp)
 {
-	GError *local_error = NULL;
 	gchar *object_path;
 	GVariant *args;
 
@@ -656,10 +690,7 @@ dbus_send_state_signal(vrrp_t *vrrp)
 	object_path = dbus_object_create_path_instance(IF_NAME(IF_BASE_IFP(vrrp->ifp)), vrrp->vrid, vrrp->family);
 
 	args = g_variant_new("(u)", vrrp->state);
-	g_dbus_connection_emit_signal(global_connection, NULL, object_path,
-				      DBUS_VRRP_INSTANCE_INTERFACE,
-				      "VrrpStatusChange", args, &local_error);
-
+	dbus_emit_signal(global_connection, object_path, DBUS_VRRP_INSTANCE_INTERFACE, "VrrpStatusChange", args);
 	g_free(object_path);
 }
 
@@ -667,15 +698,13 @@ dbus_send_state_signal(vrrp_t *vrrp)
 static void
 dbus_send_reload_signal(void)
 {
-	GError *local_error = NULL;
 	gchar *path;
 
 	if (global_connection == NULL)
 		return;
 
 	path = dbus_object_create_path_vrrp();
-	g_dbus_connection_emit_signal(global_connection, NULL, path,
-				      DBUS_VRRP_INTERFACE, "VrrpReloaded", NULL, &local_error);
+	dbus_emit_signal(global_connection, path, DBUS_VRRP_INTERFACE, "VrrpReloaded", NULL);
 	g_free(path);
 }
 
@@ -894,15 +923,13 @@ dbus_start(void)
 void
 dbus_stop(void)
 {
-	GError *local_error = NULL;
 	struct timespec thread_end_wait;
 	int ret;
 	gchar *path;
 
 	if (global_connection != NULL) {
 		path = dbus_object_create_path_vrrp();
-		g_dbus_connection_emit_signal(global_connection, NULL, path,
-					      DBUS_VRRP_INTERFACE, "VrrpStopped", NULL, &local_error);
+		dbus_emit_signal(global_connection, path, DBUS_VRRP_INTERFACE, "VrrpStopped", NULL);
 		g_free(path);
 	}
 


### PR DESCRIPTION
If you want to run multiple keepalived processes on the same machine and enable the DBus interface on all of them, only one will obtain the service name on the bus.

I've added a new `dbus_service_name` option to specify a custom name (other daemons like e.g. `dnsmasq` follow the same approach).

While going through the DBus code I also noticed a few issues with regards to error handling. Not all glib DBus calls are checked for errors, and if errors occur, the error is not free'ed. This has also been fixed.