### PR TITLE
parser: do not exit when glob() doesn't match any files

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -384,9 +384,12 @@ read_conf_file(const char *conf_file)
 	globbuf.gl_offs = 0;
 	res = glob(conf_file, 0, NULL, &globbuf);
 
-	if (res) {
-		log_message(LOG_INFO, "Unable to find config file(s) '%s'.", conf_file);
-		exit(KEEPALIVED_EXIT_CONFIG);
+	if (res == GLOB_NOMATCH) {
+		log_message(LOG_INFO, "No config files matched '%s'.", conf_file);
+		goto done;
+	} else if (res) {
+		log_message(LOG_INFO, "Error reading config file(s): glob(\"%s\") returned %d, skipping.", res);
+		goto done;
 	}
 
 	for(i = 0; i < globbuf.gl_pathc; i++){
@@ -434,6 +437,7 @@ read_conf_file(const char *conf_file)
 		}
 	}
 
+done:
 	globfree(&globbuf);
 }
 


### PR DESCRIPTION
Hi,

Commit 3455c4a9 changed `read_conf_file()`'s behaviour to exit when `glob()` returned non-success. Calling `exit(3)` from within a utility function like `read_conf_file` causes a number of issues:

 - Keepalived will refuse to start when used together with `include` to modularize configuration (e.g. `include /etc/keepalived/puppet.d/*.conf` which may be empty).
 - It also causes the main process to exit uncleanly during reloads, leaving orphan child processes around. This issue is serious, as it leaves keepalived in a crippled state; subsequent attempts to restart    the keepalived service without manually killing the VRRP/healthcheck children first will fail.

The original commit message makes it clear that this is about the main configuration file, which is essential indeed. However, the presence of the main config file is also checked and handled by `check_conf_file()` on startup.

Revert to the previous behavior by having `read_conf_file()` log `glob()` failures and skip using the glob
buffer. For more fine-grained control of file read failures, the signature of`read_conf_file()` should be changed to return a value that can be used to check for and handle errors.

Regards,
Apollon