### PR TITLE
The current implementation of the vrrp_index hash created collisions …

### DIFF
--- a/keepalived/include/vrrp_index.h
+++ b/keepalived/include/vrrp_index.h
@@ -36,6 +36,7 @@
 /* Macro definition */
 
 /* prototypes */
+extern int get_vrrp_hash(const int, const int);
 extern void alloc_vrrp_bucket(vrrp_t *);
 extern void alloc_vrrp_fd_bucket(vrrp_t *);
 extern void remove_vrrp_fd_bucket(vrrp_t *);

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -597,7 +597,7 @@ free_vrrp_data(vrrp_data_t * data)
 	free_list(&data->static_addresses);
 	free_list(&data->static_routes);
 	free_list(&data->static_rules);
-	free_mlist(data->vrrp_index, 1024+1);
+	free_mlist(data->vrrp_index, 1151+1);
 	free_mlist(data->vrrp_index_fd, 1024+1);
 	free_list(&data->vrrp);
 	free_list(&data->vrrp_sync_group);

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -582,7 +582,7 @@ alloc_vrrp_data(void)
 
 	new = (vrrp_data_t *) MALLOC(sizeof(vrrp_data_t));
 	new->vrrp = alloc_list(free_vrrp, dump_vrrp);
-	new->vrrp_index = alloc_mlist(NULL, NULL, 255+1);
+	new->vrrp_index = alloc_mlist(NULL, NULL, 1024+1);
 	new->vrrp_index_fd = alloc_mlist(NULL, NULL, 1024+1);
 	new->vrrp_sync_group = alloc_list(free_vgroup, dump_vgroup);
 	new->vrrp_script = alloc_list(free_vscript, dump_vscript);
@@ -597,7 +597,7 @@ free_vrrp_data(vrrp_data_t * data)
 	free_list(&data->static_addresses);
 	free_list(&data->static_routes);
 	free_list(&data->static_rules);
-	free_mlist(data->vrrp_index, 255+1);
+	free_mlist(data->vrrp_index, 1024+1);
 	free_mlist(data->vrrp_index_fd, 1024+1);
 	free_list(&data->vrrp);
 	free_list(&data->vrrp_sync_group);

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -582,7 +582,7 @@ alloc_vrrp_data(void)
 
 	new = (vrrp_data_t *) MALLOC(sizeof(vrrp_data_t));
 	new->vrrp = alloc_list(free_vrrp, dump_vrrp);
-	new->vrrp_index = alloc_mlist(NULL, NULL, 1024+1);
+	new->vrrp_index = alloc_mlist(NULL, NULL, 1151+1);
 	new->vrrp_index_fd = alloc_mlist(NULL, NULL, 1024+1);
 	new->vrrp_sync_group = alloc_list(free_vgroup, dump_vgroup);
 	new->vrrp_script = alloc_list(free_vscript, dump_vscript);

--- a/keepalived/vrrp/vrrp_index.c
+++ b/keepalived/vrrp/vrrp_index.c
@@ -30,10 +30,17 @@
 #include "list.h"
 
 /* VRID hash table */
+int
+get_vrrp_hash(const int vrid, const int fd)
+{
+	/* Cantor pairing function, modulus 1024 */
+	return ((( vrid + fd ) * ( vrid + fd + 1 ) / 2 ) + vrid )%1024;
+}
+
 void
 alloc_vrrp_bucket(vrrp_t *vrrp)
 {
-	list_add(&vrrp_data->vrrp_index[vrrp->vrid], vrrp);
+	list_add(&vrrp_data->vrrp_index[get_vrrp_hash(vrrp->vrid, vrrp->fd_in)], vrrp);
 }
 
 vrrp_t *
@@ -41,7 +48,7 @@ vrrp_index_lookup(const int vrid, const int fd)
 {
 	vrrp_t *vrrp;
 	element e;
-	list l = &vrrp_data->vrrp_index[vrid];
+	list l = &vrrp_data->vrrp_index[get_vrrp_hash(vrid, fd)];
 
 	/* return if list is empty */
 	if (LIST_ISEMPTY(l))
@@ -53,7 +60,7 @@ vrrp_index_lookup(const int vrid, const int fd)
 	 */
 	if (LIST_SIZE(l) == 1) {
 		vrrp = ELEMENT_DATA(LIST_HEAD(l));
-		return (vrrp->fd_in == fd) ? vrrp : NULL;
+		return ((vrrp->fd_in == fd) && (vrrp->vrid == vrid)) ? vrrp : NULL;
 	}
 
 	/*
@@ -63,7 +70,7 @@ vrrp_index_lookup(const int vrid, const int fd)
 	 */
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		vrrp =  ELEMENT_DATA(e);
-		if (vrrp->fd_in == fd)
+		if ((vrrp->fd_in == fd) && (vrrp->vrid == vrid))
 			return vrrp;
 	}
 

--- a/keepalived/vrrp/vrrp_index.c
+++ b/keepalived/vrrp/vrrp_index.c
@@ -33,8 +33,7 @@
 int
 get_vrrp_hash(const int vrid, const int fd)
 {
-	/* Cantor pairing function, modulus 1024 */
-	return ((( vrid + fd ) * ( vrid + fd + 1 ) / 2 ) + vrid )%1024;
+	return ( vrid * 31 + ( fd/2 ) * 37 )%1151;
 }
 
 void

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -363,7 +363,6 @@ vrrp_vrid_handler(vector_t *strvec)
 	}
 
 	vrrp->vrid = (uint8_t)vrid;
-	alloc_vrrp_bucket(vrrp);
 }
 static void
 vrrp_prio_handler(vector_t *strvec)

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -372,9 +372,18 @@ vrrp_compute_timer(const int fd)
 	element e;
 	list l = &vrrp_data->vrrp_index_fd[fd%1024 + 1];
 	timeval_t timer;
+	timer_reset(timer);
+
+	/*
+	 * If list size's is 1 then no collisions. So
+	 * Test and return the singleton.
+	 */
+	if (LIST_SIZE(l) == 1) {
+		vrrp = ELEMENT_DATA(LIST_HEAD(l));
+			return vrrp->sands;
+	}
 
 	/* Multiple instances on the same interface */
-	timer_reset(timer);
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		vrrp = ELEMENT_DATA(e);
 		if (timer_cmp(vrrp->sands, timer) < 0 ||
@@ -441,8 +450,9 @@ vrrp_register_workers(list l)
 	vrrp_init_sands(vrrp_data->vrrp);
 
 	/* Init VRRP tracking scripts */
-	if (!LIST_ISEMPTY(vrrp_data->vrrp_script))
+	if (!LIST_ISEMPTY(vrrp_data->vrrp_script)) {
 		vrrp_init_script(vrrp_data->vrrp_script);
+	}
 
 	/* Register VRRP workers threads */
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
@@ -579,6 +589,7 @@ vrrp_set_fds(list l)
 
 				/* append to hash index */
 				alloc_vrrp_fd_bucket(vrrp);
+				alloc_vrrp_bucket(vrrp);
 			}
 		}
 	}


### PR DESCRIPTION
…when all instances have the same vrid, which is possible when each instance has a different vmac.

This patch:
- Increases the size of vrrp_index to match vrrp_index_fd
- Changes the hash function to Cantor pairing function, taking into account both vrid and fd_in to avoid collisions
- Creates a get_vrrp_hash function to ease the change of hash in the future
- Populates the vrrp_index hash only when fds are attributed to vrrp instances