### PR TITLE
Dev/damien.clabaut/python scripts

### DIFF
--- a/tools/json_tracking/isolate
+++ b/tools/json_tracking/isolate
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+#####
+#
+# This script is used to start a slow transition of many vrrp instances
+# towards the peer router. Launch with -h to get the full list of options.
+# For this script to work you need each instance to track a different file.
+# You can generate such config with the templates in the same folder.
+#
+# Author: Damien Clabaut <damien.clabaut@corp.ovh.com>
+#
+#####
+
+import argparse
+import json
+import os
+from termcolor import cprint
+import time
+import _thread
+import sys
+
+# Configuration
+# Path to the keepalived json dump
+keepalived_json_file = "/tmp/keepalived.json"
+
+# Path to the keepalived PID file
+keepalived_pid_file = "/var/run/keepalived.pid"
+
+# Path to the folder containing files tracked by each instance
+keepalived_offset_folder = "/etc/keepalived_offset/"
+
+# Offset we want with the "-r" option
+offset_default = 0
+
+# Offset we want without the "-r" option
+offset_slave = -100
+
+# Delay in seconds between each priority change
+offset_delay = 1
+
+# Delay in seconds between each update given to the user
+check_delay = 5
+
+
+def main(args):
+    keepalived_data = getFreshData()
+
+    if args.reset:
+        offset = offset_default
+        action = "Removing"
+        partial_list = getSlaves(keepalived_data)
+    else:
+        offset = offset_slave
+        action = "Adding"
+        partial_list = getMasters(keepalived_data)
+
+    # No specification of count or instances: we impact everything
+    if args.count == 0 and args.instances == 0:
+        for instance in keepalived_data:
+            print(action + " offset for instance " + instance["data"]["iname"])
+            if (updateOffset(instance["data"]["iname"], offset) == 1):
+                time.sleep(offset_delay)
+
+    # Here we impact a certain count of instances
+    elif args.count != 0:
+        done = 0
+        for instance in partial_list:
+            if (updateOffset(instance["data"]["iname"], offset) == 1):
+                print(action + " offset for instance " + instance["data"]["iname"])
+                done += 1
+                if done >= args.count:
+                    break
+                time.sleep(offset_delay)
+
+    # Here we impact specific instances. There is no check that this instance actually exists.
+    # It may be populated in the future
+    elif args.instances != 0:
+        for instance in args.instances:
+            print(action + " offset for instance " + str(instance))
+            if (updateOffset(str(instance), offset) == 1):
+                time.sleep(offset_delay)
+
+
+def getFreshData():
+    with open(keepalived_pid_file, "r") as f:
+        keepalived_pid = int(f.read())
+    os.kill(keepalived_pid, 36)
+    time.sleep(0.1)
+    try:
+        with open(keepalived_json_file) as jsonfile:
+            return json.load(jsonfile)
+    except:
+        return {}
+
+
+def getMasters(keepalived_data):
+    masters = []
+    for instance in keepalived_data:
+        if instance["data"]["state"] == 2:
+            masters.append(instance)
+    return masters
+
+
+def getSlaves(keepalived_data):
+    slaves = []
+    for instance in keepalived_data:
+        if instance["data"]["state"] == 1:
+            slaves.append(instance)
+    return slaves
+
+
+def updateOffset(instance, offset):
+    try:
+        with open(keepalived_offset_folder + str(instance), "r") as f:
+            offset_cur = f.read()
+    except:
+        offset_cur = 0
+
+    try:
+        if int(offset_cur) == int(offset):
+            # Notify that we did not change anything
+            to_return = 0
+
+        else:
+            # Notify that we changed something
+            to_return = 1
+    # Value does not exist in json file
+    except:
+        offset_cur = int(offset)
+        if int(offset) == 0:
+            # Notify that we did not change anything
+            to_return = 0
+        else:
+            # Notify that we changed something
+            to_return = 1
+
+    if to_return == 1:
+        with open(keepalived_offset_folder + str(instance), "w") as f:
+            f.write(str(offset))
+
+    return to_return
+
+
+def checkStatus():
+    while True:
+        keepalived_data = getFreshData()
+        instance_count = len(keepalived_data)
+        master_count = len(getMasters(keepalived_data))
+        slave_count = len(getSlaves(keepalived_data))
+        cprint(
+               "Instances: " + str(instance_count) + ", Masters: "
+               + str(master_count) + ", Slaves: " + str(slave_count), 'green'
+        )
+        time.sleep(check_delay)
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Arguments')
+    parser.add_argument('--count', '-c', type=int, default=0, help="Number of instances to impact")
+    parser.add_argument('--instances', '-i', type=int, nargs='+', default=0, help="List of instances to impact")
+    parser.add_argument('--reset', '-r', action='store_true', help="Set to get instances back to their base priority")
+    args = parser.parse_args()
+    if (args.count != 0) and (args.instances) != 0:
+        sys.exit("You cannot define instances and count at the same time")
+    mon = _thread.start_new_thread(checkStatus, ())
+    main(args)
+    cprint(
+           "All modifications in priorities have been made. I will keep monitoring Keepalived until you press enter",
+           'yellow'
+    )
+    input()

--- a/tools/json_tracking/make_conf.py
+++ b/tools/json_tracking/make_conf.py
@@ -12,7 +12,6 @@
 #
 #####
 
-import argparse
 import jinja2
 
 # Configuration
@@ -28,6 +27,7 @@ keepalived_offset_folder = "/etc/keepalived_offset/"
 # Path to the output file
 output_file = "keepalived.conf"
 
+
 class Vlan:
     def __init__(self, name, ip4addr, ip4net, ip6addr):
         self.name = name
@@ -35,19 +35,20 @@ class Vlan:
         self.ip4net = ip4net
         self.ip6addr = ip6addr
 
+
 vlans = []
-for vlan_id in range(first_vlan, last_vlan +1):
+for vlan_id in range(first_vlan, last_vlan + 1):
     ip4addr = "10.0." + str(vlan_id) + ".254"
     ip4net = "10.0." + str(vlan_id) + ".0/24"
     ip6addr = "fd00:42:ffff:" + format(vlan_id, '02x') + ":ff:ff:ff:ff/64"
-    new_vlan = Vlan(vlan_id, ip4addr, ip4net, ip6addr) 
+    new_vlan = Vlan(vlan_id, ip4addr, ip4net, ip6addr)
     vlans.append(new_vlan)
 
 to_return = ""
-templateLoader = jinja2.FileSystemLoader( searchpath="./" )
-templateEnv = jinja2.Environment( loader=templateLoader )
+templateLoader = jinja2.FileSystemLoader(searchpath="./")
+templateEnv = jinja2.Environment(loader=templateLoader)
 vrrpconf = templateEnv.get_template('template_vrrp_instance').render(
-                vlans=vlans,track_files=keepalived_offset_folder
+                vlans=vlans, track_files=keepalived_offset_folder
                 ) + "\n"
 
 output_file = open(output_file, "w")

--- a/tools/json_tracking/make_conf.py
+++ b/tools/json_tracking/make_conf.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+#####
+#
+# This script will generate a sample configuration for Keepalived.
+# The configuration is as follows:
+# Each vlan contains a VRRPv2 instance with a private IPv4 address
+# and a VRRPv3 instance with a Local Address.
+# Each instance tracks a file located in keepalived_offset_folder.
+#
+# Author: Damien Clabaut <damien.clabaut@corp.ovh.com>
+#
+#####
+
+import argparse
+import jinja2
+
+# Configuration
+# First vlan of the range
+first_vlan = 2
+
+# Last vlan of the range, must not be higher than 255
+last_vlan = 100
+
+# Path to the folder containing files tracked by each instance
+keepalived_offset_folder = "/etc/keepalived_offset/"
+
+# Path to the output file
+output_file = "keepalived.conf"
+
+class Vlan:
+    def __init__(self, name, ip4addr, ip4net, ip6addr):
+        self.name = name
+        self.ip4addr = ip4addr
+        self.ip4net = ip4net
+        self.ip6addr = ip6addr
+
+vlans = []
+for vlan_id in range(first_vlan, last_vlan +1):
+    ip4addr = "10.0." + str(vlan_id) + ".254"
+    ip4net = "10.0." + str(vlan_id) + ".0/24"
+    ip6addr = "fd00:42:ffff:" + format(vlan_id, '02x') + ":ff:ff:ff:ff/64"
+    new_vlan = Vlan(vlan_id, ip4addr, ip4net, ip6addr) 
+    vlans.append(new_vlan)
+
+to_return = ""
+templateLoader = jinja2.FileSystemLoader( searchpath="./" )
+templateEnv = jinja2.Environment( loader=templateLoader )
+vrrpconf = templateEnv.get_template('template_vrrp_instance').render(
+                vlans=vlans,track_files=keepalived_offset_folder
+                ) + "\n"
+
+output_file = open(output_file, "w")
+output_file.write(vrrpconf)
+output_file.close()

--- a/tools/json_tracking/make_conf.py
+++ b/tools/json_tracking/make_conf.py
@@ -27,6 +27,11 @@ keepalived_offset_folder = "/etc/keepalived_offset/"
 # Path to the output file
 output_file = "keepalived.conf"
 
+# Underlying interface.
+# For this configuration to work you need vlan subinterfaces.
+# For example, if the value below is bond0, you need to have
+# interfaces bond0.2 to bond0.<last_vlan>
+interface = "bond0"
 
 class Vlan:
     def __init__(self, name, ip4addr, ip4net, ip6addr):
@@ -48,7 +53,8 @@ to_return = ""
 templateLoader = jinja2.FileSystemLoader(searchpath="./")
 templateEnv = jinja2.Environment(loader=templateLoader)
 vrrpconf = templateEnv.get_template('template_vrrp_instance').render(
-                vlans=vlans, track_files=keepalived_offset_folder
+                vlans=vlans, track_files=keepalived_offset_folder,
+                interface=interface
                 ) + "\n"
 
 output_file = open(output_file, "w")

--- a/tools/json_tracking/template_vrrp_instance
+++ b/tools/json_tracking/template_vrrp_instance
@@ -1,0 +1,55 @@
+! Configuration File for keepalived
+
+global_defs {
+}
+{% for vlan in vlans %}
+vrrp_track_file offset_instance_4{{ vlan.name }} {
+    file "{{ track_files }}4{{ vlan.name }}"
+    init_file 0
+}
+
+vrrp_track_file offset_instance_6{{ vlan.name }} {
+    file "{{ track_files }}6{{ vlan.name }}"
+    init_file 0
+}
+
+{% endfor %}
+{% for vlan in vlans %}
+vrrp_instance 4{{ vlan.name }} {
+    state BACKUP
+    interface bond0.{{ vlan.name }}
+    use_vmac vrrp4.{{ vlan.name }}.1
+    virtual_router_id 1
+    priority 100
+    advert_int 1
+    preempt_delay 5
+    virtual_ipaddress {
+        {{ vlan.ip4addr }}
+    }
+    unicast_src_ip {{ vlan.ip4addr }}
+
+    track_file {
+        offset_instance_4{{ vlan.name }}
+    }
+}
+vrrp_instance 6{{ vlan.name }} {
+    version 3
+    native_ipv6
+    state BACKUP
+    interface bond0.{{ vlan.name }}
+    use_vmac vrrp6.{{ vlan.name }}.1
+    virtual_router_id 1
+    priority 100
+    advert_int 1
+    preempt_delay 5
+    virtual_ipaddress {
+        fe80::1/64
+        {{ vlan.ip6addr }}
+    }
+
+
+    track_file {
+        offset_instance_6{{ vlan.name }}
+    }
+}
+{% endfor %}

--- a/tools/json_tracking/template_vrrp_instance
+++ b/tools/json_tracking/template_vrrp_instance
@@ -17,7 +17,7 @@ vrrp_track_file offset_instance_6{{ vlan.name }} {
 {% for vlan in vlans %}
 vrrp_instance 4{{ vlan.name }} {
     state BACKUP
-    interface bond0.{{ vlan.name }}
+    interface {{ interface }}.{{ vlan.name }}
     use_vmac vrrp4.{{ vlan.name }}.1
     virtual_router_id 1
     priority 100
@@ -36,7 +36,7 @@ vrrp_instance 6{{ vlan.name }} {
     version 3
     native_ipv6
     state BACKUP
-    interface bond0.{{ vlan.name }}
+    interface {{ interface }}.{{ vlan.name }}
     use_vmac vrrp6.{{ vlan.name }}.1
     virtual_router_id 1
     priority 100

--- a/tools/json_tracking/vrrp_recap
+++ b/tools/json_tracking/vrrp_recap
@@ -2,7 +2,7 @@
 
 #####
 #
-# This script isolate Keepalived's dump-to-json function
+# This script triggers Keepalived's dump-to-json function
 # and prints most of the interesting info into a table.
 #
 # Author: Damien Clabaut <damien.clabaut@corp.ovh.com>

--- a/tools/json_tracking/vrrp_recap
+++ b/tools/json_tracking/vrrp_recap
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+#####
+#
+# This script isolate Keepalived's dump-to-json function
+# and prints most of the interesting info into a table.
+#
+# Author: Damien Clabaut <damien.clabaut@corp.ovh.com>
+#
+#####
+
+import datetime
+import json
+import os
+import sys
+import time
+from prettytable import PrettyTable
+
+# Configuration
+# Path to the keepalived json dump
+keepalived_json_file = "/tmp/keepalived.json"
+
+# Path to the keepalived PID file
+keepalived_pid_file = "/var/run/keepalived.pid"
+
+
+with open(keepalived_pid_file, "r") as f:
+    keepalived_pid = int(f.read())
+
+os.kill(keepalived_pid, 36)
+
+try:
+    time.sleep(0.5)
+    keepalived_data = json.load(open(keepalived_json_file))
+except:
+    sys.exit("Could not load json from file, please check that keepalived is running at a compatible version")
+
+data_table = PrettyTable([
+                          "Instance", "Interface", "Addresses", "Version",
+                          "Priority", "Master prio", "State", "Last Transition"
+                        ])
+for instance in keepalived_data:
+    if instance["data"]["state"] == 0:
+        instance["data"]["state_cleartext"] = "Init"
+    elif instance["data"]["state"] == 1:
+        instance["data"]["state_cleartext"] = "Slave"
+    elif instance["data"]["state"] == 2:
+        instance["data"]["state_cleartext"] = "Master"
+    else:
+        instance["data"]["state_cleartext"] = "Fault"
+
+    unicast_vips = []
+    for vip in instance["data"]["vips"]:
+        # We do not display link-local addresses as they are usually not relevant
+        if not vip.startswith("fe80"):
+            unicast_vips.append(vip)
+
+    data_table.add_row([
+                        int(instance["data"]["iname"]), instance["data"]["vmac_ifname"],
+                        "\n".join(unicast_vips), instance["data"]["version"],
+                        instance["data"]["effective_priority"], instance["data"]["master_priority"],
+                        instance["data"]["state_cleartext"],
+                        datetime.datetime.fromtimestamp(instance["data"]["last_transition"])
+                      ])
+
+print(data_table.get_string(sortby="Instance"))


### PR DESCRIPTION
Those are a few scripts that help with keepalived in the case of many instances:
- template_vrrp_instance, called by make_conf.py, can generate a large config file.
- vrrp_recap prints a table with most of the important info from every vrrp instance.
- isolate can change effective priorities smoothly, to move instances to the peer machine one by one at a fixed rate while monitoring the status of keepalived.