### PR TITLE
Fix segfault when parsing invalid real server

### DIFF
--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -496,6 +496,7 @@ alloc_rs(char *ip, char *port)
 		vs->af = new->addr.ss_family;
 	else if (vs->af != new->addr.ss_family) {
 		log_message(LOG_INFO, "Address family of virtual server and real server %s don't match - skipping.", ip);
+		skip_block();
 		FREE(new);
 		return;
 	}


### PR DESCRIPTION
If the first real server ip address doesn't match the address
family of the virtual server, then we need to skip parsing the
rest of the real_server block.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>