### PR TITLE
Allow flexibility of positioning or { and } in config files

### DIFF
--- a/configure
+++ b/configure
@@ -12108,3 +12108,9 @@ if test ${IPVS_SUPPORT} = Yes -a ${IPVS_USE_NL} = No; then
   echo "*** WARNING - this build will not support IPVS with IPv6. Please install libnl/libnl-3 dev libraries to support IPv6 with IPVS."
   echo
 fi
+
+if test ${ENABLE_DEBUG} = Yes; then
+  echo
+  echo "*** WARNING --enable-debug is only for debugging purposes and isn't expected to work properly"
+  echo
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -1507,3 +1507,9 @@ if test ${IPVS_SUPPORT} = Yes -a ${IPVS_USE_NL} = No; then
   echo "*** WARNING - this build will not support IPVS with IPv6. Please install libnl/libnl-3 dev libraries to support IPv6 with IPVS."
   echo
 fi
+
+if test ${ENABLE_DEBUG} = Yes; then
+  echo
+  echo "*** WARNING --enable-debug is only for debugging purposes and isn't expected to work properly"
+  echo
+fi

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -97,7 +97,7 @@ vsg_handler(vector_t *strvec)
 
 	/* Fetch queued vsg */
 	alloc_vsg(strvec_slot(strvec, 1));
-	alloc_value_block(alloc_vsg_entry);
+	alloc_value_block(alloc_vsg_entry, strvec_slot(strvec, 0));
 
 	/* Ensure the virtual server group has some configuration */
 	vsg = LIST_TAIL_DATA(check_data->vs_group);

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -447,12 +447,14 @@ sigend(__attribute__((unused)) void *v, __attribute__((unused)) int sig)
 	if (!sigismember(&old_set, SIGCHLD))
 		sigprocmask(SIG_UNBLOCK, &child_wait, NULL);
 }
+#endif
 
 /* Initialize signal handler */
 static void
 signal_init(void)
 {
 	signal_handler_init();
+#ifndef _DEBUG_
 	signal_set(SIGHUP, propogate_signal, NULL);
 	signal_set(SIGUSR1, propogate_signal, NULL);
 	signal_set(SIGUSR2, propogate_signal, NULL);
@@ -461,9 +463,9 @@ signal_init(void)
 #endif
 	signal_set(SIGINT, sigend, NULL);
 	signal_set(SIGTERM, sigend, NULL);
+#endif
 	signal_ignore(SIGPIPE);
 }
-#endif
 
 /* To create a core file when abrt is running (a RedHat distribution),
  * and keepalived isn't installed from an RPM package, edit the file
@@ -1084,10 +1086,8 @@ keepalived_main(int argc, char **argv)
 	if (!pidfile_write(main_pidfile, getpid()))
 		goto end;
 
-#ifndef _DEBUG_
 	/* Signal handling initialization  */
 	signal_init();
-#endif
 
 	/* Create the master thread */
 	master = thread_make_master();

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -335,6 +335,7 @@ start_vrrp(void)
 		list ifl;
 
 		dump_global_data(global_data);
+		dump_list(garp_delay);
 		dump_vrrp_data(vrrp_data);
 		ifl = get_if_list();
 		if (!LIST_ISEMPTY(ifl))

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -329,10 +329,22 @@ free_if(void *data)
 
 /* garp_delay facility function */
 void
+dump_garp_delay(void *data)
+{
+	garp_delay_t *gd = data;
+
+	log_message(LOG_INFO, "------< GARP delay group %d >------", gd->aggregation_group);
+	if (gd->have_garp_interval)
+		log_message(LOG_INFO, " GARP interval = %ld.%6.6ld", gd->garp_interval.tv_sec, gd->garp_interval.tv_usec);
+	if (gd->have_gna_interval)
+		log_message(LOG_INFO, " GNA interval = %ld.%6.6ld", gd->gna_interval.tv_sec, gd->gna_interval.tv_usec);
+}
+
+void
 alloc_garp_delay(void)
 {
 	if (!LIST_EXISTS(garp_delay))
-		garp_delay = alloc_list(NULL, NULL);
+		garp_delay = alloc_list(NULL, dump_garp_delay);
 
 	list_add(garp_delay, MALLOC(sizeof(garp_delay_t)));
 }

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -838,7 +838,7 @@ garp_group_garp_interval_handler(vector_t *strvec)
 {
 	garp_delay_t *delay = LIST_TAIL_DATA(garp_delay);
 
-	delay->garp_interval.tv_usec = (useconds_t)atof(strvec_slot(strvec, 1)) * 1000000;
+	delay->garp_interval.tv_usec = (suseconds_t)(atof(strvec_slot(strvec, 1)) * 1000000);
 	delay->garp_interval.tv_sec = delay->garp_interval.tv_usec / 1000000;
 	delay->garp_interval.tv_usec %= 1000000;
 	delay->have_garp_interval = true;

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -53,24 +53,24 @@ static bool remove_script;
 
 /* Static addresses handler */
 static void
-static_addresses_handler(__attribute__((unused)) vector_t *strvec)
+static_addresses_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_saddress);
+	alloc_value_block(alloc_saddress, vector_slot(strvec, 0));
 }
 
 #ifdef _HAVE_FIB_ROUTING_
 /* Static routes handler */
 static void
-static_routes_handler(__attribute__((unused)) vector_t *strvec)
+static_routes_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_sroute);
+	alloc_value_block(alloc_sroute, vector_slot(strvec, 0));
 }
 
 /* Static rules handler */
 static void
-static_rules_handler(__attribute__((unused)) vector_t *strvec)
+static_rules_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_srule);
+	alloc_value_block(alloc_srule, vector_slot(strvec, 0));
 }
 #endif
 
@@ -106,6 +106,7 @@ vrrp_sync_group_handler(vector_t *strvec)
 
 	alloc_vrrp_sync_group(gname);
 }
+
 static void
 vrrp_group_handler(vector_t *strvec)
 {
@@ -242,9 +243,9 @@ vrrp_vmac_xmit_base_handler(__attribute__((unused)) vector_t *strvec)
 }
 #endif
 static void
-vrrp_unicast_peer_handler(__attribute__((unused)) vector_t *strvec)
+vrrp_unicast_peer_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_vrrp_unicast_peer);
+	alloc_value_block(alloc_vrrp_unicast_peer, vector_slot(strvec, 0));
 }
 #ifdef _WITH_UNICAST_CHKSUM_COMPAT_
 static void
@@ -313,14 +314,14 @@ vrrp_int_handler(vector_t *strvec)
 	}
 }
 static void
-vrrp_track_int_handler(__attribute__((unused)) vector_t *strvec)
+vrrp_track_int_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_vrrp_track);
+	alloc_value_block(alloc_vrrp_track, vector_slot(strvec, 0));
 }
 static void
-vrrp_track_scr_handler(__attribute__((unused)) vector_t *strvec)
+vrrp_track_scr_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_vrrp_track_script);
+	alloc_value_block(alloc_vrrp_track_script, vector_slot(strvec, 0));
 }
 static void
 vrrp_dont_track_handler(__attribute__((unused)) vector_t *strvec)
@@ -665,14 +666,14 @@ vrrp_auth_pass_handler(vector_t *strvec)
 }
 #endif
 static void
-vrrp_vip_handler(__attribute__((unused)) vector_t *strvec)
+vrrp_vip_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_vrrp_vip);
+	alloc_value_block(alloc_vrrp_vip, vector_slot(strvec, 0));
 }
 static void
-vrrp_evip_handler(__attribute__((unused)) vector_t *strvec)
+vrrp_evip_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_vrrp_evip);
+	alloc_value_block(alloc_vrrp_evip, vector_slot(strvec, 0));
 }
 static void
 vrrp_promote_secondaries(__attribute__((unused)) vector_t *strvec)
@@ -683,14 +684,14 @@ vrrp_promote_secondaries(__attribute__((unused)) vector_t *strvec)
 }
 #ifdef _HAVE_FIB_ROUTING_
 static void
-vrrp_vroutes_handler(__attribute__((unused)) vector_t *strvec)
+vrrp_vroutes_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_vrrp_vroute);
+	alloc_value_block(alloc_vrrp_vroute, vector_slot(strvec, 0));
 }
 static void
-vrrp_vrules_handler(__attribute__((unused)) vector_t *strvec)
+vrrp_vrules_handler(vector_t *strvec)
 {
-	alloc_value_block(alloc_vrrp_vrule);
+	alloc_value_block(alloc_vrrp_vrule, vector_slot(strvec, 0));
 }
 #endif
 static void

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -1033,7 +1033,7 @@ read_value_block(vector_t *strvec)
 }
 
 void
-alloc_value_block(void (*alloc_func) (vector_t *))
+alloc_value_block(void (*alloc_func) (vector_t *), const char *block_type)
 {
 	char *buf;
 	char *str = NULL;
@@ -1051,7 +1051,7 @@ alloc_value_block(void (*alloc_func) (vector_t *))
 			if (!strcmp(vector_slot(vec, 0), BOB))
 				continue;
 
-			log_message(LOG_INFO, "'%s' missing from beginning of block", BOB);
+			log_message(LOG_INFO, "'%s' missing from beginning of block %s", BOB, block_type);
 		}
 
 		str = vector_slot(vec, 0);

--- a/lib/parser.h
+++ b/lib/parser.h
@@ -37,9 +37,6 @@
 
 /* Global definitions */
 #define KEEPALIVED_CONFIG_FILE "/etc/keepalived/keepalived.conf"
-#define BOB  "{"
-#define EOB  "}"
-#define MAXBUF	1024
 
 /* keyword definition */
 typedef struct _keyword {

--- a/lib/parser.h
+++ b/lib/parser.h
@@ -70,7 +70,7 @@ extern void install_keyword(const char *, void (*handler) (vector_t *));
 extern vector_t *alloc_strvec(char *);
 extern bool check_conf_file(const char*);
 extern vector_t *read_value_block(vector_t *);
-extern void alloc_value_block(void (*alloc_func) (vector_t *));
+extern void alloc_value_block(void (*alloc_func) (vector_t *), const char *);
 extern void *set_value(vector_t *);
 extern unsigned long read_timer(vector_t *);
 extern int check_true_false(char *);


### PR DESCRIPTION
Issue #768 complained about restrictions of placing of { and } in config file; those restrictions are now removed.

These commits also streamline some configuration parsing and fix one or two minor bug fixes.