### PR TITLE
Fix build with Linux kernel headers v4.15

### DIFF
--- a/keepalived/include/vrrp_arp.h
+++ b/keepalived/include/vrrp_arp.h
@@ -24,6 +24,7 @@
 #define _VRRP_ARP_H
 
 /* system includes */
+#include <netinet/in.h>
 #include <net/ethernet.h>
 #include <net/if_arp.h>
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -26,6 +26,7 @@
 #include "config.h"
 
 /* local include */
+#define _GNU_SOURCE
 #include "vrrp_arp.h"
 #include "vrrp_ndisc.h"
 #include "vrrp_scheduler.h"


### PR DESCRIPTION
Linux kernel version 4.15 changed the libc/kernel headers suppression
logic in a way that introduces collisions:

In file included from ./../include/vrrp_ipaddress.h:32:0,
                 from ./../include/vrrp_arp.h:31,
                 from vrrp.c:29:
/home/peko/autobuild/instance-1/output/host/arc-buildroot-linux-uclibc/sysroot/usr/include/linux/in.h:29:3: error: redeclaration of enumerator 'IPPROTO_IP'
   IPPROTO_IP = 0,  /* Dummy protocol for TCP  */
   ^
/home/peko/autobuild/instance-1/output/host/arc-buildroot-linux-uclibc/sysroot/usr/include/netinet/in.h:33:5: note: previous definition of 'IPPROTO_IP' was here
     IPPROTO_IP = 0,    /* Dummy protocol for TCP.  */
     ^~~~~~~~~~

Include the libc netinet/in.h header first to suppress the kernel
header.

In addition, add _GNU_SOURCE to vrrp.c for the libc provided in6_pktinfo
definition.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>