### PR TITLE
fixes #761: INSTALL: note linux distro package that provides 'sphinx_rtd_theme'

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,9 +30,11 @@ For JSON support:
 	json-c-devel
 
 For building the documentation, the following packages need to be installed:
-	python2-sphinx
+	Fedora: python-sphinx (will pull in: python2-sphinx_rtd_theme)
+	CentOS-and-friends: python-sphinx epel-release python-sphinx_rtd_theme
    For latex or pdf files, the following are also needed:
-	python-sphinx-latex
+	Fedora: latexmk python-sphinx-latex
+	CentOS-and-friends: latexmk texlive texlive-titlesec texlive-framed texlive-threeparttable texlive-wrapfig texlive-multirow
 
 Debian/Ubuntu
 -------------
@@ -59,12 +61,22 @@ The following libraries need to be installed:
 For SNMP support:
 	net-snmp-dev (requires libressl-dev and not openssl-dev)
 
+For building the documentation, the following packages need to be installed:
+	py-sphinx py3-sphinx_rtd_theme
+   For latex or pdf files, you'll need texlive or similar, which is not yet
+   available as a distro package.
+
+
 Archlinux
 ---------
 Run the following to install the required libraries:
 	pacman -S ipset libnfnetlink libnl1
 For SNMP support:
 	pacman -S net-snmp
+For building the documentation, the following packages need to be installed:
+	python-sphinx python-sphinx_rtd_theme
+   For latex or pdf files, the following are also needed:
+	texlive-core texlive-bin texlive-latexextra
 
 Installation
 ============


### PR DESCRIPTION
This changeset updates the individual sections for each of the four Linux
distro-lineages that currently have a section in the `INSTALL` file
(RedHat-based, Debian-based, Alpine Linux, and archlinux). The changes just
note the distro-specific package names for the tools needed to build the
HTML-based documentation (basically, some variant of the `sphinx-build` tool
and `sphinx_rtd_theme`) and (except for Alpine Linux[0]) the LaTeX-based PDF
documentation.

The changes were tested using `vagrant` and the vagrant "boxes" published by
respective distros (and/or their trusted volunteers) for the latest stable
version of each distro.

   * RedHat-based
     - centos/7              (virtualbox, 1801.02)
     - fedora/27-cloud-base  (virtualbox, 20171105)

   * Debian-based
     - debian/stretch64      (virtualbox, 9.3.0)
     - ubuntu/artful64       (virtualbox, 20180126.0.0)

   * Alpine Linux
     - alpine/alpine64       (virtualbox, 3.6.0)

   * archlinux
     - archlinux/archlinux   (virtualbox, 2018.01.07)

[0] LaTeX/PDF documentation build on Alpine Linux currently requires a
    roll-your-own approach, as texlive is not yet a supported package for that
    distro. See also:

        https://bugs.alpinelinux.org/issues/3920
        https://bugs.alpinelinux.org/issues/4969