### PR TITLE
Clear /proc/sys/net/ipv6/conf/IF/disable_ipv6 when create VMACs

### DIFF
--- a/keepalived/include/vrrp_if_config.h
+++ b/keepalived/include/vrrp_if_config.h
@@ -23,6 +23,8 @@
 #ifndef _VRRP_IF_CONFIG_H
 #define _VRRP_IF_CONFIG_H 1
 
+#include <stdbool.h>
+
 #include "vrrp_if.h"
 
 /* prototypes */
@@ -32,8 +34,8 @@ extern void reset_promote_secondaries(interface_t*);
 extern void restore_rp_filter(void);
 extern void set_interface_parameters(const interface_t*, interface_t*);
 extern void reset_interface_parameters(interface_t*);
+extern void link_enable_ipv6(const interface_t*, bool);
 #endif
-extern void link_disable_ipv6(const interface_t*);
 extern int get_ipv6_forwarding(const interface_t*);
 
 #endif

--- a/keepalived/vrrp/vrrp_if_config.c
+++ b/keepalived/vrrp/vrrp_if_config.c
@@ -658,11 +658,13 @@ void reset_interface_parameters(interface_t *base_ifp)
 }
 #endif
 
-void link_disable_ipv6(const interface_t* ifp)
+#ifdef _HAVE_VRRP_VMAC_
+void link_enable_ipv6(const interface_t* ifp, bool enable)
 {
 	/* libnl3, nor the kernel, support setting IPv6 options */
-	set_sysctl("net/ipv6/conf", ifp->ifname, "disable_ipv6", 1);
+	set_sysctl("net/ipv6/conf", ifp->ifname, "disable_ipv6", !enable);
 }
+#endif
 
 int get_ipv6_forwarding(const interface_t* ifp)
 {

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -211,13 +211,18 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 		/* We don't want IPv6 running on the interface unless we have some IPv6
 		 * eVIPs, so disable it if not needed */
 		if (!vrrp->evip_add_ipv6)
-			link_disable_ipv6(ifp);
+			link_enable_ipv6(ifp, false);
 	}
 	if (vrrp->family == AF_INET6 || vrrp->evip_add_ipv6) {
-		// We don't want a link-local address auto assigned - see RFC5798 paragraph 7.4.
-		// If we have a sufficiently recent kernel, we can stop a link local address
-		// based on the MAC address being automatically assigned. If not, then we have
-		// to delete the generated address after bringing the interface up (see below).
+		/* Make sure IPv6 is enabled for the interface, in case the
+		 * sysctl net.ipv6.conf.default.disable_ipv6 is set true. */
+		link_enable_ipv6(ifp, true);
+
+		/* We don't want a link-local address auto assigned - see RFC5798 paragraph 7.4.
+		 * If we have a sufficiently recent kernel, we can stop a link local address
+		 * based on the MAC address being automatically assigned. If not, then we have
+		 * to delete the generated address after bringing the interface up (see below).
+		 */
 #if HAVE_DECL_IFLA_INET6_ADDR_GEN_MODE
 		memset(&req, 0, sizeof (req));
 		req.n.nlmsg_len = NLMSG_LENGTH(sizeof (struct ifinfomsg));


### PR DESCRIPTION
An issue was identified where keepalived was reporting permission
denied when attempting to add an IPv6 address to a VMAC interface.
It turned out that this was because
/proc/sys/net/ipv6/conf/default/disable_ipv6
was set to 1, causing IPv6 to be disables on all interfaces that
keepalived created.

This commit clears disable_ipv6 on any VMAC interfaces that
keepalived creates if the vrrp instance is using IPv6.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>