### PR TITLE
Fix persistence_granularity IPv4 netmask validation

### DIFF
--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -339,7 +339,7 @@ pgr_handler(vector_t *strvec)
 			return;
 		}
 	} else {
-		if (inet_aton(strvec_slot(strvec, 1), &addr)) {
+		if (!inet_aton(strvec_slot(strvec, 1), &addr)) {
 			log_message(LOG_INFO, "Invalid IPv4 persistence_granularity specified - %s", FMT_STR_VSLOT(strvec, 1));
 			return;
 		}


### PR DESCRIPTION
The logic test from inet_aton() appears to be inverted.

Tested-by: Simon Kirby <sim@hostway.ca>
Fixes: fecfe5af9913 ("Improve persistence handling")