### PR TITLE
Support parsing of kernel versions containing '+'

### DIFF
--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -902,7 +902,7 @@ keepalived_main(int argc, char **argv)
 				os_major = 0;
 			else {
 				os_release = (unsigned)strtoul(end + 1, &end, 10);
-				if (*end && *end != '-')
+				if (*end && *end != '-' && *end != '+')
 					os_major = 0;
 			}
 		}


### PR DESCRIPTION
Checking out an upstream kernel (tagged release) using git, changing
anything, and then building and installing the kernel will result in in a
version string such as "4.15.10+" returned by "uname -r". We can just
treat this like '-', if it comes first.