### PR TITLE
add support for SNI in SSL_GET check

### DIFF
--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -835,6 +835,10 @@ virtual_server group <STRING>      {  # VS group declaration
                                   #  virtual_server.
         }
 
+        SSL_GET {
+            enable_sni            # send Server Name Indication during SSL handshake
+        }
+
         TCP_CHECK {  # TCP healthchecker
             # No additional options
         }

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1012,6 +1012,11 @@ A virtual_server can be a declaration of one of
                }
            }
 
+           SSL_GET {
+               # when provided, send Server Name Indicator during SSL handshake
+               enable_sni
+           }
+
            # TCP healthchecker
            TCP_CHECK
            {

--- a/genhash/include/main.h
+++ b/genhash/include/main.h
@@ -70,6 +70,7 @@ typedef struct {
 	char		*vhost;
 	int		verbose;
 	int		ssl;
+	int		sni;
 	SSL_CTX		*ctx;
 	SSL_METHOD	*meth;
 	enum		feat_hashes hash;

--- a/genhash/main.c
+++ b/genhash/main.c
@@ -79,6 +79,7 @@ usage(const char *prog)
 		"Commands:\n"
 		"Either long or short options are allowed.\n"
 		"  %1$s --use-ssl         -S       Use SSL connection to remote server.\n"
+		"  %1$s --use-sni         -I       Use SNI during SSL handshake (uses virtualhost setting; see -V).\n"
 		"  %1$s --server          -s       Use the specified remote server address.\n"
 		"  %1$s --port            -p       Use the specified remote server port.\n"
 		"  %1$s --url             -u       Use the specified remote server url.\n"
@@ -115,6 +116,7 @@ parse_cmdline(int argc, char **argv, REQ * req_obj)
 		{"help",            no_argument,       0, 'h'},
 		{"verbose",         no_argument,       0, 'v'},
 		{"use-ssl",         no_argument,       0, 'S'},
+		{"use-sni",         no_argument,       0, 'I'},
 		{"server",          required_argument, 0, 's'},
 		{"hash",            required_argument, 0, 'H'},
 		{"use-virtualhost", required_argument, 0, 'V'},
@@ -125,7 +127,7 @@ parse_cmdline(int argc, char **argv, REQ * req_obj)
 	};
 
 	/* Parse the command line arguments */
-	while ((c = getopt_long (argc, argv, "rhvSs:H:V:p:u:m:", long_options, NULL)) != EOF) {
+	while ((c = getopt_long (argc, argv, "rhvSIs:H:V:p:u:m:", long_options, NULL)) != EOF) {
 		switch (c) {
 		case 'r':
 			fprintf(stderr, VERSION_STRING);
@@ -139,6 +141,9 @@ parse_cmdline(int argc, char **argv, REQ * req_obj)
 		case 'S':
 			req_obj->ssl = 1;
 			break;
+		case 'I':
+			req_obj->sni = 1;
+			break;	
 		case 's':
 			if ((ret = getaddrinfo(optarg, NULL, &hint, &res)) != 0){
 				fprintf(stderr, "server should be an IP, not %s\n", optarg);

--- a/genhash/ssl.c
+++ b/genhash/ssl.c
@@ -118,6 +118,11 @@ ssl_connect(thread_t * thread)
 	SSL_set0_rbio(sock_obj->ssl, sock_obj->bio);
 	SSL_set0_wbio(sock_obj->ssl, sock_obj->bio);
 #endif
+#if OPENSSL_VERSION_NUMBER > 0x10000000L
+		if (req->vhost != NULL && req->sni) {
+			SSL_set_tlsext_host_name(sock_obj->ssl, req->vhost);
+		}
+#endif
 
 	ret = SSL_connect(sock_obj->ssl);
 

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -253,6 +253,22 @@ url_virtualhost_handler(vector_t *strvec)
 }
 
 static void
+enable_sni_handler(vector_t *strvec)
+{
+	http_checker_t *http_get_chk = CHECKER_GET();
+	int res = true;
+
+	if (vector_size(strvec) >= 2) {
+		res = check_true_false(strvec_slot(strvec, 1));
+		if (res == -1) {
+			log_message(LOG_INFO, "Invalid enable_sni parameter %s", FMT_STR_VSLOT(strvec, 1));
+			return;
+		}
+	}
+	http_get_chk->enable_sni = res;
+}
+
+static void
 url_check(void)
 {
 	http_checker_t *http_get_chk = CHECKER_GET();
@@ -271,6 +287,7 @@ install_http_ssl_check_keyword(const char *keyword)
 	install_checker_common_keywords(true);
 	install_keyword("nb_get_retry", &http_get_retry_handler);	/* Deprecated */
 	install_keyword("virtualhost", &virtualhost_handler);
+	install_keyword("enable_sni", &enable_sni_handler);
 	install_keyword("url", &url_handler);
 	install_sublevel();
 	install_keyword("path", &path_handler);

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -190,6 +190,7 @@ ssl_connect(thread_t * thread, int new_req)
 	checker_t *checker = THREAD_ARG(thread);
 	http_checker_t *http_get_check = CHECKER_ARG(checker);
 	request_t *req = http_get_check->req;
+	url_t *url = list_element(http_get_check->url, http_get_check->url_it);
 	int ret = 0;
 	int val = 0;
 
@@ -206,6 +207,21 @@ ssl_connect(thread_t * thread, int new_req)
 		BIO_up_ref(req->bio);
 		SSL_set0_rbio(req->ssl, req->bio);
 		SSL_set0_wbio(req->ssl, req->bio);
+#endif
+#if OPENSSL_VERSION_NUMBER > 0x10000000L
+		char* vhost = NULL;
+		if (checker->vs->virtualhost != NULL) {
+			vhost = checker->vs->virtualhost;
+		}
+		if (http_get_check->virtualhost != NULL) {
+			vhost = http_get_check->virtualhost;
+		}
+		if (url != NULL && url->virtualhost != NULL) {
+			vhost = url->virtualhost;
+		}
+		if (vhost != NULL && http_get_check->enable_sni) {
+			SSL_set_tlsext_host_name(req->ssl, vhost);
+		}
 #endif
 	}
 

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -65,6 +65,7 @@ typedef struct _http_checker {
 	request_t			*req;		/* GET buffer and SSL args */
 	list				url;
 	char				*virtualhost;
+	bool				enable_sni;
 } http_checker_t;
 
 /* global defs */


### PR DESCRIPTION
This adds a `enable_sni` parameter to SSL_GET, making sure the check
passes the virtualhost in the SNI extension during SSL handshake.

It also adds support for SNI to genhash.

fixes #804 