### PR TITLE
configure.ac: do not force PIE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,8 +233,8 @@ AC_SUBST(ARFLAGS)
 # AC_PROG_LIBTOOL
 
 KA_CPPFLAGS="$kernelinc"
-KA_CFLAGS="-Wall -Wunused -Wstrict-prototypes -Wextra -g -O2 -fPIE -D_GNU_SOURCE"
-KA_LDFLAGS="-pie"
+KA_CFLAGS="-Wall -Wunused -Wstrict-prototypes -Wextra -g -O2 -D_GNU_SOURCE"
+KA_LDFLAGS=""
 KA_LIBS=
 NEED_LIBDL=No
 #KA_LIBTOOLFLAGS =


### PR DESCRIPTION
PIE is not necessarily supported on all architectures, so leave it up
to the user to pass the appropriate CFLAGS/LDFLAGS if he wants to use
PIE.

This fixes the build on the m68k and Microblaze architecture:

  http://autobuild.buildroot.net/results/a536f5947b3b70fdaecad1af5542572c504ad046/
  http://autobuild.buildroot.net/results/0ffbf1e8d181c9463847a5b2be6f9baa18face24/

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>