### PR TITLE
Make checker process handle RTM_NEWLINK messages with -a option

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1182,7 +1182,7 @@ netlink_broadcast_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 		 * when RTNLGRP_LINK has not been subscribed to. This
 		 * occurs when the link is set to up state.
 		 * Only the VRRP process is interested in link messages. */
-#ifndef _DEBUG_
+#if defined _WITH_VRRP_ && !defined _DEBUG_
 		if (prog_type == PROG_TYPE_VRRP)
 #endif
 			return netlink_reflect_filter(snl, h);

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1182,10 +1182,12 @@ netlink_broadcast_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 		 * when RTNLGRP_LINK has not been subscribed to. This
 		 * occurs when the link is set to up state.
 		 * Only the VRRP process is interested in link messages. */
-#if defined _WITH_VRRP_ && !defined _DEBUG_
+#ifdef _WITH_VRRP_ 
+#ifndef _DEBUG_
 		if (prog_type == PROG_TYPE_VRRP)
 #endif
 			return netlink_reflect_filter(snl, h);
+#endif
 		break;
 	case RTM_NEWADDR:
 	case RTM_DELADDR:

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1175,12 +1175,18 @@ static int
 netlink_broadcast_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 {
 	switch (h->nlmsg_type) {
-#ifdef _WITH_VRRP_
 	case RTM_NEWLINK:
 	case RTM_DELLINK:
-		return netlink_reflect_filter(snl, h);
-		break;
+		/* It appears that older kernels (certainly 2.6.32) can
+		 * send RTM_NEWLINK (but not RTM_DELLINK) messages even
+		 * when RTNLGRP_LINK has not been subscribed to. This
+		 * occurs when the link is set to up state.
+		 * Only the VRRP process is interested in link messages. */
+#ifndef _DEBUG_
+		if (prog_type == PROG_TYPE_VRRP)
 #endif
+			return netlink_reflect_filter(snl, h);
+		break;
 	case RTM_NEWADDR:
 	case RTM_DELADDR:
 		return netlink_if_address_filter(snl, h);


### PR DESCRIPTION
Even though the checker process doesn't subscribe to RTNLGRP_LINK
messages, it appears that older kernels (certainly 2.6.32) can
send RTM_NEWLINK (but not RTM_DELLINK) messages. This occurs
when the link is set to up state.

Only the VRRP process is interested in link messages, and so the
checker process doesn't do the necessary initialisation to be able
to handle RTM_NEWLINK messages.

This commit makes the checker process simply discard RTM_NEWLINK
and RTM_DELLINK messages, rather than assuming that if it receives
an RTM_NEWLINK message it must be the VRRP process.

This problem was reported in issue #848 since the checker process
was segfaulting when a new interface was added when the -a command
line option was specified.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>