### PR TITLE
Fix building on Fedora 28

### DIFF
--- a/configure
+++ b/configure
@@ -9919,6 +9919,30 @@ fi
   NETSNMP_LIBS="$NETSNMP_LIBS_AGENT $NETSNMP_LIBS_EXT"
   NETSNMP_CFLAGS="`${NETSNMP_CONFIG} --base-cflags` -DNETSNMP_NO_INLINE"
 
+  # net-snmp-config adds compiler and linker options that were set at the time
+  # net-snmp was built, and this can include spec files that may not exist
+  # on the system building keepalived. We need to check if any spec files
+  # are specified, and if they do not exist on this system, then remove them
+  # from NETSNMP_LIBS or NETSNMP_CFLAGS.
+  # For further information, see https://bugzilla.redhat.com/show_bug.cgi?id=1544527
+  # and the other bugs referred to in it.
+  for spec in `echo $NETSNMP_LIBS | sed -e "s? ?\n?g" | grep "^-specs="`; do
+    SPEC_FILE=`echo $spec | sed -e "s?^-spaces=??"`
+    if test ! -f $SPEC_FILE; then
+      NETSNMP_LIBS=`echo $NETSNMP_LIBS | sed -e "s? *$spec *? ?"`
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Removing $spec from NETSNMP_LIBS since spec file not installed" >&5
+$as_echo "$as_me: WARNING: Removing $spec from NETSNMP_LIBS since spec file not installed" >&2;}
+    fi
+  done
+  for spec in `echo $NETSNMP_CFLAGS | sed -e "s? ?\n?g" | grep "^-specs="`; do
+    SPEC_FILE=`echo $spec | sed -e "s?^-spaces=??"`
+    if test ! -f $SPEC_FILE; then
+      NETSNMP_CFLAGS=`echo $NETSNMP_CFLAGS | sed -e "s? *$spec *? ?"`
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Removing $spec from NETSNMP_CFLAGS since spec file not installed" >&5
+$as_echo "$as_me: WARNING: Removing $spec from NETSNMP_CFLAGS since spec file not installed" >&2;}
+    fi
+  done
+
   SAV_CFLAGS="$CFLAGS"
   CFLAGS="$CFLAGS ${NETSNMP_CFLAGS}"
   SAV_LIBS="$LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -1194,6 +1194,28 @@ if test "$enable_snmp" = yes -o \
   NETSNMP_LIBS="$NETSNMP_LIBS_AGENT $NETSNMP_LIBS_EXT"
   NETSNMP_CFLAGS="`${NETSNMP_CONFIG} --base-cflags` -DNETSNMP_NO_INLINE"
 
+  # net-snmp-config adds compiler and linker options that were set at the time
+  # net-snmp was built, and this can include spec files that may not exist
+  # on the system building keepalived. We need to check if any spec files
+  # are specified, and if they do not exist on this system, then remove them
+  # from NETSNMP_LIBS or NETSNMP_CFLAGS.
+  # For further information, see https://bugzilla.redhat.com/show_bug.cgi?id=1544527
+  # and the other bugs referred to in it.
+  for spec in `echo $NETSNMP_LIBS | sed -e "s? ?\n?g" | grep "^-specs="`; do
+    SPEC_FILE=`echo $spec | sed -e "s?^-spaces=??"`
+    if test ! -f $SPEC_FILE; then
+      NETSNMP_LIBS=`echo $NETSNMP_LIBS | sed -e "s? *$spec *? ?"`
+      AC_MSG_WARN([Removing $spec from NETSNMP_LIBS since spec file not installed])
+    fi
+  done
+  for spec in `echo $NETSNMP_CFLAGS | sed -e "s? ?\n?g" | grep "^-specs="`; do
+    SPEC_FILE=`echo $spec | sed -e "s?^-spaces=??"`
+    if test ! -f $SPEC_FILE; then
+      NETSNMP_CFLAGS=`echo $NETSNMP_CFLAGS | sed -e "s? *$spec *? ?"`
+      AC_MSG_WARN([Removing $spec from NETSNMP_CFLAGS since spec file not installed])
+    fi
+  done
+
   SAV_CFLAGS="$CFLAGS"
   CFLAGS="$CFLAGS ${NETSNMP_CFLAGS}"
   SAV_LIBS="$LIBS"


### PR DESCRIPTION
net-snmp-config output can include compiler and linker flags that
refer to spec files that were used to build net-snmp but may not
exist on the system building keepalived. That would cause the build
done by configure to test for net-snmp support to fail; in particular
on a Fedora 28 system that doesn't have the redhat-rpm-config package
installed.

This commit checks that any spec files in the compiler and linker
flags returned by net-snmp-config exist on the system building
keepalived, and if not it removes the reference(s) to the spec file(s).

See https://bugzilla.redhat.com/show_bug.cgi?id=1544527 for further
details.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>