### PR TITLE
Don't send TSM logs to stdout, but log_message

### DIFF
--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -103,7 +103,6 @@ static int vrrp_bfd_thread(thread_t *);
 
 static int vrrp_read_dispatcher_thread(thread_t *);
 
-#define	TSM_DEBUG
 
 /* VRRP TSM (Transition State Matrix) design.
  *
@@ -848,10 +847,9 @@ vrrp_dispatcher_read_timeout(int fd)
 			vrrp_master(vrrp);
 
 		/* handle instance synchronization */
-#ifdef TSM_DEBUG
-		printf("Send [%s] TSM transtition : [%d,%d] Wantstate = [%d]\n",
-			vrrp->iname, prev_state, vrrp->state, vrrp->wantstate);
-#endif
+		if (__test_bit(LOG_DETAIL_BIT, &debug))
+			log_message(LOG_INFO, "Send [%s] TSM transtition : [%d,%d] Wantstate = [%d]\n",
+				vrrp->iname, prev_state, vrrp->state, vrrp->wantstate);
 		VRRP_TSM_HANDLE(prev_state, vrrp);
 
 		vrrp_init_instance_sands(vrrp);
@@ -906,10 +904,9 @@ vrrp_dispatcher_read(sock_t * sock)
 		log_message(LOG_INFO, "(%s) In dispatcher_read with state %d", vrrp->iname, vrrp->state);
 
 	/* handle instance synchronization */
-#ifdef TSM_DEBUG
-	printf("Read [%s] TSM transtition : [%d,%d] Wantstate = [%d]\n",
-		vrrp->iname, prev_state, vrrp->state, vrrp->wantstate);
-#endif
+	if (__test_bit(LOG_DETAIL_BIT, &debug))
+		log_message(LOG_INFO, "Read [%s] TSM transtition : [%d,%d] Wantstate = [%d]\n",
+			vrrp->iname, prev_state, vrrp->state, vrrp->wantstate);
 	VRRP_TSM_HANDLE(prev_state, vrrp);
 
 	/* If we have sent an advert, reset the timer */


### PR DESCRIPTION
Hello,

TSM logs are always sent to stdout. This generates a lot of noise if keepalived is run in foreground.
This change sends TSM log using log_message, only if LOG_DETAIL_BIT is set.

Gautier