### PR TITLE
Don't create a link-local address for vmac when vmac_xmit_base is set

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1124,6 +1124,7 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 						else if (vrrp->family == AF_INET6 &&
 							 ifp == vrrp->ifp->base_ifp &&
 							 vrrp->ifp->vmac &&
+							 !__test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->vmac_flags) &&
 							 vrrp->num_script_if_fault &&
 							 vrrp->family == ifa->ifa_family &&
 							 vrrp->saddr.ss_family == AF_UNSPEC &&
@@ -1175,6 +1176,7 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 						    __test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags) &&
 						    ifp == vrrp->ifp->base_ifp &&
 						    ifa->ifa_scope == RT_SCOPE_LINK &&
+						    !__test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->vmac_flags) &&
 						    !vrrp->saddr_from_config &&
 						    vrrp->ifp->base_ifp->sin6_addr.s6_addr32[0] == addr.in6->s6_addr32[0] &&
 						    vrrp->ifp->base_ifp->sin6_addr.s6_addr32[1] == addr.in6->s6_addr32[1] &&

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -350,7 +350,8 @@ netlink_link_add_vmac(vrrp_t *vrrp)
 			log_message(LOG_INFO, "vmac: Error setting ADDR_GEN_MODE to NONE");
 #endif
 
-		if (vrrp->family == AF_INET6) {
+		if (vrrp->family == AF_INET6 &&
+		    !__test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->vmac_flags)) {
 			/* Add link-local address. If a source address has been specified, use it,
 			 * else use link-local address from underlying interface to vmac if there is one,
 			 * otherwise construct a link-local address based on underlying interface's


### PR DESCRIPTION
Since commit 18ec95add483 ("Make vmac_xmit_base work for IPv6
instances") VRRP advertisements are sent from the base interface and not
from the vmac interface when vmac_xmit_base is set.

Therefore, there is no need to configure a link-local address on the
vmac interface. This also means that we don't need to regenerate a
link-local address for the vmac if the link-local address was removed
from the base interface, or inherit a link-local address in case one was
configured on the base interface.

Signed-off-by: Ido Schimmel <idosch@mellanox.com>