### PR TITLE
Add newlines to the keepalived.stats output for better readability.

### DIFF
--- a/keepalived/vrrp/vrrp_print.c
+++ b/keepalived/vrrp/vrrp_print.c
@@ -70,34 +70,34 @@ vrrp_print_stats(void)
 
 	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
 		vrrp = ELEMENT_DATA(e);
-		fprintf(file, "VRRP Instance: %s", vrrp->iname);
-		fprintf(file, "  Advertisements:");
-		fprintf(file, "    Received: %" PRIu64 "", vrrp->stats->advert_rcvd);
-		fprintf(file, "    Sent: %d", vrrp->stats->advert_sent);
-		fprintf(file, "  Became master: %d", vrrp->stats->become_master);
-		fprintf(file, "  Released master: %d",
+		fprintf(file, "VRRP Instance: %s\n", vrrp->iname);
+		fprintf(file, "  Advertisements:\n");
+		fprintf(file, "    Received: %" PRIu64 "\n", vrrp->stats->advert_rcvd);
+		fprintf(file, "    Sent: %d\n", vrrp->stats->advert_sent);
+		fprintf(file, "  Became master: %d\n", vrrp->stats->become_master);
+		fprintf(file, "  Released master: %d\n",
 			vrrp->stats->release_master);
-		fprintf(file, "  Packet Errors:");
-		fprintf(file, "    Length: %" PRIu64 "", vrrp->stats->packet_len_err);
-		fprintf(file, "    TTL: %" PRIu64 "", vrrp->stats->ip_ttl_err);
-		fprintf(file, "    Invalid Type: %" PRIu64 "",
+		fprintf(file, "  Packet Errors:\n");
+		fprintf(file, "    Length: %" PRIu64 "\n", vrrp->stats->packet_len_err);
+		fprintf(file, "    TTL: %" PRIu64 "\n", vrrp->stats->ip_ttl_err);
+		fprintf(file, "    Invalid Type: %" PRIu64 "\n",
 			vrrp->stats->invalid_type_rcvd);
-		fprintf(file, "    Advertisement Interval: %" PRIu64 "",
+		fprintf(file, "    Advertisement Interval: %" PRIu64 "\n",
 			vrrp->stats->advert_interval_err);
-		fprintf(file, "    Address List: %" PRIu64 "",
+		fprintf(file, "    Address List: %" PRIu64 "\n",
 			vrrp->stats->addr_list_err);
-		fprintf(file, "  Authentication Errors:");
-		fprintf(file, "    Invalid Type: %d",
+		fprintf(file, "  Authentication Errors:\n");
+		fprintf(file, "    Invalid Type: %d\n",
 			vrrp->stats->invalid_authtype);
 #ifdef _WITH_VRRP_AUTH_
-		fprintf(file, "    Type Mismatch: %d",
+		fprintf(file, "    Type Mismatch: %d\n",
 			vrrp->stats->authtype_mismatch);
-		fprintf(file, "    Failure: %d",
+		fprintf(file, "    Failure: %d\n",
 			vrrp->stats->auth_failure);
 #endif
-		fprintf(file, "  Priority Zero:");
-		fprintf(file, "    Received: %" PRIu64 "", vrrp->stats->pri_zero_rcvd);
-		fprintf(file, "    Sent: %" PRIu64 "", vrrp->stats->pri_zero_sent);
+		fprintf(file, "  Priority Zero:\n");
+		fprintf(file, "    Received: %" PRIu64 "\n", vrrp->stats->pri_zero_rcvd);
+		fprintf(file, "    Sent: %" PRIu64 "\n", vrrp->stats->pri_zero_sent);
 	}
 	fclose(file);
 }


### PR DESCRIPTION
At some point, newlines have disappeared from the /tmp/keepalived.stats file generated on SIGUSR2, which made it completele unreadable for machines and hard to read for humans, so I've added the newlines back.

This is what it was like for me in 2.0.5.

````

# cat /tmp/keepalived.stats 
VRRP Instance: Bar  Advertisements:    Received: 0    Sent: 18120  Became master: 1  Released master: 0  Packet Errors:    Length: 0    TTL: 0    Invalid Type: 0    Advertisement Interval: 0    Address List: 0  Authentication Errors:    Invalid Type: 0    Type Mismatch: 0    Failure: 0  Priority Zero:    Received: 0    Sent: 0VRRP Instance: Foo  Advertisements:    Received: 0    Sent: 18120  Became master: 1  Released master: 0  Packet Errors:    Length: 0    TTL: 0    Invalid Type: 0    Advertisement Interval: 0    Address List: 0  Authentication Errors:    Invalid Type: 0    Type Mismatch: 0    Failure: 0  Priority Zero:    Received: 0    Sent: 0

````
