### PR TITLE
Add notify_master_rx_lower_pri script option and FIFO output

### DIFF
--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201806040000Z"
+     LAST-UPDATED "201807180000Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201807180000Z"
+     DESCRIPTION "add script master rx lower priority"
      REVISION "201806040000Z"
      DESCRIPTION "add ip rule protocol, ip_proto, src and dst port ranges"
      REVISION "201805170000Z"
@@ -735,7 +737,8 @@ VrrpInstanceEntry ::= SEQUENCE {
     vrrpInstanceAccept INTEGER,
     vrrpInstancePromoteSecondaries INTEGER,
     vrrpInstanceUseLinkbeat INTEGER,
-    vrrpInstanceVrrpVersion INTEGER
+    vrrpInstanceVrrpVersion INTEGER,
+    vrrpInstanceScriptMstrRxLowerPri DisplayString
 }
 
 vrrpInstanceIndex OBJECT-TYPE
@@ -994,6 +997,14 @@ vrrpInstanceVrrpVersion OBJECT-TYPE
     DESCRIPTION
         "VRRP protocol version."
     ::= { vrrpInstanceEntry 30 }
+
+vrrpInstanceScriptMstrRxLowerPri OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Script to execute when master instance receives lower priority advert."
+    ::= { vrrpInstanceEntry 31 }
 
 vrrpTrackedInterfaceTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpTrackedInterfaceEntry
@@ -4108,6 +4119,7 @@ vrrpInstanceGroup OBJECT-GROUP
     vrrpInstancePromoteSecondaries,
     vrrpInstanceUseLinkbeat,
     vrrpInstanceVrrpVersion,
+    vrrpInstanceScriptMstrRxLowerPri,
     vrrpTrackedInterfaceName,
     vrrpTrackedInterfaceWeight,
     vrrpTrackedScriptName,

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -759,7 +759,7 @@ vrrp_sync_group <STRING> {      # VRRP sync group declaration
     $(n-1) = The state it's transitioning to ("MASTER", "BACKUP", "FAULT" or "STOP")
     $(n)   = The priority value
 
-    $1 and $3 are ALWAYS sent in uppercase, and the possible strings sent are the
+    $(n-3) and $(n-1) are ALWAYS sent in uppercase, and the possible strings sent are the
     same ones listed above ("GROUP"/"INSTANCE", "MASTER"/"BACKUP"/"FAULT"/"STOP")
     (note: STOP is only applicable to instances)
 
@@ -771,6 +771,14 @@ Important: for a SYNC group to run reliably, it is vital that all instances in
            track scripts/files configured against member VRRP instances will have
            their tracking weights automatically set to zero, in order to avoid
            inconsistent priorities across instances.
+
+(2) The notify fifo output is the same as the last 4 parameters for the "notify"
+    script, with the addition of "MASTER_RX_LOWER_PRI" instead of state for an
+    instance. This is used if a master needs to set some external state, such as
+    setting a secondary IP address when using Amazon AWS; if another keepalived
+    has transitioned to master due to a communications break, the lower priority
+    instance will have taken over the secondary IP address, and the proper master
+    needs to be able to restore it.
 
     2.5. VRRP gratuitous ARP/NA intervals
 
@@ -950,6 +958,8 @@ vrrp_instance <STRING> {                      # VRRP instance declaration
                                               # Script to launch when stopping vrrp
     notify <STRING>|<QUOTED-STRING> [username [groupname]]
                                               # Same as vrrp_sync_group
+    notify_master_rx_lower_pri <STRING>|<QUOTED-STRING> [username [groupname]]
+                                              # Script to run if a master receives a lower priority advert
     smtp_alert <BOOL>                         # Same as vrrp_sync_group
                                               #   (default no, unless global smtp_alert/smtp_alert_vrrp set)
     kernel_rx_buf_size                        # Set socket receive buffer size (see global_defs

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -757,14 +757,22 @@ bfd_instance <STRING> {
 
             # for ANY state transition.
             # "notify" script is called AFTER the notify_* script(s) and
-            # is executed # with 4 additional arguments after the configured
+            # is executed with 4 additional arguments after the configured
             # arguments provided by Keepalived:
             # $(n-3) = "GROUP"|"INSTANCE"
             # $(n-2) = name of the group or instance
             # $(n-1) = target state of transition (stop only applies to instances)
             #     ("MASTER"|"BACKUP"|"FAULT"|"STOP")
             # $(n)   = priority value
-            notify /path/notify.sh [username [groupname]]
+            notify <STRING>|<QUOTED-STRING> [username [groupname]]
+
+            # The notify fifo output is the same as the last 4 parameters for the "notify"
+            # script, with the addition of "MASTER_RX_LOWER_PRI" instead of state for an
+            # instance. This is used if a master needs to set some external state, such as
+            # setting a secondary IP address when using Amazon AWS; if another keepalived
+            # has transitioned to master due to a communications break, the lower priority
+            # instance will have taken over the secondary IP address, and the proper master
+            # needs to be able to restore it.
 
             # Send email notification during state transition,
             # using addresses in global_defs above (default no,
@@ -1053,6 +1061,9 @@ bfd_instance <STRING> {
            notify_fault <STRING>|<QUOTED-STRING> [username [groupname]]
            notify_stop <STRING>|<QUOTED-STRING> [username [groupname]]      # executed when stopping vrrp
            notify <STRING>|<QUOTED-STRING> [username [groupname]]
+           # The notify_master_rx_lower_pri script is executed if a master
+           #  receives an advert with priority lower than the master's advert.
+           notify_master_rx_lower_pri <STRING>|<QUOTED-STRING> [username [groupname]]
            smtp_alert <BOOL>
            kernel_rx_buf_size                 # Set socket receive buffer size (see global_defs
                                               #   vrrp_rx_bufs_policy for explanation)

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -278,6 +278,7 @@ typedef struct _vrrp_t {
 	notify_script_t		*script_master;
 	notify_script_t		*script_fault;
 	notify_script_t		*script_stop;
+	notify_script_t		*script_master_rx_lower_pri;
 	notify_script_t		*script;
 
 	/* rfc2338.6.2 */
@@ -315,6 +316,7 @@ typedef struct _vrrp_t {
 #define VRRP_STATE_FAULT		3	/* internal */
 #define VRRP_STATE_STOP			98	/* internal */
 #define VRRP_DISPATCHER			99	/* internal */
+#define VRRP_EVENT_MASTER_RX_LOWER_PRI	1000	/* Dummy state for sending event notify */
 
 /* VRRP packet handling */
 #define VRRP_PACKET_OK       0

--- a/keepalived/include/vrrp_notify.h
+++ b/keepalived/include/vrrp_notify.h
@@ -27,6 +27,7 @@
 /* local include */
 #include "vrrp.h"
 
+extern void send_event_notify(vrrp_t *, int);
 extern void send_instance_notifies(vrrp_t *);
 extern void send_group_notifies(vrrp_sgroup_t *);
 extern void notify_shutdown(void);

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -317,6 +317,7 @@ free_vrrp(void *data)
 	free_notify_script(&vrrp->script_fault);
 	free_notify_script(&vrrp->script_stop);
 	free_notify_script(&vrrp->script);
+	free_notify_script(&vrrp->script_master_rx_lower_pri);
 	FREE_PTR(vrrp->stats);
 
 	free_list(&vrrp->track_ifp);
@@ -500,6 +501,8 @@ dump_vrrp(FILE *fp, void *data)
 		dump_notify_script(fp, vrrp->script_stop, "Stop");
 	if (vrrp->script)
 		dump_notify_script(fp, vrrp->script, "Generic");
+	if (vrrp->script_master_rx_lower_pri)
+		dump_notify_script(fp, vrrp->script_master_rx_lower_pri, "Master rx lower pri");
 }
 
 void

--- a/keepalived/vrrp/vrrp_json.c
+++ b/keepalived/vrrp/vrrp_json.c
@@ -236,6 +236,9 @@ vrrp_print_json(void)
 		if (vrrp->script)
 			json_object_object_add(json_data, "script",
 				json_object_new_string(cmd_str(vrrp->script)));
+		if (vrrp->script_master_rx_lower_pri)
+			json_object_object_add(json_data, "script_master_rx_lower_pri",
+				json_object_new_string(cmd_str(vrrp->script_master_rx_lower_pri)));
 		json_object_object_add(json_data, "smtp_alert",
 			json_object_new_boolean(vrrp->smtp_alert));
 #ifdef _WITH_VRRP_AUTH_

--- a/keepalived/vrrp/vrrp_notify.c
+++ b/keepalived/vrrp/vrrp_notify.c
@@ -97,10 +97,21 @@ notify_fifo(const char *name, int state_num, bool group, uint8_t priority)
 		return;
 
 	switch (state_num) {
-		case VRRP_STATE_MAST  : state = "MASTER" ; break;
-		case VRRP_STATE_BACK  : state = "BACKUP" ; break;
-		case VRRP_STATE_FAULT : state = "FAULT" ; break;
-		case VRRP_STATE_STOP  : state = "STOP" ; break;
+	case VRRP_STATE_MAST:
+		state = "MASTER";
+		break;
+	case VRRP_STATE_BACK:
+		state = "BACKUP";
+		break;
+	case VRRP_STATE_FAULT:
+		state = "FAULT";
+		break;
+	case VRRP_STATE_STOP:
+		state = "STOP";
+		break;
+	case VRRP_EVENT_MASTER_RX_LOWER_PRI:
+		state = "MASTER_RX_LOWER_PRI";
+		break;
 	}
 
 	type = group ? "GROUP" : "INSTANCE";
@@ -222,6 +233,18 @@ vrrp_sync_smtp_notifier(vrrp_sgroup_t *vgroup)
 
 		vgroup->last_email_state = vgroup->state;
 	}
+}
+
+void
+send_event_notify(vrrp_t *vrrp, int event)
+{
+	notify_script_t *script = vrrp->script_master_rx_lower_pri;
+
+	/* Launch the notify_* script */
+	if (script)
+		notify_exec(script);
+
+	notify_fifo(vrrp->iname, event, false, vrrp->effective_priority);
 }
 
 void

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -707,6 +707,17 @@ vrrp_notify_handler(vector_t *strvec)
 	vrrp->notify_exec = true;
 }
 static void
+vrrp_notify_master_rx_lower_pri(vector_t *strvec)
+{
+	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
+	if (vrrp->script_master_rx_lower_pri) {
+		log_message(LOG_INFO, "(%s) notify_master_rx_lower_pri script already specified - ignoring %s", vrrp->iname, FMT_STR_VSLOT(strvec,1));
+		return;
+	}
+	vrrp->script_master_rx_lower_pri = set_vrrp_notify_script(strvec, 0);
+	vrrp->notify_exec = true;
+}
+static void
 vrrp_smtp_handler(__attribute__((unused)) vector_t *strvec)
 {
 	vrrp_t *vrrp = LIST_TAIL_DATA(vrrp_data->vrrp);
@@ -1366,6 +1377,7 @@ init_vrrp_keywords(bool active)
 	install_keyword("notify_fault", &vrrp_notify_fault_handler);
 	install_keyword("notify_stop", &vrrp_notify_stop_handler);
 	install_keyword("notify", &vrrp_notify_handler);
+	install_keyword("notify_master_rx_lower_pri", vrrp_notify_master_rx_lower_pri);
 	install_keyword("smtp_alert", &vrrp_smtp_handler);
 #ifdef _WITH_LVS_
 	install_keyword("lvs_sync_daemon_interface", &vrrp_lvs_syncd_handler);

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -200,6 +200,7 @@ enum snmp_vrrp_magic {
 	VRRP_SNMP_INSTANCE_PROMOTE_SECONDARIES,
 	VRRP_SNMP_INSTANCE_USE_LINKBEAT,
 	VRRP_SNMP_INSTANCE_VRRP_VERSION,
+	VRRP_SNMP_INSTANCE_SCRIPTMASTER_RX_LOWER_PRI,
 	VRRP_SNMP_TRACKEDINTERFACE_NAME,
 	VRRP_SNMP_TRACKEDINTERFACE_WEIGHT,
 	VRRP_SNMP_TRACKEDSCRIPT_NAME,
@@ -2067,6 +2068,13 @@ vrrp_snmp_instance(struct variable *vp, oid *name, size_t *length,
 			return (u_char *)buf;
 		}
 		break;
+	case VRRP_SNMP_INSTANCE_SCRIPTMASTER_RX_LOWER_PRI:
+		if (rt->script_master_rx_lower_pri) {
+			cmd_str_r(rt->script_master_rx_lower_pri, buf, sizeof(buf));
+			*var_len = strlen(buf);
+			return (u_char *)buf;
+		}
+		break;
 	case VRRP_SNMP_INSTANCE_SCRIPT:
 		if (rt->script) {
 			cmd_str_r(rt->script, buf, sizeof(buf));
@@ -2717,6 +2725,8 @@ static struct variable8 vrrp_vars[] = {
 	 vrrp_snmp_instance, 3, {3, 1, 29} },
 	{VRRP_SNMP_INSTANCE_VRRP_VERSION, ASN_INTEGER, RONLY,
 	 vrrp_snmp_instance, 3, {3, 1, 30} },
+	{VRRP_SNMP_INSTANCE_SCRIPTMASTER_RX_LOWER_PRI, ASN_OCTET_STR, RONLY,
+	 vrrp_snmp_instance, 3, {3, 1, 31}},
 
 	/* vrrpTrackedInterfaceTable */
 	{VRRP_SNMP_TRACKEDINTERFACE_NAME, ASN_OCTET_STR, RONLY,


### PR DESCRIPTION
If a lower priority router has transitioned to master, there has presumably
been an intermittent communications break between the master and backup. It
appears that servers in an Amazon AWS environment can experience this.
The problem then occurs if a notify_master script is executed on the backup
that has just transitioned to master and the script executes something like
a `aws ec2 assign-private-ip-addresses` command, thereby removing the address
from the 'proper' master. Executing notify_master_rx_lower_pri notification
allows the 'proper' master to recover the secondary addresses.

This problem was reported in issue #950.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>