### PR TITLE
Add mh scheduler for LVS

### DIFF
--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -2784,7 +2784,9 @@ VirtualServerEntry ::= SEQUENCE {
     virtualServerDelayBeforeRetry Unsigned32,
     virtualServerWarmup Unsigned32,
     virtualServerWeight INTEGER,
-    virtualServerSmtpAlert INTEGER
+    virtualServerSmtpAlert INTEGER,
+    virtualServerMHFallback TruthValue,
+    virtualServerMHPort TruthValue
 }
 
 virtualServerIndex OBJECT-TYPE
@@ -2875,6 +2877,7 @@ virtualServerLoadBalancingAlgo OBJECT-TYPE
     nq(10),
     fo(11),
     ovf(12),
+    mh(13),
     unknown(99)
     }
     MAX-ACCESS read-only
@@ -3339,6 +3342,23 @@ virtualServerSmtpAlert OBJECT-TYPE
     DESCRIPTION
         "Will SMTP alert be sent for this virtual server?"
     ::= { virtualServerEntry 61 }
+
+virtualServerMHFallback OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "If set to true(1), MH scheduler fallback."
+    ::= { virtualServerEntry 62 }
+
+virtualServerMHPort OBJECT-TYPE
+    SYNTAX TruthValue
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "If set to true(1), MH scheduler use port."
+    ::= { virtualServerEntry 63 }
+
 
 -- real servers
 
@@ -4385,6 +4405,8 @@ virtualServerGroup OBJECT-GROUP
     virtualServerWarmup,
     virtualServerWeight,
     virtualServerSmtpAlert
+    virtualServerMHFallback,
+    virtualServerMHPort,
     }
     STATUS current
     DESCRIPTION

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -1053,7 +1053,7 @@ virtual_server fwmark <INTEGER>      {        # VS fwmark declaration
 virtual_server group <STRING>        {        # VS group declaration
     ip_family inet|inet6                      # Address family
     delay_loop <INTEGER>                      # delay timer for service polling
-    lvs_sched rr|wrr|lc|wlc|lblc|sh|dh|fo|ovf|lblcr|sed|nq
+    lvs_sched rr|wrr|lc|wlc|lblc|sh|mh|dh|fo|ovf|lblcr|sed|nq
                                               # LVS scheduler used
     hashed                                    # Apply hashing
     flag-1                                    # Apply scheduler flag 1
@@ -1063,6 +1063,10 @@ virtual_server group <STRING>        {        # VS group declaration
                                               #  same as flag-2 for sh scheduler)
     sh-fallback                               # Apply sh-fallback scheduler flag (only for sh scheduler,
                                               #  same as flag-1 for sh scheduler)
+    mh-port                                   # Apply mh-port scheduler flag (only for mh scheduler,
+                                              #  same as flag-2 for mh scheduler)
+    mh-fallback                               # Apply mh-fallback scheduler flag (only for mh scheduler,
+                                              #  same as flag-1 for mh scheduler)
     ops                                       # Apply One-Packet-Scheduling (only for UDP)
     lvs_method NAT|DR|TUN                     # default LVS method to use
     persistence_engine <STRING>               # LVS persistence engine name

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1144,7 +1144,7 @@ A virtual_server can be a declaration of one of
     delay_loop <INT>
 
     # LVS scheduler
-    lvs_sched rr|wrr|lc|wlc|lblc|sh|dh|fo|ovf|lblcr|sed|nq
+    lvs_sched rr|wrr|lc|wlc|lblc|sh|mh|dh|fo|ovf|lblcr|sed|nq
 
     # Enable hashed entry
     hashed
@@ -1158,6 +1158,10 @@ A virtual_server can be a declaration of one of
     sh-port
     # Enable sh-fallback for sh scheduler  (-b sh-fallback in ipvsadm)
     sh-fallback
+    # Enable mh-port for mh scheduler (-b mh-port in ipvsadm)
+    mh-port
+    # Enable mh-fallback for mh scheduler  (-b mh-fallback in ipvsadm)
+    mh-fallback
     # Enable One-Packet-Scheduling for UDP (-O in ipvsadm)
     ops
     # Default LVS forwarding method

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -278,6 +278,11 @@ dump_vs(FILE *fp, void *data)
 		conf_write(fp, "   sh-port = %sabled", vs->flags & IP_VS_SVC_F_SCHED_SH_PORT ? "en" : "dis");
 		conf_write(fp, "   sh-fallback = %sabled", vs->flags & IP_VS_SVC_F_SCHED_SH_FALLBACK ? "en" : "dis");
 	}
+	else if (!strcmp(vs->sched, "mh"))
+	{
+		conf_write(fp, "   mh-port = %sabled", vs->flags & IP_VS_SVC_F_SCHED_MH_PORT ? "en" : "dis");
+		conf_write(fp, "   mh-fallback = %sabled", vs->flags & IP_VS_SVC_F_SCHED_MH_FALLBACK ? "en" : "dis");
+	}
 	else
 	{
 		conf_write(fp, "   flag-1 = %sabled", vs->flags & IP_VS_SVC_F_SCHED1 ? "en" : "dis");

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -48,7 +48,7 @@
 
 /* List of valid schedulers */
 char *lvs_schedulers[] =
-	{"rr", "wrr", "lc", "wlc", "lblc", "sh", "dh", "fo", "ovf", "lblcr", "sed", "nq", NULL};
+	{"rr", "wrr", "lc", "wlc", "lblc", "sh", "mh", "dh", "fo", "ovf", "lblcr", "sed", "nq", NULL};
 
 /* SSL handlers */
 static void
@@ -305,6 +305,14 @@ lbflags_handler(vector_t *strvec)
 			vs->flags |= IP_VS_SVC_F_SCHED_SH_PORT;
 		if (!strcmp(str, "sh-fallback"))
 			vs->flags |= IP_VS_SVC_F_SCHED_SH_FALLBACK;
+	}
+	else if (!strcmp(vs->sched , "mh") )
+	{
+		/* mh-port and mh-fallback flags are relevant for mh scheduler only */
+		if (!strcmp(str, "mh-port")  )
+			vs->flags |= IP_VS_SVC_F_SCHED_MH_PORT;
+		if (!strcmp(str, "mh-fallback"))
+			vs->flags |= IP_VS_SVC_F_SCHED_MH_FALLBACK;
 	}
 	else
 		report_config_error(CONFIG_GENERAL_ERROR, "%s only applies to sh scheduler - ignoring", str);

--- a/keepalived/check/check_snmp.c
+++ b/keepalived/check/check_snmp.c
@@ -104,6 +104,8 @@ enum check_snmp_virtualserver_magic {
 	CHECK_SNMP_VSHASHED,
 	CHECK_SNMP_VSSHFALLBACK,
 	CHECK_SNMP_VSSHPORT,
+	CHECK_SNMP_VSMHFALLBACK,
+	CHECK_SNMP_VSMHPORT,
 	CHECK_SNMP_VSSCHED3,
 	CHECK_SNMP_VSACTIONWHENDOWN,
 	CHECK_SNMP_VSRETRY,
@@ -459,6 +461,8 @@ check_snmp_virtualserver(struct variable *vp, oid *name, size_t *length,
 			long_ret.u = 11;
 		else if (!strcmp(v->sched, "ovf"))
 			long_ret.u = 12;
+		else if (!strcmp(v->sched, "mh"))
+			long_ret.u = 13;
 		else
 			long_ret.u = 99;
 		return (u_char*)&long_ret;
@@ -661,6 +665,12 @@ check_snmp_virtualserver(struct variable *vp, oid *name, size_t *length,
 		return (u_char*)&long_ret;
 	case CHECK_SNMP_VSSHPORT:
 		long_ret.u = v->flags & IP_VS_SVC_F_SCHED_SH_PORT ? 1 : 2;
+		return (u_char*)&long_ret;
+	case CHECK_SNMP_VSMHFALLBACK:
+		long_ret.u = v->flags & IP_VS_SVC_F_SCHED_MH_FALLBACK ? 1 : 2;
+		return (u_char*)&long_ret;
+	case CHECK_SNMP_VSMHPORT:
+		long_ret.u = v->flags & IP_VS_SVC_F_SCHED_MH_PORT ? 1 : 2;
 		return (u_char*)&long_ret;
 	case CHECK_SNMP_VSSCHED3:
 		long_ret.u = v->flags & IP_VS_SVC_F_SCHED3 ? 1 : 2;
@@ -1306,6 +1316,10 @@ static struct variable8 check_vars[] = {
 	 check_snmp_virtualserver, 3, {3, 1, 60}},
 	{CHECK_SNMP_VSSMTPALERT, ASN_INTEGER, RONLY,
 	 check_snmp_virtualserver, 3, {3, 1, 61}},
+	{CHECK_SNMP_VSMHFALLBACK, ASN_INTEGER, RONLY,
+	 check_snmp_virtualserver, 3, {3, 1, 62}},
+	{CHECK_SNMP_VSMHPORT, ASN_INTEGER, RONLY,
+	 check_snmp_virtualserver, 3, {3, 1, 63}},
 
 	/* realServerTable */
 	{CHECK_SNMP_RSTYPE, ASN_INTEGER, RONLY,

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -228,6 +228,13 @@ typedef struct _check_data {
 			 !(X)->virtualhost	      == !(Y)->virtualhost		&& \
 			 (!(X)->virtualhost || !strcmp((X)->virtualhost, (Y)->virtualhost)))
 
+#ifndef IP_VS_SVC_F_SCHED_MH_PORT
+#define IP_VS_SVC_F_SCHED_MH_PORT IP_VS_SVC_F_SCHED_SH_PORT
+#endif
+#ifndef IP_VS_SVC_F_SCHED_MH_FALLBACK
+#define IP_VS_SVC_F_SCHED_MH_FALLBACK IP_VS_SVC_F_SCHED_SH_FALLBACK
+#endif
+
 /* Global vars exported */
 extern check_data_t *check_data;
 extern check_data_t *old_check_data;


### PR DESCRIPTION
This is similar to the sh scheduler. Options are the same but we
duplicate everything. An alternative would have been to reuse the
names for the sh scheduler.

The mh scheduler is supported starting from Linux 4.18. It's a
consistent hash scheduler.