### PR TITLE
Update libnl_link.c

### DIFF
--- a/keepalived/core/libnl_link.c
+++ b/keepalived/core/libnl_link.c
@@ -182,13 +182,13 @@ libnl_init(void)
 	    !(rtnl_link_inet_set_conf_addr = dlsym(libnl_route_handle, "rtnl_link_inet_set_conf")) ||
 	    !(rtnl_link_put_addr = dlsym(libnl_route_handle, "rtnl_link_put")) ||
 #endif
-	    !(nl_connect_addr = dlsym(libnl_route_handle, "nl_connect")) ||
-	    !(nl_socket_add_membership_addr = dlsym(libnl_route_handle, "nl_socket_add_membership")) ||
-	    !(nl_socket_drop_membership_addr = dlsym(libnl_route_handle, "nl_socket_drop_membership")) ||
-	    !(nl_socket_get_fd_addr = dlsym(libnl_route_handle, "nl_socket_get_fd")) ||
-	    !(nl_socket_get_local_port_addr = dlsym(libnl_route_handle, "nl_socket_get_local_port")) ||
-	    !(nl_socket_set_buffer_size_addr = dlsym(libnl_route_handle, "nl_socket_set_buffer_size")) ||
-	    !(nl_socket_set_nonblocking_addr = dlsym(libnl_route_handle, "nl_socket_set_nonblocking")) ||
+	    !(nl_connect_addr = dlsym(libnl_handle, "nl_connect")) ||
+	    !(nl_socket_add_membership_addr = dlsym(libnl_handle, "nl_socket_add_membership")) ||
+	    !(nl_socket_drop_membership_addr = dlsym(libnl_handle, "nl_socket_drop_membership")) ||
+	    !(nl_socket_get_fd_addr = dlsym(libnl_handle, "nl_socket_get_fd")) ||
+	    !(nl_socket_get_local_port_addr = dlsym(libnl_handle, "nl_socket_get_local_port")) ||
+	    !(nl_socket_set_buffer_size_addr = dlsym(libnl_handle, "nl_socket_set_buffer_size")) ||
+	    !(nl_socket_set_nonblocking_addr = dlsym(libnl_handle, "nl_socket_set_nonblocking")) ||
 #endif
 	    false) {
 		log_message(LOG_INFO, "Failed to dynamic link a libnli/libnl-3 function");


### PR DESCRIPTION
Hi, 

I think i discover a SegFault when launch with dynamic LIBNL because of loading symbol from wrong library, (if i made a mistake on my analyse please forgive me)

--- /var/log/messages ----

Thu Aug 16 16:33:23 2018: Starting VRRP child process, pid=32349
Thu Aug 16 16:33:23 2018: **Failed to dynamic link a libnli/libnl-3 function**
Thu Aug 16 16:33:23 2018: **Keepalived_vrrp exited due to segmentation fault (SIGSEGV).**
Thu Aug 16 16:33:23 2018:   Please report a bug at https://github.com/acassen/keepalived/issues
Thu Aug 16 16:33:23 2018:   and include this log from when keepalived started, a description
Thu Aug 16 16:33:23 2018:   of what happened before the crash, your configuration file and the details below.
Thu Aug 16 16:33:23 2018:   Also provide the output of keepalived -v, what Linux distro and version
Thu Aug 16 16:33:23 2018:   you are running on, and whether keepalived is being run in a container or VM.
Thu Aug 16 16:33:23 2018:   A failure to provide all this information may mean the crash cannot be investigated.
Thu Aug 16 16:33:23 2018:   If you are able to provide a stack backtrace with gdb that would really help.
Thu Aug 16 16:33:23 2018:   Source version 2.0.6
Thu Aug 16 16:33:23 2018:   Built with kernel headers for Linux 3.10.0
Thu Aug 16 16:33:23 2018:   Running on Linux 3.10.0-229.11.1.el7.x86_64 #1 SMP Wed Jul 22 12:06:11 EDT 2015
Thu Aug 16 16:33:23 2018:   configure options: --prefix=/lpath/to/keepalived-2.0.6
Thu Aug 16 16:33:23 2018:                       --mandir=/lpath/to/keepalived-2.0.6/man
Thu Aug 16 16:33:23 2018:                       --docdir=/lpath/to/keepalived-2.0.6/doc
Thu Aug 16 16:33:23 2018:                       --with-kernel-dir=/lib/modules/3.10.0-229.11.1.el7.x86_64/build
Thu Aug 16 16:33:23 2018:                       --enable-libnl-dynamic CFLAGS=-I/path/to//libnl/include
Thu Aug 16 16:33:23 2018:                       -I/path/to/krb5/include
Thu Aug 16 16:33:23 2018:                       LDFLAGS=-L//path/to/libnl/lib
Thu Aug 16 16:33:23 2018:                       -Wl,-rpath,/path/to//libnl/lib
Thu Aug 16 16:33:23 2018:                       -L/path/to//krb5/lib
Thu Aug 16 16:33:23 2018:                       -Wl,-rpath,/path/to/krb5/lib
Thu Aug 16 16:33:23 2018:                       CPPFLAGS=-I/lpath/to/libnl/include
Thu Aug 16 16:33:23 2018:                       -I/lpath/to//krb5/include
Thu Aug 16 16:33:23 2018:                       PKG_CONFIG_PATH=/path/to/libnl/lib/pkgconfig:/path/to/haproxy/1
Thu Aug 16 16:33:23 2018:                       /path/to/krb5/lib/pkgconfig
Thu Aug 16 16:33:23 2018:   Config options:  LVS VRRP VRRP_AUTH OLD_CHKSUM_COMPAT FIB_ROUTING
Thu Aug 16 16:33:23 2018:   System options:  PIPE2 SIGNALFD INOTIFY_INIT1 VSYSLOG LIBNL3 LIBNL_DYNAMIC RTAX_CC_ALGO RTAX_QUICKACK
Thu Aug 16 16:33:23 2018:                    FRA_OIFNAME IFA_FLAGS IP_MULTICAST_ALL NET_LINUX_IF_H_COLLISION
Thu Aug 16 16:33:23 2018:                    LIBIPTC_LINUX_NET_IF_H_COLLISION LIBIPVS_NETLINK VRRP_VMAC SOCK_NONBLOCK SOCK_CLOEXEC
Thu Aug 16 16:33:23 2018:                    O_PATH GLOB_BRACE INET6_ADDR_GEN_MODE SO_MARK SCHED_RT SCHED_RESET_ON_FORK
Thu Aug 16 16:33:23 2018: VRRP child process(32349) died: Respawning


--- GDB Analyse ---

[root@localhost tmp]#  gdb  /path/to/keepalived/sbin/keepalived /tmp/core.9029
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-94.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /path/to/keepalived-2.0.6/sbin/keepalived...done.

warning: exec file is newer than core file.
[New LWP 9029]

warning: .dynamic section for "/path/to/libnl/lib/libnl-genl-3.so" is not at the expected address (wrong library or version mismatch?)
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `/path/to/keepalived/sbin/keepalived -f /path/to/keepalived.conf'.
Program terminated with signal 11, Segmentation fault.
#0  0x0000000000000000 in ?? ()
Missing separate debuginfos, use: debuginfo-install <package rpm>
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  **0x00007fe9b1c58a24 in netlink_socket (nl=nl@entry=0x7fe9b1eae400 <nl_kernel>, rcvbuf_size=0, force=<optimized out>,
    flags=flags@entry=2048, group=group@entry=1) at keepalived_netlink.c:564**
#2  0x00007fe9b1c5b04d in kernel_netlink_init () at keepalived_netlink.c:2199
#3  0x00007fe9b1c6aba4 in start_vrrp () at vrrp_daemon.c:306
#4  0x00007fe9b1c6b269 in start_vrrp_child () at vrrp_daemon.c:815
#5  0x00007fe9b1c6b380 in vrrp_respawn_thread (thread=<optimized out>) at vrrp_daemon.c:698
#6  0x00007fe9b1c8ca43 in thread_call (thread=0x7fe9b2706e70) at scheduler.c:1281
#7  process_threads (m=0x7fe9b2705140) at scheduler.c:1162
#8  0x00007fe9b1c8caec in launch_scheduler () at scheduler.c:1290
#9  0x00007fe9b1c53ffb in keepalived_main (argc=<optimized out>, argv=<optimized out>) at main.c:1514
#10 0x00007fe9b0e2fb35 in __libc_start_main () from /lib64/libc.so.6
#11 0x00007fe9b1c52221 in _start ()
(gdb)

I look in keepalived_netlink.c
-- In file  keepalived_netlink.c -- 
 564                 ret = nl_connect(nl->sk, NETLINK_ROUTE);

Ok so SegFault happend when calling nl_connect function. 

-- I notice in file keepalived/core/libnl_link.c --

119 #else
120         if (!(l**ibnl_handle = dlopen("libnl-3.so", RTLD_NOW))** &&
121             !(libnl_handle = dlopen(NL3_LIB_NAME, RTLD_NOW))) {
122                 log_message(LOG_INFO, "Unable to load nl-3 library - %s", dlerror());
123                 return false;
124         }       
...
132 #if defined _WITH_VRRP_ && defined _HAVE_IPV4_DEVCONF_
133         if (!(**libnl_route_handle = dlopen("libnl-route-3.so", RTLD_NOW))** &&
134             !(libnl_route_handle = dlopen(NL3_ROUTE_LIB_NAME, RTLD_NOW))) {
135                 log_message(LOG_INFO, "Unable to load nl-route-3 library - %s", dlerror());
136                 return false;
137         }       
138 #endif 
...
185             !(nl_connect_addr = dlsym(libnl_route_handle, "nl_connect")) ||
186             !(nl_socket_add_membership_addr = dlsym(libnl_route_handle, "nl_socket_add_membership")) ||
187             !(nl_socket_drop_membership_addr = dlsym(libnl_route_handle, "nl_socket_drop_membership")) ||
188             !(nl_socket_get_fd_addr = dlsym(libnl_route_handle, "nl_socket_get_fd")) ||
189             !(nl_socket_get_local_port_addr = dlsym(libnl_route_handle, "nl_socket_get_local_port")) ||
190             !(nl_socket_set_buffer_size_addr = dlsym(libnl_route_handle, "nl_socket_set_buffer_size")) ||
191             !(nl_socket_set_nonblocking_addr = dlsym(libnl_handle, "nl_socket_set_nonblocking")) ||
...


So i check symbol on library with this command :

objdump -T /usr/lib64/libnl-route-3.so.200.23.0 | grep -i " nl_connect" 
and all other symbol from quote sample and no one match so i try to match symbol on the other library /usr/lib64/libnl-3.so.200.23.0 and it worked so i juste change the handle from libnl_route_handle to libnl_handle.

Just to be sur my libnl was good i download libnl 3.4.0 and do the same exercice on matching  symbol and nl_connect and other only match with libnl-3.so.

I beleive in typo on you code an so if that could help other to fix this SegFault, i gonna be happy :-)


