### PR TITLE
Fix variable name in keepalived.spec.in file

### DIFF
--- a/keepalived.spec.in
+++ b/keepalived.spec.in
@@ -27,8 +27,8 @@ BuildRequires: libnfnetlink-devel
 @INIT_SYSV_TRUE@Requires(postun): /sbin/service
 BuildRequires: autoconf automake pkgconfig
 @INIT_SYSTEMD_TRUE@BuildRequires: systemd-units
-@WITH_REGEX@BuildRequires: pcre2-devel
-@WITH_REGEX@Requires: pcre2
+@WITH_REGEX_TRUE@BuildRequires: pcre2-devel
+@WITH_REGEX_TRUE@Requires: pcre2
 
 %description
 The main goal of the keepalived project is to add a strong & robust keepalive
@@ -63,7 +63,7 @@ CONFIG_OPTS=
 @WITH_SHA1_TRUE@CONFIG_OPTS="$CONFIG_OPTS --enable-sha1"
 @WITH_DBUS_TRUE@CONFIG_OPTS="$CONFIG_OPTS --enable-dbus"
 @INIT_SYSTEMD_TRUE@CONFIG_OPTS="$CONFIG_OPTS --with-init=systemd"
-@WITH_REGEX@CONFIG_OPTS="$CONFIG_OPTS --enable-regex"
+@WITH_REGEX_TRUE@CONFIG_OPTS="$CONFIG_OPTS --enable-regex"
 %{?el3:export CPPFLAGS="-I/usr/kerberos/include"}
 %{?rh9:export CPPFLAGS="-I/usr/kerberos/include"}
 autoreconf -f -i


### PR DESCRIPTION
I tried to build RPM package for keepalived v2.0.7, but I got this error.

```
$ rpmbuild -ba keepalived.spec
error: line 31: Unknown tag: @WITH_REGEX@BuildRequires: pcre2-devel
```

I think `@WITH_REGEX@` in `keepalived.spec.in` is mistake. 
This should be `@WITH_REGEX_TRUE@`, shouldn't it?
I modified, then it works.