### PR TITLE
Merge the next-generation scheduler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ env:
     - KEEPALIVED_CONFIG_ARGS="--enable-conversion-checks --enable-stacktrace --enable-mem-check --enable-mem-check-log --disable-lvs-64bit-stats --enable-snmp-rfcv2"
     - KEEPALIVED_CONFIG_ARGS="--disable-lvs --enable-snmp-vrrp --enable-snmp-rfc --enable-json --enable-sha1 --enable-dbus --disable-routes --enable-bfd"
     - KEEPALIVED_CONFIG_ARGS="--disable-vrrp --enable-snmp-checker --enable-json --enable-sha1 --enable-dbus"
-    - KEEPALIVED_CONFIG_ARGS="--disable-hardening --enable-dump-threads --enable-select-debug --enable-timer-debug --enable-snmp-rfcv3"
+    - KEEPALIVED_CONFIG_ARGS="--disable-hardening --enable-dump-threads --enable-epoll-debug --enable-snmp-rfcv3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   matrix:
     - KEEPALIVED_CONFIG_ARGS=""
     - KEEPALIVED_CONFIG_ARGS="--enable-snmp --enable-snmp-rfc --enable-json --enable-dbus --disable-checksum-compat --enable-bfd"
-    - KEEPALIVED_CONFIG_ARGS="--enable-sha1 --enable-dbus --enable-dbus-create-instance --disable-dynamic-linking --disable-fwmark --disable-lvs-syncd --enable-snmp-vrrp"
+    - KEEPALIVED_CONFIG_ARGS="--enable-sha1 --enable-dbus --enable-dbus-create-instance --disable-dynamic-linking --disable-fwmark --disable-lvs-syncd --enable-snmp-vrrp --enable-timer-check"
     - KEEPALIVED_CONFIG_ARGS="--enable-dynamic-linking --disable-vrrp-auth --enable-snmp-rfc --disable-snmp-reply-v3-for-v2"
     - KEEPALIVED_CONFIG_ARGS="--disable-libiptc --disable-libipset --disable-libnl --enable-snmp-checker"
     - KEEPALIVED_CONFIG_ARGS="--enable-conversion-checks --enable-stacktrace --enable-mem-check --enable-mem-check-log --disable-lvs-64bit-stats --enable-snmp-rfcv2"

--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,8 @@ AC_ARG_ENABLE(mem-check,
   [AS_HELP_STRING([--enable-mem-check], [compile with memory alloc checking])])
 AC_ARG_ENABLE(mem-check-log,
   [AS_HELP_STRING([--enable-mem-check-log], [compile with memory alloc checking writing to syslog])])
+AC_ARG_ENABLE(timer-check,
+  [AS_HELP_STRING([--enable-timer-check], [compile with set time logging])])
 AC_ARG_ENABLE(debug,
   [AS_HELP_STRING([--enable-debug], [compile with debugging flags])])
 AC_ARG_ENABLE(netlink-timers,
@@ -1702,6 +1704,14 @@ if test "${enable_mem_check}" = "yes"; then
   fi
 fi
 
+dnl ----[ Memory alloc check or not ? ]----
+TIMER_CHECK=No
+if test "${enable_timer_check}" = "yes"; then
+  TIMER_CHECK=Yes
+  AC_DEFINE([_TIMER_CHECK_], [ 1 ], [Define to 1 to build with set time logging])
+  add_config_opt([TIMER_CHECK])
+fi
+
 dnl ----[ Debug or not ? ]----
 if test "${enable_debug}" = yes; then
   AC_DEFINE([_DEBUG_], [ 1 ], [Define to 1 to build with debugging support])
@@ -1934,6 +1944,9 @@ fi
 if test ${MEM_CHECK} = Yes; then
   echo "Memory alloc check       : ${MEM_CHECK}"
   echo "Memory alloc check log   : ${MEM_CHECK_LOG}"
+fi
+if test ${TIMER_CHECK} = Yes; then
+  echo "Set time logging         : ${TIMER_CHECK}"
 fi
 if test ${ENABLE_DUMP_THREADS} = Yes; then
   echo "Thread debugging         : ${ENABLE_DUMP_THREADS}"

--- a/configure.ac
+++ b/configure.ac
@@ -1778,6 +1778,10 @@ else
   ENABLE_EPOLL_DEBUG=No
 fi
 
+if test $ENABLE_EPOLL_DEBUG = Yes -o $ENABLE_DUMP_THREADS = Yes; then
+  AC_DEFINE([THREAD_DUMP], [ 1 ], [Define to 1 to build with thread dumping support])
+fi
+
 dnl ----[ regex debugging support or not ? ]----
 if test "${enable_regex_debug}" = yes; then
   AC_DEFINE([_REGEX_DEBUG_], [ 1 ], [Define to 1 to build with regex debugging support])

--- a/configure.ac
+++ b/configure.ac
@@ -227,8 +227,6 @@ AC_ARG_ENABLE(regex-debug,
   [  --enable-regex-debug    compile with regex debugging support])
 AC_ARG_ENABLE(tsm-debug,
   [  --enable-tsm-debug      compile with TSM debugging support])
-AC_ARG_ENABLE(timer-debug,
-  [  --enable-timer-debug    compile with timer debugging support])
 AC_ARG_ENABLE(profile,
   [AS_HELP_STRING([--enable-profile], [compile with profiling flags])])
 AC_ARG_ENABLE(conversion-checks,
@@ -1759,7 +1757,7 @@ else
   ENABLE_DUMP_THREADS=No
 fi
 
-dnl ----[ select() debugging support or not ? ]----
+dnl ----[ epoll() debugging support or not ? ]----
 if test "${enable_epoll_debug}" = yes; then
   AC_DEFINE([_EPOLL_DEBUG_], [ 1 ], [Define to 1 to build with epoll_wait() debugging support])
   ENABLE_EPOLL_DEBUG=Yes
@@ -1784,15 +1782,6 @@ if test "${enable_tsm_debug}" = yes; then
   add_config_opt([TSM_DEBUG])
 else
   ENABLE_TSM_DEBUG=No
-fi
-
-dnl ----[ Timer debugging support or not ? ]----
-if test "${enable_timer_debug}" = yes; then
-  AC_DEFINE([_TIMER_DEBUG_], [ 1 ], [Define to 1 to build with timer debugging support])
-  ENABLE_TIMER_DEBUG=Yes
-  add_config_opt([TIMER_DEBUG])
-else
-  ENABLE_TIMER_DEBUG=No
 fi
 
 dnl ----[ Profiling or not ? ]----
@@ -1959,9 +1948,6 @@ if test ${ENABLE_REGEX_DEBUG} = Yes; then
 fi
 if test ${ENABLE_TSM_DEBUG} = Yes; then
   echo "TSM debugging            : ${ENABLE_TSM_DEBUG}"
-fi
-if test ${ENABLE_TIMER_DEBUG} = Yes; then
-  echo "Timer debugging          : ${ENABLE_TIMER_DEBUG}"
 fi
 if test ${ENABLE_DEBUG} = Yes; then
   echo "Use Debug flags          : ${ENABLE_DEBUG}"

--- a/configure.ac
+++ b/configure.ac
@@ -219,6 +219,8 @@ AC_ARG_ENABLE(smtp-alert-debug,
   [AS_HELP_STRING([--enable-smtp-alert-debug], [compile with smtp-alert debugging])])
 AC_ARG_ENABLE(stacktrace,
   [AS_HELP_STRING([--enable-stacktrace], [compile with stacktrace support])])
+AC_ARG_ENABLE(perf,
+  [AS_HELP_STRING([--enable-perf], [compile with perf performance data recording support for vrrp process])])
 AC_ARG_ENABLE(dump-threads,
   [  --enable-dump-threads   compile with thread dumping support])
 AC_ARG_ENABLE(epoll-debug,
@@ -1748,6 +1750,16 @@ else
   ENABLE_STACKTRACE=No
 fi
 
+dnl ----[ perf support or not ? ]----
+if test "${enable_perf}" = yes; then
+  AC_DEFINE([_WITH_PERF_], [ 1 ], [Define to 1 to build with perf support])
+  ENABLE_PERF=Yes
+  add_config_opt([PERF])
+  add_to_var([KA_CFLAGS], [-pg])
+else
+  ENABLE_PERF=No
+fi
+
 dnl ----[ Thread dumping support or not ? ]----
 if test "${enable_dump_threads}" = yes; then
   AC_DEFINE([_WITH_DUMP_THREADS_], [ 1 ], [Define to 1 to build with thread dumping support])
@@ -1929,6 +1941,9 @@ echo "Build genhash            : ${BUILD_GENHASH}"
 echo "Build documentation      : ${HAVE_SPHINX_BUILD}"
 if test ${ENABLE_STACKTRACE} = Yes; then
   echo "Stacktrace support       : ${ENABLE_STACKTRACE}"
+fi
+if test ${ENABLE_PERF} = Yes; then
+  echo "Perf support             : ${ENABLE_PERF}"
 fi
 if test ${MEM_CHECK} = Yes; then
   echo "Memory alloc check       : ${MEM_CHECK}"

--- a/configure.ac
+++ b/configure.ac
@@ -219,8 +219,8 @@ AC_ARG_ENABLE(stacktrace,
   [AS_HELP_STRING([--enable-stacktrace], [compile with stacktrace support])])
 AC_ARG_ENABLE(dump-threads,
   [  --enable-dump-threads   compile with thread dumping support])
-AC_ARG_ENABLE(select-debug,
-  [  --enable-select-debug   compile with select debugging support])
+AC_ARG_ENABLE(epoll-debug,
+  [  --enable-epoll-debug    compile with epoll_wait() debugging support])
 AC_ARG_ENABLE(regex-debug,
   [  --enable-regex-debug    compile with regex debugging support])
 AC_ARG_ENABLE(tsm-debug,
@@ -535,6 +535,8 @@ dnl - inotify_init1() since Linux 2.6.27
 AC_CHECK_FUNCS([inotify_init1], [add_system_opt([INOTIFY_INIT1])])
 dnl - vsyslog() Not defined by Posix, but available in glibc and musl
 AC_CHECK_FUNCS([vsyslog], [add_system_opt([VSYSLOG])])
+dnl - epoll_create1() since Linux  2.6.27 and glibc 2.9
+AC_CHECK_FUNCS([epoll_create1], [add_system_opt([EPOLL_CREATE1])])
 
 # glibc uses unsigned int as 3rd parameter to __assert_fail(), musl uses int.
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
@@ -1748,12 +1750,12 @@ else
 fi
 
 dnl ----[ select() debugging support or not ? ]----
-if test "${enable_select_debug}" = yes; then
-  AC_DEFINE([_SELECT_DEBUG_], [ 1 ], [Define to 1 to build with select debugging support])
-  ENABLE_SELECT_DEBUG=Yes
-  add_config_opt([SELECT_DEBUG])
+if test "${enable_epoll_debug}" = yes; then
+  AC_DEFINE([_EPOLL_DEBUG_], [ 1 ], [Define to 1 to build with epoll_wait() debugging support])
+  ENABLE_EPOLL_DEBUG=Yes
+  add_config_opt([EPOLL_DEBUG])
 else
-  ENABLE_SELECT_DEBUG=No
+  ENABLE_EPOLL_DEBUG=No
 fi
 
 dnl ----[ regex debugging support or not ? ]----
@@ -1936,8 +1938,8 @@ fi
 if test ${ENABLE_DUMP_THREADS} = Yes; then
   echo "Thread debugging         : ${ENABLE_DUMP_THREADS}"
 fi
-if test ${ENABLE_SELECT_DEBUG} = Yes; then
-  echo "Select() debugging       : ${ENABLE_SELECT_DEBUG}"
+if test ${ENABLE_EPOLL_DEBUG} = Yes; then
+  echo "epoll_wait() debugging   : ${ENABLE_EPOLL_DEBUG}"
 fi
 if test ${ENABLE_REGEX_DEBUG} = Yes; then
   echo "regex debugging          : ${ENABLE_REGEX_DEBUG}"

--- a/doc/man/man8/keepalived.8
+++ b/doc/man/man8/keepalived.8
@@ -38,6 +38,7 @@ keepalived \- load\-balancing and high\-availability service
 [\fB\-M\fP|\fB\-\-core\-dump\-pattern\fP[=PATTERN]]
 [\fB\-\-signum\fP=SIGFUNC]
 [\fB\-t\fP|\fB\-\-config\-test\fP[=FILE]]
+[\fB\-\-perf\fP[={all|run|end}]]
 [\fB\-v\fP|\fB\-\-version\fP]
 [\fB\-h\fP|\fB\-\-help\fP]
 
@@ -188,6 +189,10 @@ exit status 0 (see \fBExit status\fP below for details).
 
 Rather that writing to syslog, it will write diagnostic messages to stderr
 unless file is specified, in which case it will write to the file.
+.TP
+\fB --perf\fP[={all|run|end}]
+Record perf data for vrrp process. Data will be written to /perf_vrrp.data.
+The data recorded is for use with the perf tool.
 .TP
 \fB -v, --version\fP
 Display the version and exit.

--- a/genhash/http.c
+++ b/genhash/http.c
@@ -129,7 +129,7 @@ finalize(thread_t * thread)
 	if (req->verbose) {
 		printf("\n");
 		printf(HTML_HASH);
-		dump_buffer((char *) digest, digest_length, stdout);
+		dump_buffer((char *) digest, digest_length, stdout, 0);
 
 		printf(HTML_HASH_FINAL);
 	}
@@ -149,7 +149,7 @@ finalize(thread_t * thread)
 static void
 http_dump_header(char *buffer, size_t size)
 {
-	dump_buffer(buffer, size, stdout);
+	dump_buffer(buffer, size, stdout, 0);
 	printf(HTTP_HEADER_ASCII);
 	printf("%*s\n", (int)size, buffer);
 }
@@ -204,7 +204,7 @@ http_process_stream(SOCK * sock_obj, int r)
 			if (r) {
 				if (req->verbose) {
 					printf(HTML_HEADER_HEXA);
-					dump_buffer(sock_obj->extracted, (size_t)r, stdout);
+					dump_buffer(sock_obj->extracted, (size_t)r, stdout, 0);
 				}
 				memmove(sock_obj->buffer, sock_obj->extracted, (size_t)r);
 				HASH_UPDATE(sock_obj, sock_obj->buffer, (ssize_t)r);
@@ -226,7 +226,7 @@ http_process_stream(SOCK * sock_obj, int r)
 		}
 	} else if (sock_obj->size) {
 		if (req->verbose)
-			dump_buffer(sock_obj->buffer, (size_t)r, stdout);
+			dump_buffer(sock_obj->buffer, (size_t)r, stdout, 0);
 		HASH_UPDATE(sock_obj, sock_obj->buffer, (ssize_t)sock_obj->size);
 		sock_obj->rx_bytes += sock_obj->size;
 		sock_obj->size = 0;

--- a/genhash/http.c
+++ b/genhash/http.c
@@ -101,7 +101,7 @@ free_all(thread_t * thread)
 	 * Decrement the current global get number.
 	 * => free the reserved thread
 	 */
-	req->response_time = timer_tol(timer_now());
+	req->response_time = timer_long(timer_now());
 	thread_add_terminate_event(thread->master);
 }
 

--- a/genhash/layer4.c
+++ b/genhash/layer4.c
@@ -203,6 +203,7 @@ tcp_check_thread(thread_t * thread)
 				sock_obj->lock = 0;
 				thread_add_event(thread->master,
 						 http_request_thread, sock_obj, 0);
+				thread_del_write(thread);
 			} else {
 				DBG("Connection trouble to: [%s]:%d.\n",
 				    req->ipaddress,

--- a/genhash/layer4.c
+++ b/genhash/layer4.c
@@ -107,7 +107,7 @@ tcp_socket_state(thread_t * thread, int (*func) (thread_t *))
 	if (thread->type == THREAD_WRITE_TIMEOUT) {
 		DBG("TCP connection timeout to [%s]:%d.\n",
 		    req->ipaddress, ntohs(req->addr_port));
-		close(thread->u.fd);
+		thread_close_fd(thread);
 		return connect_timeout;
 	}
 
@@ -121,7 +121,7 @@ tcp_socket_state(thread_t * thread, int (*func) (thread_t *))
 	if (ret) {
 		DBG("TCP connection failed to [%s]:%d.\n",
 		    req->ipaddress, ntohs(req->addr_port));
-		close(thread->u.fd);
+		thread_close_fd(thread);
 		return connect_error;
 	}
 

--- a/genhash/main.c
+++ b/genhash/main.c
@@ -259,7 +259,7 @@ main(int argc, char **argv)
 		req->url = url_default;
 
 	/* Init the reference timer */
-	req->ref_time = timer_tol(timer_now());
+	req->ref_time = timer_long(timer_now());
 	DBG("Reference timer = %lu\n", req->ref_time);
 
 	/* Init SSL context */

--- a/genhash/main.c
+++ b/genhash/main.c
@@ -53,7 +53,6 @@ sigend(__attribute__((unused)) void *v, __attribute__((unused)) int sig)
 static void
 signal_init(void)
 {
-	signal_handler_init();
 	signal_set(SIGHUP, sigend, NULL);
 	signal_set(SIGINT, sigend, NULL);
 	signal_set(SIGTERM, sigend, NULL);
@@ -266,13 +265,11 @@ main(int argc, char **argv)
 	/* Init SSL context */
 	init_ssl();
 
-	/* Signal handling initialization  */
-	signal_init();
-
 	/* Create the master thread */
 	master = thread_make_master();
 
-	add_signal_read_thread();
+	/* Signal handling initialization  */
+	signal_init();
 
 	/* Register the GET request */
 	init_sock();
@@ -281,9 +278,9 @@ main(int argc, char **argv)
 	 * Processing the master thread queues,
 	 * return and execute one ready thread.
 	 * Run until error, used for debuging only.
-	 * Note that not calling launch_scheduler() does
-	 * not activate SIGCHLD handling, however, this
-	 * is no issue here.
+	 * Note that not calling launch_thread_scheduler()
+	 * does not activate SIGCHLD handling, however,
+	 * this is no issue here.
 	 */
 	process_threads(master);
 

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -277,7 +277,7 @@ bfd_respawn_thread(thread_t * thread)
 }
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 static void
 register_bfd_thread_addresses(void)
 {
@@ -408,14 +408,14 @@ start_bfd_child(void)
 	return 0;
 #else
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	register_bfd_thread_addresses();
 #endif
 
 	/* Launch the scheduling I/O multiplexer */
 	launch_thread_scheduler(master);
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	deregister_thread_addresses();
 #endif
 
@@ -427,7 +427,7 @@ start_bfd_child(void)
 #endif
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_bfd_parent_addresses(void)
 {

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -241,7 +241,7 @@ reload_bfd_thread(__attribute__((unused)) thread_t * thread)
 	UNSET_RELOAD;
 
 	set_time_now();
-	log_message(LOG_INFO, "Reload finished in %li usec", -timer_tol(timer_sub_now(timer)));
+	log_message(LOG_INFO, "Reload finished in %li usec", -timer_long(timer_sub_now(timer)));
 
 	return 0;
 }

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -277,6 +277,24 @@ bfd_respawn_thread(thread_t * thread)
 }
 #endif
 
+#ifdef _EPOLL_DEBUG_
+static void
+register_bfd_thread_addresses(void)
+{
+	register_scheduler_addresses();
+	register_signal_thread_addresses();
+
+	register_bfd_scheduler_addresses();
+
+	register_thread_address("bfd_dispatcher_init", bfd_dispatcher_init);
+	register_thread_address("reload_bfd_thread", reload_bfd_thread);
+
+	register_signal_handler_address("sigreload_bfd", sigreload_bfd);
+	register_signal_handler_address("sigend_bfd", sigend_bfd);
+	register_signal_handler_address("thread_child_handler", thread_child_handler);
+}
+#endif
+
 int
 start_bfd_child(void)
 {
@@ -390,8 +408,16 @@ start_bfd_child(void)
 	return 0;
 #else
 
+#ifdef _EPOLL_DEBUG_
+	register_bfd_thread_addresses();
+#endif
+
 	/* Launch the scheduling I/O multiplexer */
 	launch_thread_scheduler(master);
+
+#ifdef _EPOLL_DEBUG_
+	deregister_thread_addresses();
+#endif
 
 	/* Finish BFD daemon process */
 	stop_bfd(EXIT_SUCCESS);
@@ -400,3 +426,11 @@ start_bfd_child(void)
 	exit(EXIT_SUCCESS);
 #endif
 }
+
+#ifdef _EPOLL_DEBUG_
+void
+register_bfd_parent_addresses(void)
+{
+	register_thread_address("bfd_respawn_thread", bfd_respawn_thread);
+}
+#endif

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -68,8 +68,6 @@ stop_bfd(int status)
 	if (__test_bit(CONFIG_TEST_BIT, &debug))
 		return;
 
-	signal_handler_destroy();
-
 	/* Stop daemon */
 	pidfile_rm(bfd_pidfile);
 
@@ -202,7 +200,6 @@ sigend_bfd(__attribute__ ((unused)) void *v,
 static void
 bfd_signal_init(void)
 {
-	signal_handler_child_init();
 	signal_set(SIGHUP, sigreload_bfd, NULL);
 	signal_set(SIGINT, sigend_bfd, NULL);
 	signal_set(SIGTERM, sigend_bfd, NULL);
@@ -223,9 +220,6 @@ reload_bfd_thread(__attribute__((unused)) thread_t * thread)
 
 	/* set the reloading flag */
 	SET_RELOAD;
-
-	/* Signal handling */
-//	signal_handler_destroy();
 
 	/* Destroy master thread */
 	bfd_dispatcher_release(bfd_data);
@@ -351,8 +345,6 @@ start_bfd_child(void)
 #endif
 				global_data->instance_name);
 
-	signal_handler_destroy();
-
 #ifdef _MEM_CHECK_
 	mem_log_init(PROG_BFD, "BFD child process");
 #endif
@@ -399,7 +391,7 @@ start_bfd_child(void)
 #else
 
 	/* Launch the scheduling I/O multiplexer */
-	launch_scheduler();
+	launch_thread_scheduler(master);
 
 	/* Finish BFD daemon process */
 	stop_bfd(EXIT_SUCCESS);

--- a/keepalived/bfd/bfd_scheduler.c
+++ b/keepalived/bfd/bfd_scheduler.c
@@ -63,7 +63,7 @@ thread_time_to_wakeup(thread_t *thread)
 
 	timersub(&thread->sands, &time_now, &tmp_time);
 
-	return timer_tol(tmp_time);
+	return timer_long(tmp_time);
 }
 
 /* Sends one BFD control packet and reschedules itself if needed */
@@ -230,7 +230,7 @@ bfd_expire_thread(thread_t *thread)
 
 	/* Time since last received control packet */
 	timersub(&time_now, &bfd->last_seen, &dead_time_tv);
-	dead_time = timer_tol(dead_time_tv);
+	dead_time = timer_long(dead_time_tv);
 
 	/* Difference between expected and actual failure detection time */
 	overdue_time = dead_time - bfd->local_detect_time;

--- a/keepalived/bfd/bfd_scheduler.c
+++ b/keepalived/bfd/bfd_scheduler.c
@@ -1136,7 +1136,7 @@ bfd_dispatcher_init(thread_t *thread)
 }
 
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_bfd_scheduler_addresses(void)
 {

--- a/keepalived/bfd/bfd_scheduler.c
+++ b/keepalived/bfd/bfd_scheduler.c
@@ -1065,8 +1065,6 @@ bfd_register_workers(bfd_data_t *data)
 		if (!reload && !bfd->passive)
 			thread_add_event(master, bfd_sender_thread, bfd, 0);
 	}
-
-	add_signal_read_thread();
 }
 
 /* Suspends threads, closes sockets */

--- a/keepalived/bfd/bfd_scheduler.c
+++ b/keepalived/bfd/bfd_scheduler.c
@@ -1131,3 +1131,16 @@ bfd_dispatcher_init(thread_t *thread)
 
 	return 0;
 }
+
+
+#ifdef _EPOLL_DEBUG_
+void
+register_bfd_scheduler_addresses(void)
+{
+	register_thread_address("bfd_sender_thread", bfd_sender_thread);
+	register_thread_address("bfd_expire_thread", bfd_expire_thread);
+	register_thread_address("bfd_reset_thread", bfd_reset_thread);
+	register_thread_address("bfd_receiver_thread", bfd_receiver_thread);
+	register_thread_address("bfd_sender_thread", bfd_sender_thread);
+}
+#endif

--- a/keepalived/check/check_bfd.c
+++ b/keepalived/check/check_bfd.c
@@ -39,6 +39,9 @@
 #include "bfd_event.h"
 #include "bfd_daemon.h"
 #include "bitops.h"
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 /* local data */
 static thread_t *bfd_thread;
@@ -308,11 +311,10 @@ checker_bfd_dispatcher_release(void)
 	thread_cancel(bfd_thread);
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_check_bfd_addresses(void)
+register_check_bfd_addresses(void)
 {
-	log_message(LOG_INFO, "Address of dump_bfd_check() is 0x%p", dump_bfd_check);
-	log_message(LOG_INFO, "Address of bfd_check_thread() is 0x%p", bfd_check_thread);
+	register_thread_address("bfd_check_thread", bfd_check_thread);
 }
 #endif

--- a/keepalived/check/check_bfd.c
+++ b/keepalived/check/check_bfd.c
@@ -39,7 +39,7 @@
 #include "bfd_event.h"
 #include "bfd_daemon.h"
 #include "bitops.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -311,7 +311,7 @@ checker_bfd_dispatcher_release(void)
 	thread_cancel(bfd_thread);
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_bfd_addresses(void)
 {

--- a/keepalived/check/check_bfd.c
+++ b/keepalived/check/check_bfd.c
@@ -247,7 +247,7 @@ bfd_check_handle_event(bfd_event_t * evt)
 	if (__test_bit(LOG_DETAIL_BIT, &debug)) {
 		time_now = timer_now();
 		timersub(&time_now, &evt->sent_time, &timer_tmp);
-		delivery_time = timer_tol(timer_tmp);
+		delivery_time = timer_long(timer_tmp);
 		log_message(LOG_INFO, "Received BFD event: instance %s is in"
 			    " state %s (delivered in %i usec)",
 			    evt->iname, BFD_STATE_STR(evt->state), delivery_time);

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -32,7 +32,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "snmp.h"
 #include "scheduler.h"
 #include "smtp.h"
@@ -446,7 +446,7 @@ check_respawn_thread(thread_t * thread)
 }
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 static void
 register_check_thread_addresses(void)
 {
@@ -586,7 +586,7 @@ start_check_child(void)
 	return 0;
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	register_check_thread_addresses();
 #endif
 
@@ -599,7 +599,7 @@ start_check_child(void)
 	else
 		stop_check(KEEPALIVED_EXIT_OK);
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	deregister_thread_addresses();
 #endif
 
@@ -607,7 +607,7 @@ start_check_child(void)
 	exit(KEEPALIVED_EXIT_OK);
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_parent_addresses(void)
 {

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -511,14 +511,13 @@ install_dns_check_keyword(void)
 	install_sublevel_end();
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_check_dns_addresses(void)
+register_check_dns_addresses(void)
 {
-	log_message(LOG_INFO, "Address of dns_check_thread() is 0x%p", dns_check_thread);
-	log_message(LOG_INFO, "Address of dns_connect_thread() is 0x%p", dns_connect_thread);
-	log_message(LOG_INFO, "Address of dns_dump() is 0x%p", dns_dump);
-	log_message(LOG_INFO, "Address of dns_recv_thread() is 0x%p", dns_recv_thread);
-	log_message(LOG_INFO, "Address of dns_send_thread() is 0x%p", dns_send_thread);
+	register_thread_address("dns_check_thread", dns_check_thread);
+	register_thread_address("dns_connect_thread", dns_connect_thread);
+	register_thread_address("dns_recv_thread", dns_recv_thread);
+	register_thread_address("dns_send_thread", dns_send_thread);
 }
 #endif

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -521,7 +521,7 @@ install_dns_check_keyword(void)
 	install_sublevel_end();
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_dns_addresses(void)
 {

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -119,9 +119,7 @@ dns_final(thread_t * thread, int error, const char *fmt, ...)
 	DNS_DBG("final error=%d attempts=%d retry=%d", error,
 		checker->retry_it, checker->retry);
 
-	thread_event_cancel(thread);
-	close(thread->u.fd);
-	thread->u.fd = -1;
+	thread_close_fd(thread);
 
 	if (error) {
 		if (checker->is_up || !checker->has_run) {

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -48,7 +48,7 @@
 #include "layer4.h"
 #include "ipwrapper.h"
 #include "smtp.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -1560,7 +1560,7 @@ http_connect_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_http_addresses(void)
 {

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -1401,6 +1401,7 @@ http_request_thread(thread_t * thread)
 	/* Register read timeouted thread */
 	thread_add_read(thread->master, http_response_thread, checker,
 			thread->u.fd, timeout);
+	thread_del_write(thread);
 	return 1;
 }
 
@@ -1452,12 +1453,14 @@ http_check_thread(thread_t * thread)
 							http_check_thread,
 							THREAD_ARG(thread),
 							thread->u.fd, timeout);
+					thread_del_write(thread);
 					break;
 				case SSL_ERROR_WANT_WRITE:
 					thread_add_write(thread->master,
 							 http_check_thread,
 							 THREAD_ARG(thread),
 							 thread->u.fd, timeout);
+					thread_del_read(thread);
 					break;
 				default:
 					ret = 0;
@@ -1478,6 +1481,7 @@ http_check_thread(thread_t * thread)
 					 http_request_thread, checker,
 					 thread->u.fd,
 					 checker->co->connection_to);
+			thread_del_read(thread);
 		} else {
 			DBG("Connection trouble to: %s."
 					 , FMT_HTTP_RS(checker));

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -328,16 +328,19 @@ http_get_check_compare(void *a, void *b)
 		if (u1->virtualhost && strcmp(u1->virtualhost, u2->virtualhost))
 			return false;
 #ifdef _WITH_REGEX_CHECK_
-		if (!u1->regex != !u2->regex ||
-		    (u1->regex && strcmp((char *)u1->regex->pattern, (char *)u2->regex->pattern)))
+		if (!u1->regex != !u2->regex)
 			return false;
-		if (u1->regex->pcre2_options != u2->regex->pcre2_options)
-			return false;
-		if (u1->regex_no_match != u2->regex_no_match)
-			return false;
-		if (u1->regex_min_offset != u2->regex_min_offset ||
-		    u1->regex_max_offset != u2->regex_max_offset)
-			return false;
+		if (u1->regex) {
+			if (strcmp((char *)u1->regex->pattern, (char *)u2->regex->pattern))
+				return false;
+			if (u1->regex->pcre2_options != u2->regex->pcre2_options)
+				return false;
+			if (u1->regex_no_match != u2->regex_no_match)
+				return false;
+			if (u1->regex_min_offset != u2->regex_min_offset ||
+			    u1->regex_max_offset != u2->regex_max_offset)
+				return false;
+		}
 #endif
 	}
 

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -886,7 +886,7 @@ epilog(thread_t * thread, int method, unsigned t, unsigned c)
 	if (req) {
 		free_http_request(req);
 		http_get_check->req = NULL;
-		close(thread->u.fd);
+		thread_close_fd(thread);
 	}
 
 	/* Register next checker thread */

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -48,6 +48,9 @@
 #include "layer4.h"
 #include "ipwrapper.h"
 #include "smtp.h"
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 #define	REGISTER_CHECKER_NEW	1
 #define	REGISTER_CHECKER_RETRY	2
@@ -1557,15 +1560,14 @@ http_connect_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_check_http_addresses(void)
+register_check_http_addresses(void)
 {
-	log_message(LOG_INFO, "Address of dump_http_get_check() is 0x%p", dump_http_get_check);
-	log_message(LOG_INFO, "Address of http_check_thread() is 0x%p", http_check_thread);
-	log_message(LOG_INFO, "Address of http_connect_thread() is 0x%p", http_connect_thread);
-	log_message(LOG_INFO, "Address of http_read_thread() is 0x%p", http_read_thread);
-	log_message(LOG_INFO, "Address of http_request_thread() is 0x%p", http_request_thread);
-	log_message(LOG_INFO, "Address of http_response_thread() is 0x%p", http_response_thread);
+	register_thread_address("http_check_thread", http_check_thread);
+	register_thread_address("http_connect_thread", http_connect_thread);
+	register_thread_address("http_read_thread", http_read_thread);
+	register_thread_address("http_request_thread", http_request_thread);
+	register_thread_address("http_response_thread", http_response_thread);
 }
 #endif

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -41,7 +41,7 @@
 #include "global_data.h"
 #include "global_parser.h"
 #include "keepalived_magic.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -484,7 +484,7 @@ misc_check_child_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_misc_addresses(void)
 {

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -41,6 +41,9 @@
 #include "global_data.h"
 #include "global_parser.h"
 #include "keepalived_magic.h"
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 static int misc_check_thread(thread_t *);
 static int misc_check_child_thread(thread_t *);
@@ -481,12 +484,11 @@ misc_check_child_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_check_misc_addresses(void)
+register_check_misc_addresses(void)
 {
-	log_message(LOG_INFO, "Address of dump_misc_check() is 0x%p", dump_misc_check);
-	log_message(LOG_INFO, "Address of misc_check_child_thread() is 0x%p", misc_check_child_thread);
-	log_message(LOG_INFO, "Address of misc_check_thread() is 0x%p", misc_check_thread);
+	register_thread_address("misc_check_child_thread", misc_check_child_thread);
+	register_thread_address("misc_check_thread", misc_check_thread);
 }
 #endif

--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -477,7 +477,7 @@ misc_check_child_thread(thread_t * thread)
 	    (next_time.tv_sec == 0 && next_time.tv_usec == 0))
 		next_time.tv_sec = 0, next_time.tv_usec = 1;
 
-	thread_add_timer(thread->master, misc_check_thread, checker, timer_tol(next_time));
+	thread_add_timer(thread->master, misc_check_thread, checker, timer_long(next_time));
 
 	misck_checker->state = SCRIPT_STATE_IDLE;
 

--- a/keepalived/check/check_smtp.c
+++ b/keepalived/check/check_smtp.c
@@ -38,7 +38,7 @@
 #endif
 #include "layer4.h"
 #include "smtp.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -828,7 +828,7 @@ smtp_connect_thread(thread_t *thread)
 }
 
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_smtp_addresses(void)
 {

--- a/keepalived/check/check_smtp.c
+++ b/keepalived/check/check_smtp.c
@@ -287,7 +287,7 @@ smtp_final(thread_t *thread, int error, const char *format, ...)
 	bool rs_was_alive;
 
 	/* Error or no error we should always have to close the socket */
-	close(thread->u.fd);
+	thread_close_fd(thread);
 
 	/* If we're here, an attempt HAS been made already for the current host */
 	checker->retry_it++;

--- a/keepalived/check/check_smtp.c
+++ b/keepalived/check/check_smtp.c
@@ -38,6 +38,9 @@
 #endif
 #include "layer4.h"
 #include "smtp.h"
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 static conn_opts_t* default_co;	/* Default conn_opts for SMTP_CHECK */
 static conn_opts_t *sav_co;	/* Saved conn_opts while host{} block processed */
@@ -824,14 +827,14 @@ smtp_connect_thread(thread_t *thread)
 	return 0;
 }
 
-#ifdef _TIMER_DEBUG_
+
+#ifdef _EPOLL_DEBUG_
 void
-print_check_smtp_addresses(void)
+register_check_smtp_addresses(void)
 {
-	log_message(LOG_INFO, "Address of dump_smtp_check() is 0x%p", dump_smtp_check);
-	log_message(LOG_INFO, "Address of smtp_check_thread() is 0x%p", smtp_check_thread);
-	log_message(LOG_INFO, "Address of smtp_connect_thread() is 0x%p", smtp_connect_thread);
-	log_message(LOG_INFO, "Address of smtp_get_line_cb() is 0x%p", smtp_get_line_cb);
-	log_message(LOG_INFO, "Address of smtp_put_line_cb() is 0x%p", smtp_put_line_cb);
+	register_thread_address("smtp_check_thread", smtp_check_thread);
+	register_thread_address("smtp_connect_thread", smtp_connect_thread);
+	register_thread_address("smtp_get_line_cb", smtp_get_line_cb);
+	register_thread_address("smtp_put_line_cb", smtp_put_line_cb);
 }
 #endif

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -32,6 +32,9 @@
 #include "check_api.h"
 #include "check_http.h"
 #include "logger.h"
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 /* SSL primitives */
 /* Free an SSL context */
@@ -303,10 +306,10 @@ ssl_read_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_check_ssl_addresses(void)
+register_check_ssl_addresses(void)
 {
-	log_message(LOG_INFO, "Address of ssl_read_thread() is 0x%p", ssl_read_thread);
+	register_thread_address("ssl_read_thread", ssl_read_thread);
 }
 #endif

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -32,7 +32,7 @@
 #include "check_api.h"
 #include "check_http.h"
 #include "logger.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -306,7 +306,7 @@ ssl_read_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_ssl_addresses(void)
 {

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -147,10 +147,9 @@ tcp_epilog(thread_t * thread, bool is_success)
 static int
 tcp_check_thread(thread_t * thread)
 {
-	checker_t *checker;
+	checker_t *checker = THREAD_ARG(thread);
 	int status;
 
-	checker = THREAD_ARG(thread);
 	status = tcp_socket_state(thread, tcp_check_thread);
 
 	/* If status = connect_in_progress, next thread is already registered.
@@ -161,7 +160,7 @@ tcp_check_thread(thread_t * thread)
 	case connect_in_progress:
 		break;
 	case connect_success:
-		close(thread->u.fd);
+		thread_close_fd(thread);
 		tcp_epilog(thread, true);
 		break;
 	case connect_timeout:

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -37,6 +37,9 @@
 #if !HAVE_DECL_SOCK_CLOEXEC
 #include "old_socket.h"
 #endif
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 static int tcp_connect_thread(thread_t *);
 
@@ -227,12 +230,11 @@ tcp_connect_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_check_tcp_addresses(void)
+register_check_tcp_addresses(void)
 {
-	log_message(LOG_INFO, "Address of dump_tcp_check() is 0x%p", dump_tcp_check);
-	log_message(LOG_INFO, "Address of tcp_check_thread() is 0x%p", tcp_check_thread);
-	log_message(LOG_INFO, "Address of tcp_connect_thread() is 0x%p", tcp_connect_thread);
+	register_thread_address("tcp_check_thread", tcp_check_thread);
+	register_thread_address("tcp_connect_thread", tcp_connect_thread);
 }
 #endif

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -37,7 +37,7 @@
 #if !HAVE_DECL_SOCK_CLOEXEC
 #include "old_socket.h"
 #endif
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -229,7 +229,7 @@ tcp_connect_thread(thread_t * thread)
 	return 0;
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_check_tcp_addresses(void)
 {

--- a/keepalived/core/Makefile.am
+++ b/keepalived/core/Makefile.am
@@ -13,8 +13,7 @@ AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 noinst_LIBRARIES	= libcore.a
 
 libcore_a_SOURCES	= main.c daemon.c pidfile.c layer4.c smtp.c \
-			  global_data.c global_parser.c process.c \
-			  keepalived_netlink.c
+			  global_data.c global_parser.c keepalived_netlink.c
 
 AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -48,6 +48,9 @@
 #include <linux/fib_rules.h>
 #endif
 #endif
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 /* local include */
 #ifdef _LIBNL_DYNAMIC_
@@ -2279,10 +2282,10 @@ kernel_netlink_read_interfaces(void)
 }
 #endif
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_vrrp_netlink_addresses(void)
+register_keepalived_netlink_addresses(void)
 {
-	log_message(LOG_INFO, "Address of kernel_netlink() is 0x%p", kernel_netlink);
+	register_thread_address("kernel_netlink", kernel_netlink);
 }
 #endif

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -48,7 +48,7 @@
 #include <linux/fib_rules.h>
 #endif
 #endif
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -2282,7 +2282,7 @@ kernel_netlink_read_interfaces(void)
 }
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_keepalived_netlink_addresses(void)
 {

--- a/keepalived/core/layer4.c
+++ b/keepalived/core/layer4.c
@@ -28,6 +28,7 @@
 
 #include "layer4.h"
 #include "logger.h"
+#include "scheduler.h"
 
 #ifndef _WITH_LVS_
 static
@@ -116,7 +117,7 @@ socket_state(thread_t * thread, int (*func) (thread_t *))
 
 	/* Handle connection timeout */
 	if (thread->type == THREAD_WRITE_TIMEOUT) {
-		close(thread->u.fd);
+		thread_close_fd(thread);
 		return connect_timeout;
 	}
 
@@ -127,7 +128,7 @@ socket_state(thread_t * thread, int (*func) (thread_t *))
 
 	/* Connection failed !!! */
 	if (ret) {
-		close(thread->u.fd);
+		thread_close_fd(thread);
 		return connect_error;
 	}
 
@@ -146,7 +147,7 @@ socket_state(thread_t * thread, int (*func) (thread_t *))
 		return connect_in_progress;
 	}
 
-	close(thread->u.fd);
+	thread_close_fd(thread);
 	return connect_error;
 }
 

--- a/keepalived/core/layer4.c
+++ b/keepalived/core/layer4.c
@@ -136,17 +136,18 @@ socket_state(thread_t * thread, int (*func) (thread_t *))
 	 * and other error code until connection is established.
 	 * Recompute the write timeout (or pending connection).
 	 */
+	if (status == 0)
+		return connect_success;
+
 	if (status == EINPROGRESS) {
 		timer_min = timer_sub_now(thread->sands);
 		thread_add_write(thread->master, func, THREAD_ARG(thread),
 				 thread->u.fd, -timer_long(timer_min));
 		return connect_in_progress;
-	} else if (status != 0) {
-		close(thread->u.fd);
-		return connect_error;
 	}
 
-	return connect_success;
+	close(thread->u.fd);
+	return connect_error;
 }
 
 #ifdef _WITH_LVS_

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -75,7 +75,7 @@
 #include "scheduler.h"
 #include "keepalived_netlink.h"
 #include "git-commit.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 #include "process.h"
@@ -1264,7 +1264,7 @@ parse_cmdline(int argc, char **argv)
 	return reopen_log;
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 static void
 register_parent_thread_addresses(void)
 {
@@ -1580,7 +1580,7 @@ keepalived_main(int argc, char **argv)
 	if (!start_keepalived())
 		log_message(LOG_INFO, "Warning - keepalived has no configuration to run");
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	register_parent_thread_addresses();
 #endif
 
@@ -1590,7 +1590,7 @@ keepalived_main(int argc, char **argv)
 	/* Finish daemon process */
 	stop_keepalived();
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	deregister_thread_addresses();
 #endif
 

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -913,6 +913,9 @@ usage(const char *prog)
 								"\n");
 	fprintf(stderr, "  -t, --config-test[=LOG_FILE] Check the configuration for obvious errors, output to\n"
 			"                                stderr by default\n");
+#ifdef _WITH_PERF_
+	fprintf(stderr, "      --perf[=PERF_TYPE]       Collect perf data, PERF_TYPE=all, run(default) or end\n");
+#endif
 	fprintf(stderr, "  -v, --version                Display the version number\n");
 	fprintf(stderr, "  -h, --help                   Display this help message\n");
 }
@@ -982,6 +985,9 @@ parse_cmdline(int argc, char **argv)
 		{"config-id",		required_argument,	NULL, 'i'},
 		{"signum",		required_argument,	NULL,  4 },
 		{"config-test",		optional_argument,	NULL, 't'},
+#ifdef _WITH_PERF_
+		{"perf",		optional_argument,	NULL,  5 },
+#endif
 		{"version",		no_argument,		NULL, 'v'},
 		{"help",		no_argument,		NULL, 'h'},
 
@@ -990,7 +996,7 @@ parse_cmdline(int argc, char **argv)
 
 	/* Unfortunately, if a short option is used, getopt_long() doesn't change the value
 	 * of longindex, so we need to ensure that before calling getopt_long(), longindex
-	 * is set to a know invalid value */
+	 * is set to a known invalid value */
 	curind = optind;
 	while (longindex = -1, (c = getopt_long(argc, argv, ":vhlndDRS:f:p:i:mM::g::Gt::"
 #if defined _WITH_VRRP_ && defined _WITH_LVS_
@@ -1207,6 +1213,23 @@ parse_cmdline(int argc, char **argv)
 			__set_bit(DAEMON_BFD, &daemon_mode);
 #endif
 			break;
+#ifdef _WITH_PERF_
+		case 5:
+			if (optarg && optarg[0]) {
+				if (!strcmp(optarg, "run"))
+					perf_run = PERF_RUN;
+				else if (!strcmp(optarg, "all"))
+					perf_run = PERF_ALL;
+				else if (!strcmp(optarg, "end"))
+					perf_run = PERF_END;
+				else
+					log_message(LOG_INFO, "Unknown perf start point %s", optarg);
+			}
+			else
+				perf_run = PERF_RUN;
+
+			break;
+#endif
 		case '?':
 			if (optopt && argv[curind][1] != '-')
 				fprintf(stderr, "Unknown option -%c\n", optopt);

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -1265,6 +1265,10 @@ keepalived_main(int argc, char **argv)
 	struct utsname uname_buf;
 	char *end;
 
+	/* Ensure time_now is set. We then don't have to check anywhere
+	 * else if it is set. */
+	set_time_now();
+
 	/* Save command line options in case need to log them later */
 	save_cmd_line_options(argc, argv);
 

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -475,6 +475,8 @@ static bool reload_config(void)
 {
 	bool unsupported_change = false;
 
+	log_message(LOG_INFO, "Reloading ...");
+
 	/* Make sure there isn't an attempt to change the network namespace or instance name */
 	old_global_data = global_data;
 	global_data = NULL;

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -39,9 +39,8 @@
 #ifdef _WITH_LVS_
 #include "check_api.h"
 #endif
-//#include "main.h"
-//#include "parser.h"
 
+#ifndef _SMTP_ALERT_DEBUG_
 /* SMTP FSM definition */
 static int connection_error(thread_t *);
 static int connection_in_progress(thread_t *);
@@ -82,6 +81,7 @@ struct {
 	{body_cmd,			body_code},		/* BODY */
 	{quit_cmd,			quit_code}		/* QUIT */
 };
+#endif
 
 static void
 free_smtp_all(smtp_t * smtp)
@@ -99,6 +99,7 @@ fetch_next_email(smtp_t * smtp)
 	return list_element(global_data->email, smtp->email_it);
 }
 
+#ifndef _SMTP_ALERT_DEBUG_
 /* layer4 connection handlers */
 static int
 connection_error(thread_t * thread)
@@ -284,6 +285,7 @@ smtp_send_thread(thread_t * thread)
 	if (smtp->stage != ERROR) {
 		thread_add_read(thread->master, smtp_read_thread, smtp,
 				thread->u.fd, global_data->smtp_connection_to);
+		thread_del_write(thread);
 	} else {
 		log_message(LOG_INFO, "Can not send data to remote SMTP server %s."
 				    , FMT_SMTP_HOST());
@@ -450,56 +452,6 @@ data_code(thread_t * thread, int status)
 	return 0;
 }
 
-/*
- * Build a comma separated string of smtp recipient email addresses
- * for the email message To-header.
- */
-static void
-build_to_header_rcpt_addrs(smtp_t *smtp)
-{
-	char *fetched_email;
-	char *email_to_addrs;
-	size_t bytes_available = SMTP_BUFFER_MAX - 1;
-	size_t bytes_to_write;
-
-	if (smtp == NULL)
-		return;
-
-	email_to_addrs = smtp->email_to;
-	smtp->email_it = 0;
-
-	while (1) {
-		fetched_email = fetch_next_email(smtp);
-		if (fetched_email == NULL)
-			break;
-
-		bytes_to_write = strlen(fetched_email);
-		if (!smtp->email_it) {
-			if (bytes_available < bytes_to_write)
-				break;
-		} else {
-			if (bytes_available < 2 + bytes_to_write)
-				break;
-
-			/* Prepend with a comma and space to all non-first email addresses */
-			*email_to_addrs++ = ',';
-			*email_to_addrs++ = ' ';
-			bytes_available -= 2;
-		}
-
-		if (snprintf(email_to_addrs, bytes_to_write + 1, "%s", fetched_email) != (int)bytes_to_write) {
-			/* Inconsistent state, no choice but to break here and do nothing */
-			break;
-		}
-
-		email_to_addrs += bytes_to_write;
-		bytes_available -= bytes_to_write;
-		smtp->email_it++;
-	}
-
-	smtp->email_it = 0;
-}
-
 /* BODY command processing.
  * Do we need to use mutli-thread for multi-part body
  * handling ? Don t really think :)
@@ -611,6 +563,82 @@ smtp_connect(smtp_t * smtp)
 	thread_add_event(master, SMTP_FSM[status].send, smtp, smtp->fd);
 }
 
+#else
+
+static void
+smtp_log_to_file(smtp_t *smtp)
+{
+	FILE *fp = fopen("/tmp/smtp-alert.log", "a");
+	struct tm tm;
+	char time_buf[25];
+	int time_buf_len;
+
+	localtime_r(&time_now.tv_sec, &tm);
+	time_buf_len = strftime(time_buf, sizeof time_buf, "%a %b %e %X %Y", &tm);
+
+	fprintf(fp, "%s: %s -> %s\n"
+		    "%*sSubject: %s\n"
+		    "%*sBody:    %s\n\n",
+		    time_buf, global_data->email_from, smtp->email_to,
+		    time_buf_len - 7, "", smtp->subject,
+		    time_buf_len - 7, "", smtp->body);
+
+	fclose(fp);
+
+	free_smtp_all(smtp);
+}
+#endif
+
+/*
+ * Build a comma separated string of smtp recipient email addresses
+ * for the email message To-header.
+ */
+static void
+build_to_header_rcpt_addrs(smtp_t *smtp)
+{
+	char *fetched_email;
+	char *email_to_addrs;
+	size_t bytes_available = SMTP_BUFFER_MAX - 1;
+	size_t bytes_to_write;
+
+	if (smtp == NULL)
+		return;
+
+	email_to_addrs = smtp->email_to;
+	smtp->email_it = 0;
+
+	while (1) {
+		fetched_email = fetch_next_email(smtp);
+		if (fetched_email == NULL)
+			break;
+
+		bytes_to_write = strlen(fetched_email);
+		if (!smtp->email_it) {
+			if (bytes_available < bytes_to_write)
+				break;
+		} else {
+			if (bytes_available < 2 + bytes_to_write)
+				break;
+
+			/* Prepend with a comma and space to all non-first email addresses */
+			*email_to_addrs++ = ',';
+			*email_to_addrs++ = ' ';
+			bytes_available -= 2;
+		}
+
+		if (snprintf(email_to_addrs, bytes_to_write + 1, "%s", fetched_email) != (int)bytes_to_write) {
+			/* Inconsistent state, no choice but to break here and do nothing */
+			break;
+		}
+
+		email_to_addrs += bytes_to_write;
+		bytes_available -= bytes_to_write;
+		smtp->email_it++;
+	}
+
+	smtp->email_it = 0;
+}
+
 /* Main entry point */
 void
 smtp_alert(smtp_msg_t msg_type, void* data, const char *subject, const char *body)
@@ -693,34 +721,17 @@ smtp_alert(smtp_msg_t msg_type, void* data, const char *subject, const char *bod
 	build_to_header_rcpt_addrs(smtp);
 
 #ifdef _SMTP_ALERT_DEBUG_
-	FILE *fp = fopen("/tmp/smtp-alert.log", "a");
-	struct tm tm;
-	char time_buf[25];
-	int time_buf_len;
-
-	localtime_r(&time_now.tv_sec, &tm);
-	time_buf_len = strftime(time_buf, sizeof time_buf, "%a %b %e %X %Y", &tm);
-
-	fprintf(fp, "%s: %s -> %s\n"
-		    "%*sSubject: %s\n"
-		    "%*sBody:    %s\n\n",
-		    time_buf, global_data->email_from, smtp->email_to,
-		    time_buf_len - 7, "", smtp->subject,
-		    time_buf_len - 7, "", smtp->body);
-
-	fclose(fp);
-
-	free_smtp_all(smtp);
-	return;
-#endif
-
+	smtp_log_to_file(smtp);
+#else
 	smtp_connect(smtp);
+#endif
 }
 
 #ifdef _TIMER_DEBUG_
 void
 print_smtp_addresses(void)
 {
+#ifndef _SMTP_ALERT_DEBUG_
 	log_message(LOG_INFO, "Address of body_cmd() is 0x%p", body_cmd);
 	log_message(LOG_INFO, "Address of connection_error() is 0x%p", connection_error);
 	log_message(LOG_INFO, "Address of connection_in_progress() is 0x%p", connection_in_progress);
@@ -733,5 +744,6 @@ print_smtp_addresses(void)
 	log_message(LOG_INFO, "Address of rcpt_cmd() is 0x%p", rcpt_cmd);
 	log_message(LOG_INFO, "Address of smtp_read_thread() is 0x%p", smtp_read_thread);
 	log_message(LOG_INFO, "Address of smtp_send_thread() is 0x%p", smtp_send_thread);
+#endif
 }
 #endif

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -39,7 +39,7 @@
 #ifdef _WITH_LVS_
 #include "check_api.h"
 #endif
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -732,7 +732,7 @@ smtp_alert(smtp_msg_t msg_type, void* data, const char *subject, const char *bod
 #endif
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_smtp_addresses(void)
 {

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -465,13 +465,13 @@ body_cmd(thread_t * thread)
 	smtp_t *smtp = THREAD_ARG(thread);
 	char *buffer;
 	char rfc822[80];
-	time_t tm;
+	time_t now;
 	struct tm *t;
 
 	buffer = (char *) MALLOC(SMTP_BUFFER_MAX);
 
-	time(&tm);
-	t = localtime(&tm);
+	time(&now);
+	t = localtime(&now);
 	strftime(rfc822, sizeof(rfc822), "%a, %d %b %Y %H:%M:%S %z", t);
 
 	snprintf(buffer, SMTP_BUFFER_MAX, SMTP_HEADERS_CMD,
@@ -572,11 +572,13 @@ static void
 smtp_log_to_file(smtp_t *smtp)
 {
 	FILE *fp = fopen("/tmp/smtp-alert.log", "a");
+	time_t now;
 	struct tm tm;
 	char time_buf[25];
 	int time_buf_len;
 
-	localtime_r(&time_now.tv_sec, &tm);
+	time(&now);
+	localtime_r(&now, &tm);
 	time_buf_len = strftime(time_buf, sizeof time_buf, "%a %b %e %X %Y", &tm);
 
 	fprintf(fp, "%s: %s -> %s\n"

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -39,6 +39,9 @@
 #ifdef _WITH_LVS_
 #include "check_api.h"
 #endif
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 #ifndef _SMTP_ALERT_DEBUG_
 /* SMTP FSM definition */
@@ -727,23 +730,23 @@ smtp_alert(smtp_msg_t msg_type, void* data, const char *subject, const char *bod
 #endif
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_smtp_addresses(void)
+register_smtp_addresses(void)
 {
 #ifndef _SMTP_ALERT_DEBUG_
-	log_message(LOG_INFO, "Address of body_cmd() is 0x%p", body_cmd);
-	log_message(LOG_INFO, "Address of connection_error() is 0x%p", connection_error);
-	log_message(LOG_INFO, "Address of connection_in_progress() is 0x%p", connection_in_progress);
-	log_message(LOG_INFO, "Address of connection_success() is 0x%p", connection_success);
-	log_message(LOG_INFO, "Address of connection_timeout() is 0x%p", connection_timeout);
-	log_message(LOG_INFO, "Address of data_cmd() is 0x%p", data_cmd);
-	log_message(LOG_INFO, "Address of helo_cmd() is 0x%p", helo_cmd);
-	log_message(LOG_INFO, "Address of mail_cmd() is 0x%p", mail_cmd);
-	log_message(LOG_INFO, "Address of quit_cmd() is 0x%p", quit_cmd);
-	log_message(LOG_INFO, "Address of rcpt_cmd() is 0x%p", rcpt_cmd);
-	log_message(LOG_INFO, "Address of smtp_read_thread() is 0x%p", smtp_read_thread);
-	log_message(LOG_INFO, "Address of smtp_send_thread() is 0x%p", smtp_send_thread);
+	register_thread_address("body_cmd", body_cmd);
+	register_thread_address("connection_error", connection_error);
+	register_thread_address("connection_in_progress", connection_in_progress);
+	register_thread_address("connection_success", connection_success);
+	register_thread_address("connection_timeout", connection_timeout);
+	register_thread_address("data_cmd", data_cmd);
+	register_thread_address("helo_cmd", helo_cmd);
+	register_thread_address("mail_cmd", mail_cmd);
+	register_thread_address("quit_cmd", quit_cmd);
+	register_thread_address("rcpt_cmd", rcpt_cmd);
+	register_thread_address("smtp_read_thread", smtp_read_thread);
+	register_thread_address("smtp_send_thread", smtp_send_thread);
 #endif
 }
 #endif

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -534,7 +534,7 @@ quit_code(thread_t * thread, __attribute__((unused)) int status)
 
 	/* final state, we are disconnected from the remote host */
 	free_smtp_all(smtp);
-	close(thread->u.fd);
+	thread_close_fd(thread);
 	return 0;
 }
 

--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -385,7 +385,7 @@ snmp_agent_close(bool base_mib)
 	snmp_running = false;
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_snmp_addresses(void)
 {

--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -370,6 +370,8 @@ snmp_agent_init(const char *snmp_socket, bool base_mib)
 				  sizeof(global_vars)/sizeof(struct variable8));
 	init_snmp(global_name);
 
+	master->snmp_timer_thread = thread_add_timer(master, snmp_timeout_thread, 0, TIMER_NEVER);
+
 	snmp_running = true;
 }
 

--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -384,3 +384,12 @@ snmp_agent_close(bool base_mib)
 
 	snmp_running = false;
 }
+
+#ifdef _EPOLL_DEBUG_
+void
+register_snmp_addresses(void)
+{
+//        register_thread_address("snmp_timeout_thread", snmp_timeout_thread);
+//        register_thread_address("snmp_read_thread", snmp_read_thread);
+}
+#endif

--- a/keepalived/include/bfd_daemon.h
+++ b/keepalived/include/bfd_daemon.h
@@ -35,5 +35,8 @@ extern int bfd_checker_event_pipe[2];
 extern void open_bfd_pipes(void);
 extern int start_bfd_child(void);
 extern void bfd_validate_config(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_bfd_parent_addresses(void);
+#endif
 
 #endif				/* _BFD_DAEMON_H_ */

--- a/keepalived/include/bfd_daemon.h
+++ b/keepalived/include/bfd_daemon.h
@@ -35,7 +35,7 @@ extern int bfd_checker_event_pipe[2];
 extern void open_bfd_pipes(void);
 extern int start_bfd_child(void);
 extern void bfd_validate_config(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_bfd_parent_addresses(void);
 #endif
 

--- a/keepalived/include/bfd_scheduler.h
+++ b/keepalived/include/bfd_scheduler.h
@@ -27,7 +27,7 @@
 
 extern int bfd_dispatcher_init(thread_t *);
 extern void bfd_dispatcher_release(bfd_data_t *);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_bfd_scheduler_addresses(void);
 #endif
 

--- a/keepalived/include/bfd_scheduler.h
+++ b/keepalived/include/bfd_scheduler.h
@@ -27,5 +27,8 @@
 
 extern int bfd_dispatcher_init(thread_t *);
 extern void bfd_dispatcher_release(bfd_data_t *);
+#ifdef _EPOLL_DEBUG_
+extern void register_bfd_scheduler_addresses(void);
+#endif
 
 #endif				/* _BFD_SCHEDULER_H_ */

--- a/keepalived/include/check_bfd.h
+++ b/keepalived/include/check_bfd.h
@@ -55,8 +55,8 @@ typedef struct _bfd_checker {
 extern void install_bfd_check_keyword(void);
 extern void start_bfd_monitoring(thread_master_t *);
 extern void checker_bfd_dispatcher_release(void);
-#ifdef _TIMER_DEBUG_
-extern void print_check_bfd_addresses(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_bfd_addresses(void);
 #endif
 
 #endif

--- a/keepalived/include/check_bfd.h
+++ b/keepalived/include/check_bfd.h
@@ -55,7 +55,7 @@ typedef struct _bfd_checker {
 extern void install_bfd_check_keyword(void);
 extern void start_bfd_monitoring(thread_master_t *);
 extern void checker_bfd_dispatcher_release(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_bfd_addresses(void);
 #endif
 

--- a/keepalived/include/check_daemon.h
+++ b/keepalived/include/check_daemon.h
@@ -35,7 +35,7 @@ extern bool using_ha_suspend;
 /* Prototypes */
 extern int start_check_child(void);
 extern void check_validate_config(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_parent_addresses(void);
 #endif
 

--- a/keepalived/include/check_daemon.h
+++ b/keepalived/include/check_daemon.h
@@ -35,5 +35,8 @@ extern bool using_ha_suspend;
 /* Prototypes */
 extern int start_check_child(void);
 extern void check_validate_config(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_parent_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/check_dns.h
+++ b/keepalived/include/check_dns.h
@@ -93,7 +93,7 @@ typedef struct _dns_check {
 } dns_check_t;
 
 extern void install_dns_check_keyword(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_dns_addresses(void);
 #endif
 

--- a/keepalived/include/check_dns.h
+++ b/keepalived/include/check_dns.h
@@ -93,5 +93,8 @@ typedef struct _dns_check {
 } dns_check_t;
 
 extern void install_dns_check_keyword(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_dns_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -132,7 +132,7 @@ extern void install_http_check_keyword(void);
 extern int timeout_epilog(thread_t *, const char *);
 extern void http_process_response(request_t *, size_t, url_t *);
 extern int http_handle_response(thread_t *, unsigned char digest[16], bool);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_http_addresses(void);
 #endif
 

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -132,4 +132,8 @@ extern void install_http_check_keyword(void);
 extern int timeout_epilog(thread_t *, const char *);
 extern void http_process_response(request_t *, size_t, url_t *);
 extern int http_handle_response(thread_t *, unsigned char digest[16], bool);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_http_addresses(void);
+#endif
+
 #endif

--- a/keepalived/include/check_misc.h
+++ b/keepalived/include/check_misc.h
@@ -45,7 +45,7 @@ typedef struct _misc_checker {
 extern void clear_dynamic_misc_check_flag(void);
 extern void install_misc_check_keyword(void);
 extern int check_misc_script_security(magic_t);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_misc_addresses(void);
 #endif
 

--- a/keepalived/include/check_misc.h
+++ b/keepalived/include/check_misc.h
@@ -45,5 +45,8 @@ typedef struct _misc_checker {
 extern void clear_dynamic_misc_check_flag(void);
 extern void install_misc_check_keyword(void);
 extern int check_misc_script_security(magic_t);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_misc_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/check_smtp.h
+++ b/keepalived/include/check_smtp.h
@@ -66,7 +66,7 @@ typedef struct _smtp_checker {
 
 /* Prototypes defs */
 extern void install_smtp_check_keyword(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_smtp_addresses(void);
 #endif
 

--- a/keepalived/include/check_smtp.h
+++ b/keepalived/include/check_smtp.h
@@ -66,5 +66,8 @@ typedef struct _smtp_checker {
 
 /* Prototypes defs */
 extern void install_smtp_check_keyword(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_smtp_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/check_ssl.h
+++ b/keepalived/include/check_ssl.h
@@ -39,5 +39,8 @@ extern int ssl_connect(thread_t *, int);
 extern int ssl_printerr(int);
 extern bool ssl_send_request(SSL *, char *, int);
 extern int ssl_read_thread(thread_t *);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_ssl_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/check_ssl.h
+++ b/keepalived/include/check_ssl.h
@@ -39,7 +39,7 @@ extern int ssl_connect(thread_t *, int);
 extern int ssl_printerr(int);
 extern bool ssl_send_request(SSL *, char *, int);
 extern int ssl_read_thread(thread_t *);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_ssl_addresses(void);
 #endif
 

--- a/keepalived/include/check_tcp.h
+++ b/keepalived/include/check_tcp.h
@@ -28,5 +28,8 @@
 
 /* Prototypes defs */
 extern void install_tcp_check_keyword(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_check_tcp_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/check_tcp.h
+++ b/keepalived/include/check_tcp.h
@@ -28,7 +28,7 @@
 
 /* Prototypes defs */
 extern void install_tcp_check_keyword(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_check_tcp_addresses(void);
 #endif
 

--- a/keepalived/include/keepalived_netlink.h
+++ b/keepalived/include/keepalived_netlink.h
@@ -106,7 +106,7 @@ extern void kernel_netlink_read_interfaces(void);
 extern void kernel_netlink_close(void);
 extern void kernel_netlink_close_monitor(void);
 extern void kernel_netlink_close_cmd(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_keepalived_netlink_addresses(void);
 #endif
 

--- a/keepalived/include/keepalived_netlink.h
+++ b/keepalived/include/keepalived_netlink.h
@@ -106,5 +106,8 @@ extern void kernel_netlink_read_interfaces(void);
 extern void kernel_netlink_close(void);
 extern void kernel_netlink_close_monitor(void);
 extern void kernel_netlink_close_cmd(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_keepalived_netlink_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/smtp.h
+++ b/keepalived/include/smtp.h
@@ -122,5 +122,8 @@ typedef void vrrp_sgroup_t;
 
 /* Prototypes defs */
 extern void smtp_alert(smtp_msg_t, void *data, const char *, const char *);
+#ifdef _EPOLL_DEBUG_
+extern void register_smtp_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/smtp.h
+++ b/keepalived/include/smtp.h
@@ -122,7 +122,7 @@ typedef void vrrp_sgroup_t;
 
 /* Prototypes defs */
 extern void smtp_alert(smtp_msg_t, void *data, const char *, const char *);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_smtp_addresses(void);
 #endif
 

--- a/keepalived/include/snmp.h
+++ b/keepalived/include/snmp.h
@@ -69,7 +69,7 @@ extern void snmp_register_mib(oid *myoid, size_t len,
 			      size_t varsize, size_t varlen);
 extern void snmp_unregister_mib(oid *myoid, size_t len);
 extern void snmp_agent_close(bool base_mib);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_snmp_addresses(void);
 #endif
 

--- a/keepalived/include/snmp.h
+++ b/keepalived/include/snmp.h
@@ -69,5 +69,8 @@ extern void snmp_register_mib(oid *myoid, size_t len,
 			      size_t varsize, size_t varlen);
 extern void snmp_unregister_mib(oid *myoid, size_t len);
 extern void snmp_agent_close(bool base_mib);
+#ifdef _EPOLL_DEBUG_
+extern void register_snmp_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -375,7 +375,7 @@ extern void clear_diff_vrrp(void);
 extern void clear_diff_script(void);
 extern void clear_diff_bfd(void);
 extern void vrrp_restore_interface(vrrp_t *, bool, bool);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_vrrp_fifo_addresses(void);
 #endif
 

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -375,5 +375,8 @@ extern void clear_diff_vrrp(void);
 extern void clear_diff_script(void);
 extern void clear_diff_bfd(void);
 extern void vrrp_restore_interface(vrrp_t *, bool, bool);
+#ifdef _EPOLL_DEBUG_
+extern void register_vrrp_fifo_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/vrrp_daemon.h
+++ b/keepalived/include/vrrp_daemon.h
@@ -33,7 +33,7 @@ extern bool non_existent_interface_specified;
 /* Prototypes */
 extern int start_vrrp_child(void);
 extern void vrrp_validate_config(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_vrrp_parent_addresses(void);
 #endif
 

--- a/keepalived/include/vrrp_daemon.h
+++ b/keepalived/include/vrrp_daemon.h
@@ -33,5 +33,8 @@ extern bool non_existent_interface_specified;
 /* Prototypes */
 extern int start_vrrp_child(void);
 extern void vrrp_validate_config(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_vrrp_parent_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/vrrp_dbus.h
+++ b/keepalived/include/vrrp_dbus.h
@@ -44,5 +44,8 @@ void dbus_remove_object(vrrp_t *);
 void dbus_reload(list, list);
 bool dbus_start(void);
 void dbus_stop(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_vrrp_dbus_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/vrrp_dbus.h
+++ b/keepalived/include/vrrp_dbus.h
@@ -44,7 +44,7 @@ void dbus_remove_object(vrrp_t *);
 void dbus_reload(list, list);
 bool dbus_start(void);
 void dbus_stop(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_vrrp_dbus_addresses(void);
 #endif
 

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -181,5 +181,8 @@ extern void interface_down(interface_t *);
 extern void cleanup_lost_interface(interface_t *);
 extern int recreate_vmac_thread(thread_t *);
 extern void update_added_interface(interface_t *);
+#ifdef _EPOLL_DEBUG_
+extern void register_vrrp_if_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -181,7 +181,7 @@ extern void interface_down(interface_t *);
 extern void cleanup_lost_interface(interface_t *);
 extern int recreate_vmac_thread(thread_t *);
 extern void update_added_interface(interface_t *);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_vrrp_if_addresses(void);
 #endif
 

--- a/keepalived/include/vrrp_scheduler.h
+++ b/keepalived/include/vrrp_scheduler.h
@@ -61,5 +61,8 @@ extern void try_up_instance(vrrp_t *, bool);
 #ifdef _WITH_DUMP_THREADS_
 extern void dump_threads(void);
 #endif
+#ifdef _EPOLL_DEBUG_
+extern void register_vrrp_scheduler_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/vrrp_scheduler.h
+++ b/keepalived/include/vrrp_scheduler.h
@@ -61,7 +61,7 @@ extern void try_up_instance(vrrp_t *, bool);
 #ifdef _WITH_DUMP_THREADS_
 extern void dump_threads(void);
 #endif
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_vrrp_scheduler_addresses(void);
 #endif
 

--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -163,5 +163,8 @@ extern void initialise_interface_tracking_priorities(void);
 extern void initialise_tracking_priorities(struct _vrrp_t *);
 extern void init_track_files(list);
 extern void stop_track_files(void);
+#ifdef _EPOLL_DEBUG_
+extern void register_vrrp_inotify_addresses(void);
+#endif
 
 #endif

--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -163,7 +163,7 @@ extern void initialise_interface_tracking_priorities(void);
 extern void initialise_tracking_priorities(struct _vrrp_t *);
 extern void init_track_files(list);
 extern void stop_track_files(void);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_vrrp_inotify_addresses(void);
 #endif
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3740,7 +3740,7 @@ clear_diff_bfd(void)
 }
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_vrrp_fifo_addresses(void)
 {

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3739,3 +3739,11 @@ clear_diff_bfd(void)
 	}
 }
 #endif
+
+#ifdef _EPOLL_DEBUG_
+void
+register_vrrp_fifo_addresses(void)
+{
+	register_thread_address("vrrp_notify_fifo_script_exit", vrrp_notify_fifo_script_exit);
+}
+#endif

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -834,7 +834,9 @@ register_vrrp_thread_addresses(void)
 	register_signal_handler_address("sigend_vrrp", sigend_vrrp);
 	register_signal_handler_address("sigusr1_vrrp", sigusr1_vrrp);
 	register_signal_handler_address("sigusr2_vrrp", sigusr2_vrrp);
+#ifdef _WITH_JSON_
 	register_signal_handler_address("sigjson_vrrp", sigjson_vrrp);
+#endif
 }
 #endif
 

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -33,7 +33,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "snmp.h"
 #include "scheduler.h"
 #include "smtp.h"
@@ -809,7 +809,7 @@ vrrp_respawn_thread(thread_t * thread)
 }
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 static void
 register_vrrp_thread_addresses(void)
 {
@@ -965,7 +965,7 @@ start_vrrp_child(void)
 	return 0;
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	register_vrrp_thread_addresses();
 #endif
 
@@ -976,7 +976,7 @@ start_vrrp_child(void)
 	/* Launch the scheduling I/O multiplexer */
 	launch_thread_scheduler(master);
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	deregister_thread_addresses();
 #endif
 
@@ -993,7 +993,7 @@ vrrp_validate_config(void)
 	start_vrrp();
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_vrrp_parent_addresses(void)
 {

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -151,6 +151,9 @@ set_vrrp_max_fds(void)
 	}
 
 	log_message(LOG_INFO, "Set maximum open files to %ld", rlim.rlim_cur);
+
+	/* We don't want child processes to get excessive limits */
+	set_child_rlimit(RLIMIT_NOFILE, &orig_rlim);
 }
 
 #ifdef _WITH_LVS_

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -284,8 +284,9 @@ static void
 dump_sock(FILE *fp, void *sock_data)
 {
 	sock_t *sock = sock_data;
-	conf_write(fp, "VRRP sockpool: [ifindex(%u), proto(%u), unicast(%d), fd(%d,%d)]"
+	conf_write(fp, "VRRP sockpool: [ifindex(%u), family(%s), proto(%u), unicast(%d), fd(%d,%d)]"
 			    , sock->ifindex
+			    , sock->family == AF_INET ? "IPv4" : sock->family == AF_INET6 ? "IPv6" : "unknown"
 			    , sock->proto
 			    , sock->unicast
 			    , sock->fd_in

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -70,7 +70,7 @@
 #include "main.h"
 #include "logger.h"
 #include "utils.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -949,7 +949,7 @@ dbus_stop(void)
 	}
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_vrrp_dbus_addresses(void)
 {

--- a/keepalived/vrrp/vrrp_dbus.c
+++ b/keepalived/vrrp/vrrp_dbus.c
@@ -70,6 +70,9 @@
 #include "main.h"
 #include "logger.h"
 #include "utils.h"
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 typedef enum dbus_action {
 	DBUS_ACTION_NONE,
@@ -946,10 +949,10 @@ dbus_stop(void)
 	}
 }
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_vrrp_dbus_addresses(void)
+register_vrrp_dbus_addresses(void)
 {
-	log_message(LOG_INFO, "Address of handle_dbus_msg() is 0x%p", handle_dbus_msg);
+	register_thread_address("handle_dbus_msg", handle_dbus_msg);
 }
 #endif

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -65,6 +65,9 @@
 #include "vrrp_track.h"
 #include "vrrp_scheduler.h"
 #include "vrrp_iproute.h"
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 
 /* Local vars */
@@ -998,14 +1001,6 @@ if_setsockopt_no_receive(int *sd)
 	return *sd;
 }
 
-#ifdef _TIMER_DEBUG_
-void
-print_vrrp_if_addresses(void)
-{
-	log_message(LOG_INFO, "Address of if_linkbeat_refresh_thread() is 0x%p", if_linkbeat_refresh_thread);
-}
-#endif
-
 void
 interface_up(interface_t *ifp)
 {
@@ -1203,3 +1198,11 @@ update_added_interface(interface_t *ifp)
 		setup_interface(vrrp);
 	}
 }
+
+#ifdef _EPOLL_DEBUG_
+void
+register_vrrp_if_addresses(void)
+{
+	register_thread_address("if_linkbeat_refresh_thread", if_linkbeat_refresh_thread);
+}
+#endif

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -1139,10 +1139,6 @@ setup_interface(vrrp_t *vrrp)
 			vrrp->sockets->fd_out = open_vrrp_send_socket(vrrp->sockets->family, vrrp->sockets->proto,
 							ifp, vrrp->sockets->unicast);
 
-		if (vrrp->sockets->fd_out > master->max_fd)
-			master->max_fd = vrrp->sockets->fd_out;
-		if (vrrp->sockets->fd_in > master->max_fd)
-			master->max_fd = vrrp->sockets->fd_in;
 		vrrp->sockets->ifindex = vrrp->ifp->ifindex;
 
 		alloc_vrrp_fd_bucket(vrrp);

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -65,7 +65,7 @@
 #include "vrrp_track.h"
 #include "vrrp_scheduler.h"
 #include "vrrp_iproute.h"
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -1199,7 +1199,7 @@ update_added_interface(interface_t *ifp)
 	}
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_vrrp_if_addresses(void)
 {

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -782,7 +782,7 @@ vrrp_handle_bfd_event(bfd_event_t * evt)
 	if (__test_bit(LOG_DETAIL_BIT, &debug)) {
 		time_now = timer_now();
 		timersub(&time_now, &evt->sent_time, &timer_tmp);
-		delivery_time = timer_tol(timer_tmp);
+		delivery_time = timer_long(timer_tmp);
 		log_message(LOG_INFO, "Received BFD event: instance %s is in"
 			    " state %s (delivered in %i usec)",
 			    evt->iname, BFD_STATE_STR(evt->state), delivery_time);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -59,6 +59,9 @@
 #include "bfd_event.h"
 #include "bfd_daemon.h"
 #endif
+#ifdef _EPOLL_DEBUG_
+#include "scheduler.h"
+#endif
 
 /* global vars */
 timeval_t garp_next_time;
@@ -1330,16 +1333,19 @@ dump_threads(void)
 }
 #endif
 
-#ifdef _TIMER_DEBUG_
+#ifdef _EPOLL_DEBUG_
 void
-print_vrrp_scheduler_addresses(void)
+register_vrrp_scheduler_addresses(void)
 {
-	log_message(LOG_INFO, "Address of vrrp_arp_thread() is 0x%p", vrrp_arp_thread);
-	log_message(LOG_INFO, "Address of vrrp_dispatcher_init() is 0x%p", vrrp_dispatcher_init);
-	log_message(LOG_INFO, "Address of vrrp_gratuitous_arp_thread() is 0x%p", vrrp_gratuitous_arp_thread);
-	log_message(LOG_INFO, "Address of vrrp_lower_prio_gratuitous_arp_thread() is 0x%p", vrrp_lower_prio_gratuitous_arp_thread);
-	log_message(LOG_INFO, "Address of vrrp_script_child_thread() is 0x%p", vrrp_script_child_thread);
-	log_message(LOG_INFO, "Address of vrrp_script_thread() is 0x%p", vrrp_script_thread);
-	log_message(LOG_INFO, "Address of vrrp_read_dispatcher_thread() is 0x%p", vrrp_read_dispatcher_thread);
+	register_thread_address("vrrp_arp_thread", vrrp_arp_thread);
+	register_thread_address("vrrp_dispatcher_init", vrrp_dispatcher_init);
+	register_thread_address("vrrp_gratuitous_arp_thread", vrrp_gratuitous_arp_thread);
+	register_thread_address("vrrp_lower_prio_gratuitous_arp_thread", vrrp_lower_prio_gratuitous_arp_thread);
+	register_thread_address("vrrp_script_child_thread", vrrp_script_child_thread);
+	register_thread_address("vrrp_script_thread", vrrp_script_thread);
+	register_thread_address("vrrp_read_dispatcher_thread", vrrp_read_dispatcher_thread);
+#ifdef _WITH_BFD_
+	register_thread_address("vrrp_bfd_thread", vrrp_bfd_thread);
+#endif
 }
 #endif

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -59,7 +59,7 @@
 #include "bfd_event.h"
 #include "bfd_daemon.h"
 #endif
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 #include "scheduler.h"
 #endif
 
@@ -1221,77 +1221,6 @@ vrrp_arp_thread(thread_t *thread)
 }
 
 #ifdef _WITH_DUMP_THREADS_
-static char *
-get_func_name_from_addr(void *func)
-{
-/*
-func
- handle_dbus_msg
- http_read_thread
- http_response_thread
- if_linkbeat_refresh_thread
- kernel_netlink
- print_vrrp_data
- print_vrrp_stats
- reload_vrrp_thread
- SMTP_FSM[status].send
- smtp_read_thread
- smtp_send_thread
- ssl_read_thread
- tcp_connect_thread
-*/
-	if (func == vrrp_arp_thread) return "vrrp_arp_thread";
-	if (func == vrrp_dispatcher_init) return "vrrp_dispatcher_init";
-	if (func == vrrp_gratuitous_arp_thread) return "vrrp_gratuitous_arp_thread";
-	if (func == vrrp_lower_prio_gratuitous_arp_thread) return "vrrp_lower_prio_gratuitous_arp_thread";
-	if (func == vrrp_read_dispatcher_thread) return "vrrp_read_dispatcher_thread";
-	if (func == vrrp_script_thread) return "vrrp_script_thread";
-
-	return NULL;
-}
-
-static void
-dump_thread_list(FILE *fp, thread_list_t *tlist, const char *type)
-{
-	thread_t *thread;
-	char time_buf[26];
-	char *func_name;
-
-	fprintf(fp, "\n  %s thread list dump\n", type);
-	for (thread = tlist->head; thread; thread = thread->next) {
-		fprintf(fp, "\n    type = %d (%s)\n", thread->type,
-				thread->type == THREAD_READ ? "THREAD_READ" :
-				thread->type == THREAD_WRITE ? "THREAD_WRITE" :
-				thread->type == THREAD_TIMER ? "THREAD_TIMER" :
-				thread->type == THREAD_EVENT ? "THREAD_EVENT" :
-				thread->type == THREAD_CHILD ? "THREAD_CHILD" :
-				thread->type == THREAD_READY ? "THREAD_READY" :
-				thread->type == THREAD_UNUSED ? "THREAD_UNUSED" :
-				thread->type == THREAD_WRITE_TIMEOUT ? "THREAD_WRITE_TIMEOUT" :
-				thread->type == THREAD_READ_TIMEOUT ? "THREAD_READ_TIMEOUT" :
-				thread->type == THREAD_CHILD_TIMEOUT ? "THREAD_CHILD_TIMEOUT" :
-				thread->type == THREAD_TERMINATE ? "THREAD_TERMINATE" :
-				thread->type == THREAD_READY_FD ? "THREAD_READY_FD" :
-				"unknown");
-
-		fprintf(fp, "    id = %lu\n", thread->id);
-		fprintf(fp, "    union = %d\n", thread->u.val);
-		ctime_r(&thread->sands.tv_sec, time_buf);
-		fprintf(fp, "    sands = %.19s.%6.6lu\n", time_buf, thread->sands.tv_usec);
-		if ((func_name = get_func_name_from_addr(thread->func)))
-			fprintf(fp, "    func = %s()\n", func_name);
-		else
-			fprintf(fp, "    func = %p\n", thread->func);
-	}
-}
-
-static void
-dump_fd_set(FILE *fp, fd_set *fd, const char *type)
-{
-	fprintf(fp, "\n  %s fd_set dump\n", type);
-	fprintf(fp, "    0x%lx\n", __FDS_BITS(fd)[0]);
-}
-
 void
 dump_threads(void)
 {
@@ -1299,41 +1228,44 @@ dump_threads(void)
 	char time_buf[26];
 	element e;
 	vrrp_t *vrrp;
+	char *file_name;
 
-	fp = fopen("/tmp/thread_dump", "a");
+	file_name = make_file_name("/tmp/thread_dump.dat",
+					"vrrp",
+#if HAVE_DECL_CLONE_NEWNET
+					global_data->network_namespace,
+#else
+					NULL,
+#endif
+					global_data->instance_name);
+	fp = fopen(file_name, "a");
+	FREE(file_name);
 
 	set_time_now();
 	ctime_r(&time_now.tv_sec, time_buf);
 
 	fprintf(fp, "\n%.19s.%6.6ld: Thread dump\n", time_buf, time_now.tv_usec);
 
-	dump_thread_list(fp, &master->read, "read");
-	dump_thread_list(fp, &master->write, "write");
-	dump_thread_list(fp, &master->timer, "timer");
-	dump_thread_list(fp, &master->child, "child");
-	dump_thread_list(fp, &master->event, "event");
-	dump_thread_list(fp, &master->ready, "ready");
-	dump_thread_list(fp, &master->unuse, "unuse");
-	dump_fd_set(fp, &master->readfd, "read");
-	dump_fd_set(fp, &master->writefd, "write");
+	dump_thread_data(master, fp);
+
 	fprintf(fp, "alloc = %lu\n", master->alloc);
 
 	fprintf(fp, "\n");
-	for (e = LIST_HEAD(vrrp_data->vrrp); e; ELEMENT_NEXT(e)) {
-		vrrp = ELEMENT_DATA(e);
+	LIST_FOREACH(vrrp_data->vrrp, vrrp, e) {
 		ctime_r(&vrrp->sands.tv_sec, time_buf);
 		fprintf(fp, "VRRP instance %s, sands %.19s.%6.6lu, status %s\n", vrrp->iname, time_buf, vrrp->sands.tv_usec,
 				vrrp->state == VRRP_STATE_INIT ? "INIT" :
 				vrrp->state == VRRP_STATE_BACK ? "BACKUP" :
 				vrrp->state == VRRP_STATE_MAST ? "MASTER" :
 				vrrp->state == VRRP_STATE_FAULT ? "FAULT" :
+				vrrp->state == VRRP_STATE_STOP ? "STOP" :
 				vrrp->state == VRRP_DISPATCHER ? "DISPATCHER" : "unknown");
 	}
 	fclose(fp);
 }
 #endif
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_vrrp_scheduler_addresses(void)
 {

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -435,10 +435,9 @@ vrrp_register_workers(list l)
 		vrrp_init_script(vrrp_data->vrrp_script);
 	}
 
-	add_signal_read_thread();
-
 #ifdef _WITH_BFD_
 	if (!LIST_ISEMPTY(vrrp_data->vrrp)) {
+// TODO - should we only do this if we have track_bfd? Probably not
 		/* Init BFD tracking thread */
 		bfd_thread = thread_add_read(master, vrrp_bfd_thread, NULL,
 					     bfd_vrrp_event_pipe[0], TIMER_NEVER);

--- a/keepalived/vrrp/vrrp_track.c
+++ b/keepalived/vrrp/vrrp_track.c
@@ -1085,3 +1085,11 @@ stop_track_files(void)
 		inotify_fd = -1;
 	}
 }
+
+#ifdef _EPOLL_DEBUG_
+void
+register_vrrp_inotify_addresses(void)
+{
+	register_thread_address("process_inotify", process_inotify);
+}
+#endif

--- a/keepalived/vrrp/vrrp_track.c
+++ b/keepalived/vrrp/vrrp_track.c
@@ -1086,7 +1086,7 @@ stop_track_files(void)
 	}
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_vrrp_inotify_addresses(void)
 {

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -17,10 +17,10 @@ noinst_LIBRARIES	= liblib.a
 
 liblib_a_SOURCES	= memory.c utils.c notify.c timer.c scheduler.c \
 	vector.c list.c html.c parser.c signals.c logger.c assert.c \
-	list_head.c rbtree.c \
+	list_head.c rbtree.c process.c \
 	bitops.h timer.h scheduler.h vector.h parser.h \
 	signals.h notify.h logger.h list.h memory.h html.h utils.h \
-	keepalived_magic.h list_head.h rbtree.h
+	keepalived_magic.h list_head.h rbtree.h process.h
 
 liblib_a_LIBADD		=
 EXTRA_liblib_a_SOURCES	=

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -17,9 +17,10 @@ noinst_LIBRARIES	= liblib.a
 
 liblib_a_SOURCES	= memory.c utils.c notify.c timer.c scheduler.c \
 	vector.c list.c html.c parser.c signals.c logger.c assert.c \
+	list_head.c rbtree.c \
 	bitops.h timer.h scheduler.h vector.h parser.h \
 	signals.h notify.h logger.h list.h memory.h html.h utils.h \
-	keepalived_magic.h
+	keepalived_magic.h list_head.h rbtree.h
 
 liblib_a_LIBADD		=
 EXTRA_liblib_a_SOURCES	=

--- a/lib/list_head.c
+++ b/lib/list_head.c
@@ -1,0 +1,100 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *		In addition it provides a VRRPv2 & VRRPv3 stack.
+ *
+ * Author:      Alexandre Cassen, <acassen@corp.free.fr>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2018 Alexandre Cassen, <acassen@corp.free.fr>
+ */
+
+#include "list_head.h"
+
+void list_sort(struct list_head *head,
+	       int (*cmp)(struct list_head *a, struct list_head *b))
+{
+	struct list_head *p, *q, *e, *list, *tail, *oldhead;
+	int insize, nmerges, psize, qsize, i;
+
+	list = head->next;
+	list_head_del(head);
+	insize = 1;
+
+	while (1) {
+		p = oldhead = list;
+		list = tail = NULL;
+		nmerges = 0;
+
+		while (p) {
+			nmerges++;
+			q = p;
+			psize = 0;
+			for (i = 0; i < insize; i++) {
+				psize++;
+				q = q->next == oldhead ? NULL : q->next;
+				if (!q)
+					break;
+			}
+
+			qsize = insize;
+			while (psize > 0 || (qsize > 0 && q)) {
+				if (!psize) {
+					e = q;
+					q = q->next;
+					qsize--;
+					if (q == oldhead)
+						q = NULL;
+				} else if (!qsize || !q) {
+					e = p;
+					p = p->next;
+					psize--;
+					if (p == oldhead)
+						p = NULL;
+				} else if (cmp(p, q) <= 0) {
+					e = p;
+					p = p->next;
+					psize--;
+					if (p == oldhead)
+						p = NULL;
+				} else {
+					e = q;
+					q = q->next;
+					qsize--;
+					if (q == oldhead)
+						q = NULL;
+				}
+				if (tail)
+					tail->next = e;
+				else
+					list = e;
+				e->prev = tail;
+				tail = e;
+			}
+			p = q;
+		}
+
+		tail->next = list;
+		list->prev = tail;
+
+		if (nmerges <= 1)
+			break;
+
+		insize *= 2;
+	}
+
+	head->next = list;
+	head->prev = list->prev;
+	list->prev->next = head;
+	list->prev = head;
+}

--- a/lib/list_head.h
+++ b/lib/list_head.h
@@ -1,0 +1,574 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *		In addition it provides a VRRPv2 & VRRPv3 stack.
+ *
+ * Author:      Alexandre Cassen, <acassen@corp.free.fr>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2018 Alexandre Cassen, <acassen@corp.free.fr>
+ */
+
+#ifndef _LIST_HEAD_H
+#define _LIST_HEAD_H
+
+#include <stdlib.h>
+#include <stddef.h>
+
+/*
+ * container_of - cast a member of a structure out to the containing structure
+ *
+ * @ptr:	the pointer to the member.
+ * @type:	the type of the container struct this is embedded in.
+ * @member:	the name of the member within the struct.
+ *
+ */
+#ifndef container_of
+# define container_of(ptr, type, member) ({			\
+	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
+	(type *)( (char *)__mptr - offsetof(type,member) );})
+#endif
+
+/*
+ * These are non-NULL pointers that will result in page faults
+ * under normal circumstances, used to verify that nobody uses
+ * non-initialized list entries.
+ */
+#define LIST_POISON1  ((void *) 0x00100100)
+#define LIST_POISON2  ((void *) 0x00200200)
+
+/*
+ * Simple doubly linked list implementation.
+ *
+ * Some of the internal functions ("__xxx") are useful when
+ * manipulating whole lists rather than single entries, as
+ * sometimes we already know the next/prev entries and we can
+ * generate better code by using them directly rather than
+ * using the generic single-entry routines.
+ */
+
+typedef struct list_head {
+	struct list_head *next, *prev;
+} list_head_t;
+
+#define LIST_HEAD_INIT(name) { &(name), &(name) }
+
+// TODO
+#define LH_LIST_HEAD(name) \
+	struct list_head name = LIST_HEAD_INIT(name)
+
+#define INIT_LIST_HEAD(ptr) do { \
+	(ptr)->next = (ptr); (ptr)->prev = (ptr); \
+} while (0)
+
+/*
+ * Insert a new entry between two known consecutive entries.
+ *
+ * This is only for internal list manipulation where we know
+ * the prev/next entries already!
+ */
+static inline void __list_add(struct list_head *new,
+			      struct list_head *prev,
+			      struct list_head *next)
+{
+	next->prev = new;
+	new->next = next;
+	new->prev = prev;
+	prev->next = new;
+}
+
+/**
+ * list_head_add - add a new entry
+ * @new: new entry to be added
+ * @head: list head to add it after
+ *
+ * Insert a new entry after the specified head.
+ * This is good for implementing stacks.
+ */
+static inline void list_head_add(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head, head->next);
+}
+
+// list_head_add_tail
+/**
+ * list_add_tail - add a new entry
+ * @new: new entry to be added
+ * @head: list head to add it before
+ *
+ * Insert a new entry before the specified head.
+ * This is useful for implementing queues.
+ */
+static inline void list_add_tail(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head->prev, head);
+}
+
+/*
+ * Delete a list entry by making the prev/next entries
+ * point to each other.
+ *
+ * This is only for internal list manipulation where we know
+ * the prev/next entries already!
+ */
+static inline void __list_del(struct list_head * prev, struct list_head * next)
+{
+	next->prev = prev;
+	prev->next = next;
+}
+
+/**
+ * list_del - deletes entry from list.
+ * @entry: the element to delete from the list.
+ * Note: list_empty on entry does not return true after this, the entry is
+ * in an undefined state.
+ */
+static inline void list_head_del(struct list_head *entry)
+{
+	__list_del(entry->prev, entry->next);
+	entry->next = LIST_POISON1;
+	entry->prev = LIST_POISON2;
+}
+
+/**
+ * list_del_init - deletes entry from list and reinitialize it.
+ * @entry: the element to delete from the list.
+ */
+static inline void list_del_init(struct list_head *entry)
+{
+	__list_del(entry->prev, entry->next);
+	INIT_LIST_HEAD(entry);
+}
+
+/**
+ * list_move - delete from one list and add as another's head
+ * @list: the entry to move
+ * @head: the head that will precede our entry
+ */
+static inline void list_move(struct list_head *list, struct list_head *head)
+{
+	__list_del(list->prev, list->next);
+	list_head_add(list, head);
+}
+
+/**
+ * list_move_tail - delete from one list and add as another's tail
+ * @list: the entry to move
+ * @head: the head that will follow our entry
+ */
+static inline void list_move_tail(struct list_head *list,
+				  struct list_head *head)
+{
+	__list_del(list->prev, list->next);
+	list_add_tail(list, head);
+}
+
+/**
+ * list_is_first - tests whether @list is the first entry in list @head
+ * @list: the entry to test
+ * @head: the head of the list
+ */
+static inline int list_is_first(const struct list_head *list,
+				const struct list_head *head)
+{
+	return list->prev == head;
+}
+
+/**
+ * list_is_last - tests whether @list is the last entry in list @head
+ * @list: the entry to test
+ * @head: the head of the list
+ */
+static inline int list_is_last(const struct list_head *list,
+			       const struct list_head *head)
+{
+	return list->next == head;
+}
+
+/**
+ * list_empty - tests whether a list is empty
+ * @head: the list to test.
+ */
+static inline int list_empty(const struct list_head *head)
+{
+	return head->next == head;
+}
+
+static inline void __list_splice(struct list_head *list,
+				 struct list_head *head)
+{
+	struct list_head *first = list->next;
+	struct list_head *last = list->prev;
+	struct list_head *at = head->next;
+
+	first->prev = head;
+	head->next = first;
+
+	last->next = at;
+	at->prev = last;
+}
+
+/**
+ * list_splice - join two lists
+ * @list: the new list to add.
+ * @head: the place to add it in the first list.
+ */
+static inline void list_splice(struct list_head *list, struct list_head *head)
+{
+	if (!list_empty(list))
+		__list_splice(list, head);
+}
+
+/**
+ * list_splice_init - join two lists and reinitialise the emptied list.
+ * @list: the new list to add.
+ * @head: the place to add it in the first list.
+ *
+ * The list at @list is reinitialised
+ */
+static inline void list_splice_init(struct list_head *list,
+				    struct list_head *head)
+{
+	if (!list_empty(list)) {
+		__list_splice(list, head);
+		INIT_LIST_HEAD(list);
+	}
+}
+
+/**
+ * list_sort - merge sort elements of a list.
+ * @head: the head of the list.
+ * @cmp: the function used to compare to list nodes.
+ */
+void list_sort(struct list_head *head,
+	       int (*cmp)(struct list_head *a, struct list_head *b));
+
+/**
+ * list_entry - get the struct for this entry
+ * @ptr:	the &struct list_head pointer.
+ * @type:	the type of the struct this is embedded in.
+ * @member:	the name of the list_struct within the struct.
+ */
+#define list_entry(ptr, type, member) \
+	container_of(ptr, type, member)
+
+/**
+ * list_first_entry - get the first element from a list
+ * @ptr:	the list head to take the element from.
+ * @type:	the type of the struct this is embedded in.
+ * @member:	the name of the list_struct within the struct.
+ *
+ * Note, that list is expected to be not empty.
+ */
+#define list_first_entry(ptr, type, member) \
+	list_entry((ptr)->next, type, member)
+
+/**
+ * list_last_entry - get the last element from a list
+ * @ptr:	the list head to take the element from.
+ * @type:	the type of the struct this is embedded in.
+ * @member:	the name of the list_struct within the struct.
+ *
+ * Note, that list is expected to be not empty.
+ */
+#define list_last_entry(ptr, type, member) \
+	list_entry((ptr)->prev, type, member)
+
+
+/**
+ * list_for_each	-	iterate over a list
+ * @pos:	the &struct list_head to use as a loop counter.
+ * @head:	the head for your list.
+ */
+#define list_for_each(pos, head) \
+	for (pos = (head)->next; pos != (head); \
+		pos = pos->next)
+
+// __list_for_each isn't different
+/**
+ * __list_for_each	-	iterate over a list
+ * @pos:	the &struct list_head to use as a loop counter.
+ * @head:	the head for your list.
+ *
+ * This variant differs from list_for_each() in that it's the
+ * simplest possible list iteration code, no prefetching is done.
+ * Use this for code that knows the list to be very short (empty
+ * or 1 entry) most of the time.
+ */
+#define __list_for_each(pos, head) \
+	for (pos = (head)->next; pos != (head); pos = pos->next)
+
+/**
+ * list_for_each_prev	-	iterate over a list backwards
+ * @pos:	the &struct list_head to use as a loop counter.
+ * @head:	the head for your list.
+ */
+#define list_for_each_prev(pos, head) \
+	for (pos = (head)->prev; pos != (head); \
+		pos = pos->prev)
+
+/**
+ * list_for_each_safe	-	iterate over a list safe against removal of list entry
+ * @pos:	the &struct list_head to use as a loop counter.
+ * @n:		another &struct list_head to use as temporary storage
+ * @head:	the head for your list.
+ */
+#define list_for_each_safe(pos, n, head) \
+	for (pos = (head)->next, n = pos->next; pos != (head); \
+		pos = n, n = pos->next)
+
+/**
+ * list_for_each_entry	-	iterate over list of given type
+ * @pos:	the type * to use as a loop counter.
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ */
+#define list_for_each_entry(pos, head, member)				\
+	for (pos = list_entry((head)->next, typeof(*pos), member);	\
+	     &pos->member != (head); 					\
+	     pos = list_entry(pos->member.next, typeof(*pos), member))
+
+/**
+ * list_for_each_entry_reverse - iterate backwards over list of given type.
+ * @pos:	the type * to use as a loop counter.
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ */
+#define list_for_each_entry_reverse(pos, head, member)			\
+	for (pos = list_entry((head)->prev, typeof(*pos), member);	\
+	     &pos->member != (head); 					\
+	     pos = list_entry(pos->member.prev, typeof(*pos), member))
+
+/**
+ * list_for_each_entry_continue -	iterate over list of given type
+ *			continuing after existing point
+ * @pos:	the type * to use as a loop counter.
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ */
+#define list_for_each_entry_continue(pos, head, member) 		\
+	for (pos = list_entry(pos->member.next, typeof(*pos), member);	\
+	     &pos->member != (head);					\
+	     pos = list_entry(pos->member.next, typeof(*pos), member))
+
+/**
+ * list_for_each_entry_continue_reverse - iterate backwards from the given point
+ * @pos:	the type * to use as a loop cursor.
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ *
+ * Start to iterate over list of given type backwards, continuing after
+ * the current position.
+ */
+#define list_for_each_entry_continue_reverse(pos, head, member)		\
+	for (pos = list_entry(pos->member.prev, typeof(*pos), member);	\
+	     &pos->member != (head);					\
+	     pos = list_entry(pos->member.prev, typeof(*pos), member))
+
+/**
+ * list_for_each_entry_from - iterate over list of given type from the current point
+ * @pos:	the type * to use as a loop cursor.
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ *
+ * Iterate over list of given type, continuing from current position.
+ */
+#define list_for_each_entry_from(pos, head, member) 			\
+	for (; &pos->member != (head);					\
+	     pos = list_entry(pos->member.next, typeof(*pos), member))
+
+/**
+ * list_for_each_entry_from - iterate over list of given type from the current point
+ * @pos:	the type * to use as a loop cursor.
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ *
+ * Iterate over list of given type, continuing from current position.
+ */
+#define list_for_each_entry_from_reverse(pos, head, member)		\
+	for (; &pos->member != (head);					\
+	     pos = list_entry(pos->member.prev, typeof(*pos), member))
+
+/**
+ * list_for_each_entry_safe - iterate over list of given type safe against removal of list entry
+ * @pos:	the type * to use as a loop counter.
+ * @n:		another type * to use as temporary storage
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ */
+// Try the alternative
+#define list_for_each_entry_safe(pos, n, head, member)			\
+	for (pos = list_entry((head)->next, typeof(*pos), member),	\
+		n = list_entry(pos->member.next, typeof(*pos), member);	\
+	     &pos->member != (head); 					\
+	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
+
+
+/*
+ * Double linked lists with a single pointer list head.
+ * Mostly useful for hash tables where the two pointer list head is
+ * too wasteful.
+ * You lose the ability to access the tail in O(1).
+ */
+
+typedef struct hlist_head {
+	struct hlist_node *first;
+} hlist_head_t;
+
+typedef struct hlist_node {
+	struct hlist_node *next, **pprev;
+} hlist_node_t;
+
+#define HLIST_HEAD_INIT { .first = NULL }
+#define HLIST_HEAD(name) struct hlist_head name = {  .first = NULL }
+#define INIT_HLIST_HEAD(ptr) ((ptr)->first = NULL)
+#define INIT_HLIST_NODE(ptr) ((ptr)->next = NULL, (ptr)->pprev = NULL)
+
+static __inline__ int hlist_unhashed(const struct hlist_node *h)
+{
+	return !h->pprev;
+}
+
+static __inline__ int hlist_empty(const struct hlist_head *h)
+{
+	return !h->first;
+}
+
+static __inline__ void __hlist_del(struct hlist_node *n)
+{
+	struct hlist_node *next = n->next;
+	struct hlist_node **pprev = n->pprev;
+	*pprev = next;
+	if (next)
+		next->pprev = pprev;
+}
+
+static __inline__ void hlist_del(struct hlist_node *n)
+{
+	__hlist_del(n);
+	n->next = LIST_POISON1;
+	n->pprev = LIST_POISON2;
+}
+
+static __inline__ void hlist_del_init(struct hlist_node *n)
+{
+	if (n->pprev)  {
+		__hlist_del(n);
+		INIT_HLIST_NODE(n);
+	}
+}
+
+static __inline__ void hlist_add_head(struct hlist_node *n, struct hlist_head *h)
+{
+	struct hlist_node *first = h->first;
+	n->next = first;
+	if (first)
+		first->pprev = &n->next;
+	h->first = n;
+	n->pprev = &h->first;
+}
+
+static __inline__ void hlist_add_before(struct hlist_node *n, struct hlist_node *next)
+{
+	n->pprev = next->pprev;
+	n->next = next;
+	next->pprev = &n->next;
+	*(n->pprev) = n;
+}
+
+static __inline__ void hlist_add_after(struct hlist_node *n,
+				       struct hlist_node *next)
+{
+	next->next = n->next;
+	n->next = next;
+	next->pprev = &n->next;
+	if (next->next)
+		next->next->pprev = &next->next;
+}
+
+#define hlist_entry(ptr, type, member) container_of(ptr,type,member)
+
+#define hlist_for_each(pos, head) \
+	for (pos = (head)->first; pos; pos = pos->next)
+
+#define hlist_for_each_safe(pos, n, head) \
+	for (pos = (head)->first; n = pos ? pos->next : 0, pos; \
+	     pos = n)
+
+/**
+ * hlist_for_each_entry	- iterate over list of given type
+ * @tpos:	the type * to use as a loop counter.
+ * @pos:	the &struct hlist_node to use as a loop counter.
+ * @head:	the head for your list.
+ * @member:	the name of the hlist_node within the struct.
+ */
+#define hlist_for_each_entry(tpos, pos, head, member)			 \
+	for (pos = (head)->first;					 \
+	     pos &&							 \
+		({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;}); \
+	     pos = pos->next)
+
+/**
+ * hlist_for_each_entry_continue - iterate over a hlist continuing after existing point
+ * @tpos:	the type * to use as a loop counter.
+ * @pos:	the &struct hlist_node to use as a loop counter.
+ * @member:	the name of the hlist_node within the struct.
+ */
+#define hlist_for_each_entry_continue(tpos, pos, member)		 \
+	for (pos = (pos)->next;						 \
+	     pos &&							 \
+		({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;}); \
+	     pos = pos->next)
+
+/**
+ * hlist_for_each_entry_from - iterate over a hlist continuing from existing point
+ * @tpos:	the type * to use as a loop counter.
+ * @pos:	the &struct hlist_node to use as a loop counter.
+ * @member:	the name of the hlist_node within the struct.
+ */
+#define hlist_for_each_entry_from(tpos, pos, member)			 \
+	for (; pos &&							 \
+		({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;}); \
+	     pos = pos->next)
+
+/**
+ * hlist_for_each_entry_safe - iterate over list of given type safe against removal of list entry
+ * @tpos:	the type * to use as a loop counter.
+ * @pos:	the &struct hlist_node to use as a loop counter.
+ * @n:		another &struct hlist_node to use as temporary storage
+ * @head:	the head for your list.
+ * @member:	the name of the hlist_node within the struct.
+ */
+#define hlist_for_each_entry_safe(tpos, pos, n, head, member) 		 \
+	for (pos = (head)->first;					 \
+	     pos && ({ n = pos->next; 1; }) && 				 \
+		({ tpos = hlist_entry(pos, typeof(*tpos), member); 1;}); \
+	     pos = n)
+
+#define hlist_insert_sorted(tpos, ntpos, pos, head, smember, hmember, res)	\
+	res = 0;								\
+	tpos = NULL;								\
+	hlist_for_each_entry(tpos, pos, (head), hmember)			\
+		if (ntpos->smember <= tpos->smember)				\
+			break;							\
+	if (tpos) {								\
+		if (ntpos->smember < tpos->smember)				\
+			hlist_add_before(&ntpos->hmember, &tpos->hmember);	\
+		else if (ntpos->smember > tpos->smember)			\
+			hlist_add_after(&tpos->hmember, &ntpos->hmember);	\
+		else								\
+			res = 1;						\
+	} else									\
+		hlist_add_head(&ntpos->hmember, (head));
+
+#endif /* ! _LIST_HEAD_H */

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -66,9 +66,6 @@ close_log_file(void)
 void
 open_log_file(const char *name, const char *prog, const char *namespace, const char *instance)
 {
-	const char *extn_start;
-	const char *dir_end;
-	size_t len;
 	char *file_name;
 
 	if (log_file) {
@@ -79,33 +76,7 @@ open_log_file(const char *name, const char *prog, const char *namespace, const c
 	if (!name)
 		return;
 
-	len = strlen(name);
-	if (prog)
-		len += strlen(prog) + 1;
-	if (namespace)
-		len += strlen(namespace) + 1;
-	if (instance)
-		len += strlen(instance) + 1;
-
-	file_name = MALLOC(len + 1);
-	dir_end = strrchr(name, '/');
-	extn_start = strrchr(dir_end ? dir_end : name, '.');
-	strncpy(file_name, name, extn_start ? (size_t)(extn_start - name) : len);
-
-	if (prog) {
-		strcat(file_name, "_");
-		strcat(file_name, prog);
-	}
-	if (namespace) {
-		strcat(file_name, "_");
-		strcat(file_name, namespace);
-	}
-	if (instance) {
-		strcat(file_name, "_");
-		strcat(file_name, instance);
-	}
-	if (extn_start)
-		strcat(file_name, extn_start);
+	file_name = make_file_name(name, prog, namespace, instance);
 
 	log_file = fopen(file_name, "a");
 	if (log_file) {

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -37,7 +37,7 @@
 /* Local defines */
 #ifdef _MEM_CHECK_
 
-#define MAX_ALLOC_LIST 2048*4*4
+#define MAX_ALLOC_LIST 2048*4*4 *2
 
 #define MALLOC(n)    ( keepalived_malloc((n), \
 		      (__FILE__), (char *)(__FUNCTION__), (__LINE__)) )

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -37,6 +37,7 @@
 /* Local defines */
 #ifdef _MEM_CHECK_
 
+/* Max used for 1000 VRRP instance each with VMAC interfaces is 33589 */
 #define MAX_ALLOC_LIST 2048*4*4 *2
 
 #define MALLOC(n)    ( keepalived_malloc((n), \

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -1178,7 +1178,7 @@ notify_script_compare(notify_script_t *a, notify_script_t *b)
 	return true;
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_notify_addresses(void)
 {

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -417,7 +417,7 @@ child_killed_thread(thread_t *thread)
 
 	/* If all children have died, we can now complete the
 	 * termination process */
-	if (!m->child.count && !m->shutdown_timer_running)
+	if (!&m->child.rb_node && !m->shutdown_timer_running)
 		thread_add_terminate_event(m);
 
 	return 0;
@@ -441,7 +441,7 @@ script_killall(thread_master_t *m, int signo, bool requeue)
 
 	p_pgid = getpgid(0);
 
-	for (thread = m->child.head; thread; thread = thread->next) {
+	rb_for_each_entry(thread, &m->child, n) {
 		c_pgid = getpgid(thread->u.c.pid);
 		if (c_pgid != p_pgid)
 			kill(-c_pgid, signo);

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -1176,3 +1176,11 @@ notify_script_compare(notify_script_t *a, notify_script_t *b)
 
 	return true;
 }
+
+#ifdef _EPOLL_DEBUG_
+void
+register_notify_addresses(void)
+{
+	register_thread_address("child_killed_thread", child_killed_thread);
+}
+#endif

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -39,6 +39,7 @@
 #include "signals.h"
 #include "logger.h"
 #include "utils.h"
+#include "process.h"
 #include "parser.h"
 #include "keepalived_magic.h"
 #include "scheduler.h"
@@ -162,7 +163,7 @@ notify_fifo_exec(thread_master_t *m, int (*func) (thread_t *), void *arg, notify
 	int retval;
 	char *scr;
 
-	pid = fork();
+	pid = local_fork();
 
 	/* In case of fork is error. */
 	if (pid < 0) {
@@ -350,7 +351,7 @@ notify_exec(const notify_script_t *script)
 	if (log_file_name)
 		flush_log_file();
 
-	pid = fork();
+	pid = local_fork();
 
 	if (pid < 0) {
 		/* fork error */
@@ -382,7 +383,7 @@ system_call_script(thread_master_t *m, int (*func) (thread_t *), void * arg, uns
 	if (log_file_name)
 		flush_log_file();
 
-	pid = fork();
+	pid = local_fork();
 
 	if (pid < 0) {
 		/* fork error */

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -106,7 +106,7 @@ extern notify_script_t* notify_script_init(int, const char *);
 extern void add_script_param(notify_script_t *, char *);
 extern void notify_resource_release(void);
 extern bool notify_script_compare(notify_script_t *, notify_script_t *);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_notify_addresses(void);
 #endif
 

--- a/lib/notify.h
+++ b/lib/notify.h
@@ -106,4 +106,8 @@ extern notify_script_t* notify_script_init(int, const char *);
 extern void add_script_param(notify_script_t *, char *);
 extern void notify_resource_release(void);
 extern bool notify_script_compare(notify_script_t *, notify_script_t *);
+#ifdef _EPOLL_DEBUG_
+extern void register_notify_addresses(void);
+#endif
+
 #endif

--- a/lib/process.h
+++ b/lib/process.h
@@ -24,6 +24,7 @@
 #define _PROCESS_H
 
 #include <sys/types.h>
+#include <sys/resource.h>
 
 #if HAVE_DECL_RLIMIT_RTTIME == 1
 #define	RT_RLIMIT_DEFAULT	10000
@@ -38,5 +39,7 @@ extern void set_process_priorities(
 #endif
 				   int, int);
 extern void reset_process_priorities(void);
+extern void set_child_rlimit(int, struct rlimit *);
+extern pid_t local_fork(void);
 
 #endif

--- a/lib/rbtree.c
+++ b/lib/rbtree.c
@@ -1,0 +1,384 @@
+/*
+  Red Black Trees
+  (C) 1999  Andrea Arcangeli <andrea@suse.de>
+  (C) 2002  David Woodhouse <dwmw2@infradead.org>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  linux/lib/rbtree.c
+*/
+
+#include <stdlib.h>
+#include "rbtree.h"
+
+static void __rb_rotate_left(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *right = node->rb_right;
+	struct rb_node *parent = rb_parent(node);
+
+	if ((node->rb_right = right->rb_left))
+		rb_set_parent(right->rb_left, node);
+	right->rb_left = node;
+
+	rb_set_parent(right, parent);
+
+	if (parent)
+	{
+		if (node == parent->rb_left)
+			parent->rb_left = right;
+		else
+			parent->rb_right = right;
+	}
+	else
+		root->rb_node = right;
+	rb_set_parent(node, right);
+}
+
+static void __rb_rotate_right(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *left = node->rb_left;
+	struct rb_node *parent = rb_parent(node);
+
+	if ((node->rb_left = left->rb_right))
+		rb_set_parent(left->rb_right, node);
+	left->rb_right = node;
+
+	rb_set_parent(left, parent);
+
+	if (parent)
+	{
+		if (node == parent->rb_right)
+			parent->rb_right = left;
+		else
+			parent->rb_left = left;
+	}
+	else
+		root->rb_node = left;
+	rb_set_parent(node, left);
+}
+
+void rb_insert_color(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *parent, *gparent;
+
+	while ((parent = rb_parent(node)) && rb_is_red(parent))
+	{
+		gparent = rb_parent(parent);
+
+		if (parent == gparent->rb_left)
+		{
+			{
+				register struct rb_node *uncle = gparent->rb_right;
+				if (uncle && rb_is_red(uncle))
+				{
+					rb_set_black(uncle);
+					rb_set_black(parent);
+					rb_set_red(gparent);
+					node = gparent;
+					continue;
+				}
+			}
+
+			if (parent->rb_right == node)
+			{
+				register struct rb_node *tmp;
+				__rb_rotate_left(parent, root);
+				tmp = parent;
+				parent = node;
+				node = tmp;
+			}
+
+			rb_set_black(parent);
+			rb_set_red(gparent);
+			__rb_rotate_right(gparent, root);
+		} else {
+			{
+				register struct rb_node *uncle = gparent->rb_left;
+				if (uncle && rb_is_red(uncle))
+				{
+					rb_set_black(uncle);
+					rb_set_black(parent);
+					rb_set_red(gparent);
+					node = gparent;
+					continue;
+				}
+			}
+
+			if (parent->rb_left == node)
+			{
+				register struct rb_node *tmp;
+				__rb_rotate_right(parent, root);
+				tmp = parent;
+				parent = node;
+				node = tmp;
+			}
+
+			rb_set_black(parent);
+			rb_set_red(gparent);
+			__rb_rotate_left(gparent, root);
+		}
+	}
+
+	rb_set_black(root->rb_node);
+}
+
+static void __rb_erase_color(struct rb_node *node, struct rb_node *parent,
+			     struct rb_root *root)
+{
+	struct rb_node *other;
+
+	while ((!node || rb_is_black(node)) && node != root->rb_node)
+	{
+		if (parent->rb_left == node)
+		{
+			other = parent->rb_right;
+			if (rb_is_red(other))
+			{
+				rb_set_black(other);
+				rb_set_red(parent);
+				__rb_rotate_left(parent, root);
+				other = parent->rb_right;
+			}
+			if ((!other->rb_left || rb_is_black(other->rb_left)) &&
+			    (!other->rb_right || rb_is_black(other->rb_right)))
+			{
+				rb_set_red(other);
+				node = parent;
+				parent = rb_parent(node);
+			}
+			else
+			{
+				if (!other->rb_right || rb_is_black(other->rb_right))
+				{
+					rb_set_black(other->rb_left);
+					rb_set_red(other);
+					__rb_rotate_right(other, root);
+					other = parent->rb_right;
+				}
+				rb_set_color(other, rb_color(parent));
+				rb_set_black(parent);
+				rb_set_black(other->rb_right);
+				__rb_rotate_left(parent, root);
+				node = root->rb_node;
+				break;
+			}
+		}
+		else
+		{
+			other = parent->rb_left;
+			if (rb_is_red(other))
+			{
+				rb_set_black(other);
+				rb_set_red(parent);
+				__rb_rotate_right(parent, root);
+				other = parent->rb_left;
+			}
+			if ((!other->rb_left || rb_is_black(other->rb_left)) &&
+			    (!other->rb_right || rb_is_black(other->rb_right)))
+			{
+				rb_set_red(other);
+				node = parent;
+				parent = rb_parent(node);
+			}
+			else
+			{
+				if (!other->rb_left || rb_is_black(other->rb_left))
+				{
+					rb_set_black(other->rb_right);
+					rb_set_red(other);
+					__rb_rotate_left(other, root);
+					other = parent->rb_left;
+				}
+				rb_set_color(other, rb_color(parent));
+				rb_set_black(parent);
+				rb_set_black(other->rb_left);
+				__rb_rotate_right(parent, root);
+				node = root->rb_node;
+				break;
+			}
+		}
+	}
+	if (node)
+		rb_set_black(node);
+}
+
+void rb_erase(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *child, *parent;
+	int color;
+
+	if (!node->rb_left)
+		child = node->rb_right;
+	else if (!node->rb_right)
+		child = node->rb_left;
+	else
+	{
+		struct rb_node *old = node, *left;
+
+		node = node->rb_right;
+		while ((left = node->rb_left) != NULL)
+			node = left;
+		child = node->rb_right;
+		parent = rb_parent(node);
+		color = rb_color(node);
+
+		if (child)
+			rb_set_parent(child, parent);
+		if (parent == old) {
+			parent->rb_right = child;
+			parent = node;
+		} else
+			parent->rb_left = child;
+
+		node->rb_parent_color = old->rb_parent_color;
+		node->rb_right = old->rb_right;
+		node->rb_left = old->rb_left;
+
+		if (rb_parent(old))
+		{
+			if (rb_parent(old)->rb_left == old)
+				rb_parent(old)->rb_left = node;
+			else
+				rb_parent(old)->rb_right = node;
+		} else
+			root->rb_node = node;
+
+		rb_set_parent(old->rb_left, node);
+		if (old->rb_right)
+			rb_set_parent(old->rb_right, node);
+		goto color;
+	}
+
+	parent = rb_parent(node);
+	color = rb_color(node);
+
+	if (child)
+		rb_set_parent(child, parent);
+	if (parent)
+	{
+		if (parent->rb_left == node)
+			parent->rb_left = child;
+		else
+			parent->rb_right = child;
+	}
+	else
+		root->rb_node = child;
+
+ color:
+	if (color == RB_BLACK)
+		__rb_erase_color(child, parent, root);
+}
+
+/*
+ * This function returns the first node (in sort order) of the tree.
+ */
+struct rb_node *rb_first(const struct rb_root *root)
+{
+	struct rb_node	*n;
+
+	n = root->rb_node;
+	if (!n)
+		return NULL;
+	while (n->rb_left)
+		n = n->rb_left;
+	return n;
+}
+
+struct rb_node *rb_last(const struct rb_root *root)
+{
+	struct rb_node	*n;
+
+	n = root->rb_node;
+	if (!n)
+		return NULL;
+	while (n->rb_right)
+		n = n->rb_right;
+	return n;
+}
+
+struct rb_node *rb_next(const struct rb_node *node)
+{
+	struct rb_node *parent;
+
+	if (!node || rb_parent(node) == node)
+		return NULL;
+
+	/* If we have a right-hand child, go down and then left as far
+	   as we can. */
+	if (node->rb_right) {
+		node = node->rb_right;
+		while (node->rb_left)
+			node=node->rb_left;
+		return (struct rb_node *)node;
+	}
+
+	/* No right-hand children.  Everything down and left is
+	   smaller than us, so any 'next' node must be in the general
+	   direction of our parent. Go up the tree; any time the
+	   ancestor is a right-hand child of its parent, keep going
+	   up. First time it's a left-hand child of its parent, said
+	   parent is our 'next' node. */
+	while ((parent = rb_parent(node)) && node == parent->rb_right)
+		node = parent;
+
+	return parent;
+}
+
+struct rb_node *rb_prev(const struct rb_node *node)
+{
+	struct rb_node *parent;
+
+	if (rb_parent(node) == node)
+		return NULL;
+
+	/* If we have a left-hand child, go down and then right as far
+	   as we can. */
+	if (node->rb_left) {
+		node = node->rb_left;
+		while (node->rb_right)
+			node=node->rb_right;
+		return (struct rb_node *)node;
+	}
+
+	/* No left-hand children. Go up till we find an ancestor which
+	   is a right-hand child of its parent */
+	while ((parent = rb_parent(node)) && node == parent->rb_left)
+		node = parent;
+
+	return parent;
+}
+
+void rb_replace_node(struct rb_node *victim, struct rb_node *new,
+		     struct rb_root *root)
+{
+	struct rb_node *parent = rb_parent(victim);
+
+	/* Set the surrounding nodes to point to the replacement */
+	if (parent) {
+		if (victim == parent->rb_left)
+			parent->rb_left = new;
+		else
+			parent->rb_right = new;
+	} else {
+		root->rb_node = new;
+	}
+	if (victim->rb_left)
+		rb_set_parent(victim->rb_left, new);
+	if (victim->rb_right)
+		rb_set_parent(victim->rb_right, new);
+
+	/* Copy the pointers/colour from the victim to the replacement */
+	*new = *victim;
+}

--- a/lib/rbtree.h
+++ b/lib/rbtree.h
@@ -1,0 +1,324 @@
+/*
+  Red Black Trees
+  (C) 1999  Andrea Arcangeli <andrea@suse.de>
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  linux/include/linux/rbtree.h
+
+  To use rbtrees you'll have to implement your own insert and search cores.
+  This will avoid us to use callbacks and to drop drammatically performances.
+  I know it's not the cleaner way,  but in C (not in C++) to get
+  performances and genericity...
+
+  Some example of insert and search follows here. The search is a plain
+  normal search over an ordered tree. The insert instead must be implemented
+  int two steps: as first thing the code must insert the element in
+  order as a red leaf in the tree, then the support library function
+  rb_insert_color() must be called. Such function will do the
+  not trivial work to rebalance the rbtree if necessary.
+
+-----------------------------------------------------------------------
+static inline struct page * rb_search_page_cache(struct inode * inode,
+						 unsigned long offset)
+{
+	struct rb_node * n = inode->i_rb_page_cache.rb_node;
+	struct page * page;
+
+	while (n)
+	{
+		page = rb_entry(n, struct page, rb_page_cache);
+
+		if (offset < page->offset)
+			n = n->rb_left;
+		else if (offset > page->offset)
+			n = n->rb_right;
+		else
+			return page;
+	}
+	return NULL;
+}
+
+static inline struct page * __rb_insert_page_cache(struct inode * inode,
+						   unsigned long offset,
+						   struct rb_node * node)
+{
+	struct rb_node ** p = &inode->i_rb_page_cache.rb_node;
+	struct rb_node * parent = NULL;
+	struct page * page;
+
+	while (*p)
+	{
+		parent = *p;
+		page = rb_entry(parent, struct page, rb_page_cache);
+
+		if (offset < page->offset)
+			p = &(*p)->rb_left;
+		else if (offset > page->offset)
+			p = &(*p)->rb_right;
+		else
+			return page;
+	}
+
+	rb_link_node(node, parent, p);
+
+	return NULL;
+}
+
+static inline struct page * rb_insert_page_cache(struct inode * inode,
+						 unsigned long offset,
+						 struct rb_node * node)
+{
+	struct page * ret;
+	if ((ret = __rb_insert_page_cache(inode, offset, node)))
+		goto out;
+	rb_insert_color(node, &inode->i_rb_page_cache);
+ out:
+	return ret;
+}
+-----------------------------------------------------------------------
+*/
+
+#ifndef	_LINUX_RBTREE_H
+#define	_LINUX_RBTREE_H
+
+typedef struct rb_node
+{
+	unsigned long  rb_parent_color;
+#define	RB_RED		0
+#define	RB_BLACK	1
+	struct rb_node *rb_right;
+	struct rb_node *rb_left;
+} rb_node_t;
+
+typedef struct rb_root
+{
+	struct rb_node *rb_node;
+} rb_root_t;
+
+/* Copy from linux kernel 2.6 source (kernel.h, stddef.h) */
+#ifndef container_of
+# define container_of(ptr, type, member) ({      \
+         const typeof( ((type *)0)->member ) *__mptr = (ptr);  \
+         (type *)( (char *)__mptr - offsetof(type,member) );})
+#endif
+
+#ifndef offsetof
+# define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#endif
+
+
+#define rb_parent(r)   ((struct rb_node *)((r)->rb_parent_color & ~3))
+#define rb_color(r)   ((r)->rb_parent_color & 1)
+#define rb_is_red(r)   (!rb_color(r))
+#define rb_is_black(r) rb_color(r)
+#define rb_set_red(r)  do { (r)->rb_parent_color &= ~1; } while (0)
+#define rb_set_black(r)  do { (r)->rb_parent_color |= 1; } while (0)
+
+static inline void rb_set_parent(struct rb_node *rb, struct rb_node *p)
+{
+	rb->rb_parent_color = (rb->rb_parent_color & 3) | (unsigned long)p;
+}
+static inline void rb_set_color(struct rb_node *rb, int color)
+{
+	rb->rb_parent_color = (rb->rb_parent_color & ~1) | color;
+}
+
+#define RB_ROOT	(struct rb_root) { NULL, }
+#define	rb_entry(ptr, type, member) (ptr) ? container_of(ptr, type, member) : NULL
+
+#define RB_EMPTY_ROOT(root)	((root)->rb_node == NULL)
+#define RB_EMPTY_NODE(node)	(rb_parent(node) == node)
+#define RB_CLEAR_NODE(node)	(rb_set_parent(node, node))
+
+extern void rb_insert_color(struct rb_node *, struct rb_root *);
+extern void rb_erase(struct rb_node *, struct rb_root *);
+
+/* Find logical next and previous nodes in a tree */
+extern struct rb_node *rb_next(const struct rb_node *);
+extern struct rb_node *rb_prev(const struct rb_node *);
+extern struct rb_node *rb_first(const struct rb_root *);
+extern struct rb_node *rb_last(const struct rb_root *);
+
+/* Fast replacement of a single node without remove/rebalance/add/rebalance */
+extern void rb_replace_node(struct rb_node *victim, struct rb_node *new,
+			    struct rb_root *root);
+
+static inline void rb_link_node(struct rb_node * node, struct rb_node * parent,
+				struct rb_node ** rb_link)
+{
+	node->rb_parent_color = (unsigned long )parent;
+	node->rb_left = node->rb_right = NULL;
+
+	*rb_link = node;
+}
+
+/**
+ * rb_search -  Search for a specific value in rbtree
+ * @root:       the rbtree root.
+ * @key:        the key to seach for in your rbtree.
+ * @member:     the name of the rb_node within the struct.
+ * @compar:     the name of the comparison function to use.
+ */
+#define rb_search(root, key, member, compar)                            \
+({                                                                      \
+        rb_node_t *__n = (root)->rb_node;                               \
+        typeof(key) __ret = NULL, __data;                               \
+                                                                        \
+        while (__n) {                                                   \
+                __data = rb_entry(__n, typeof(*key), member);           \
+                int __cmp = compar(key, __data);                        \
+                                                                        \
+                if (__cmp < 0)                                          \
+                        __n = __n->rb_left;                             \
+                else if (__cmp > 0)                                     \
+                        __n = __n->rb_right;                            \
+                else {                                                  \
+                        __ret = __data;                                 \
+                        break;                                          \
+                }                                                       \
+        }                                                               \
+        __ret;                                                          \
+})
+
+/**
+ * rb_search_first -  Search for the first greater value in rbtree
+ * @root:             the rbtree root.
+ * @key:              the key to seach for in your rbtree.
+ * @member:           the name of the rb_node within the struct.
+ * @compar:           the name of the comparison function to use.
+ */
+#define rb_search_first(root, key, member, compar)		\
+({                                                                      \
+        rb_node_t *__n = (root)->rb_node;				\
+        typeof(key) __ret = NULL, __data;                               \
+                                                                        \
+        while (__n) {                                                   \
+                __data = rb_entry(__n, typeof(*key), member);           \
+                int __cmp = compar(key, __data);                        \
+                                                                        \
+                if (__cmp < 0) {                                        \
+                        __ret = __data;                                 \
+                        __n = __n->rb_left;                             \
+                } else if (__cmp > 0)                                   \
+                        __n = __n->rb_right;                            \
+                else {                                                  \
+                        __ret = __data;                                 \
+                        break;                                          \
+                }                                                       \
+        }                                                               \
+        if (!__ret && !RB_EMPTY_ROOT(root))                             \
+                __ret = rb_entry(rb_first(root), typeof(*key), member); \
+        __ret;                                                          \
+})
+
+/**
+ * rb_insert -  Insert a new node into your rbtree
+ * @root:       the rbtree root.
+ * @new:        the node to insert.
+ * @member:     the name of the rb_node within the struct.
+ * @compar:     the name of the comparison function to use.
+ */
+#define rb_insert(root, new, member, compar)                            \
+({                                                                      \
+        rb_node_t **__n = &(root)->rb_node, *__parent = NULL;           \
+        typeof(new) __old = NULL, __data;                               \
+                                                                        \
+        while (*__n) {                                                  \
+                __data = rb_entry(*__n, typeof(*new), member);          \
+                int __cmp = compar(new, __data);                        \
+                                                                        \
+                __parent = *__n;                                        \
+                if (__cmp < 0)                                          \
+                        __n = &((*__n)->rb_left);                       \
+                else if (__cmp > 0)                                     \
+                        __n = &((*__n)->rb_right);                      \
+                else {                                                  \
+                        __old = __data;                                 \
+                        break;                                          \
+                }                                                       \
+        }                                                               \
+                                                                        \
+        if (__old == NULL) {                                            \
+                /* Add new node and rebalance tree. */                  \
+                rb_link_node(&((new)->member), __parent, __n);          \
+                rb_insert_color(&((new)->member), root);                \
+        }                                                               \
+                                                                        \
+        __old;                                                          \
+})
+
+/**
+ * rb_insert -  Insert & Sort a new node into your rbtree
+ * @root:       the rbtree root.
+ * @new:        the node to insert.
+ * @member:     the name of the rb_node within the struct.
+ * @compar:     the name of the comparison function to use.
+ */
+#define rb_insert_sort(root, new, member, compar)				\
+({									\
+        rb_node_t **__n = &(root)->rb_node, *__parent = NULL;		\
+        typeof(new) __data;						\
+									\
+        while (*__n) {							\
+                __data = rb_entry(*__n, typeof(*new), member);		\
+                int __cmp = compar(new, __data);			\
+									\
+                __parent = *__n;					\
+                if (__cmp <= 0)						\
+                        __n = &((*__n)->rb_left);			\
+                else if (__cmp > 0)					\
+                        __n = &((*__n)->rb_right);			\
+        }								\
+									\
+	/* Add new node and rebalance tree. */				\
+	rb_link_node(&((new)->member), __parent, __n);			\
+	rb_insert_color(&((new)->member), root);			\
+})
+
+/**
+ * rb_for_each_entry -  Iterate over rbtree of given type
+ * @pos:                the type * to use as a loop cursor.
+ * @root:               the rbtree root.
+ * @member:             the name of the rb_node within the struct.
+ */
+#define rb_for_each_entry(pos, root, member)				\
+	for (pos = rb_entry(rb_first(root), typeof(*pos), member);	\
+	     pos; pos = rb_entry(rb_next(&pos->member), typeof(*pos), member))
+
+/**
+ * rb_for_each_entry_safe -  Iterate over rbtree of given type safe against removal
+ * @pos:                     the type * to use as a loop cursor.
+ * @root:                    the rbtree root.
+ * @member:                  the name of the rb_node within the struct.
+ */
+#define rb_for_each_entry_safe(pos, n, root, member)				\
+	for (pos = rb_entry(rb_first(root), typeof(*pos), member);		\
+	     pos && (n = rb_entry(rb_next(&pos->member), typeof(*n), member), 1);	\
+	     pos = n)
+
+/**
+ * rb_for_each_entry_from -  Iterate over rbtree of given type from the given point
+ * @pos:                     the type * to use as a loop cursor.
+ * @root:                    the rbtree root.
+ * @member:                  the name of the rb_node within the struct.
+ */
+#define rb_for_each_entry_from(pos, root, member)			\
+	for (rb_node_t *n = &pos->member;				\
+	     n && pos = rb_entry(n, typeof(*pos), member);		\
+	     n = rb_next(n))
+
+
+#endif	/* _LINUX_RBTREE_H */

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -1524,8 +1524,13 @@ thread_rb_move_ready(thread_master_t *m, rb_root_t *root, int type)
 	thread_t *thread, *thread_tmp;
 
 	rb_for_each_entry_safe(thread, thread_tmp, root, n) {
-		if (thread->sands.tv_sec != TIMER_DISABLED && timercmp(&time_now, &thread->sands, >=))
+		if (thread->sands.tv_sec != TIMER_DISABLED && timercmp(&time_now, &thread->sands, >=)) {
+			if (type == THREAD_READ_TIMEOUT)
+				thread->event->read = NULL;
+			else if (type == THREAD_WRITE_TIMEOUT)
+				thread->event->write = NULL;
 			thread_move_ready(m, root, thread, type);
+		}
 	}
 
 	return 0;

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -1520,11 +1520,16 @@ thread_cancel(thread_t *thread)
 		 */
 		rb_erase(&thread->n, &m->child);
 		break;
-	case THREAD_EVENT:
-	case THREAD_READY:
 	case THREAD_READY_FD:
 	case THREAD_READ_TIMEOUT:
 	case THREAD_WRITE_TIMEOUT:
+		if (thread->event) {
+			rb_erase(&thread->event->n, &m->io_events);
+			FREE(thread->event);
+		}
+		/* ... falls through ... */
+	case THREAD_EVENT:
+	case THREAD_READY:
 	case THREAD_CHILD_TIMEOUT:
 		list_head_del(&thread->next);
 		break;

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -67,7 +67,6 @@ typedef struct _func_det {
 } func_det_t;
 #endif
 
-
 /* global vars */
 thread_master_t *master = NULL;
 #ifndef _DEBUG_
@@ -313,7 +312,7 @@ thread_timerfd_handler(thread_t *thread)
 	if (len < 0)
 		log_message(LOG_ERR, "scheduler: Error reading on timerfd fd:%d (%m)", m->timer_fd);
 
-	/* Read, Write, Timer thead. */
+	/* Read, Write, Timer, Child thread. */
 	thread_rb_move_ready(m, &m->read, THREAD_READ_TIMEOUT);
 	thread_rb_move_ready(m, &m->write, THREAD_WRITE_TIMEOUT);
 	thread_rb_move_ready(m, &m->timer, THREAD_READY);
@@ -1839,11 +1838,11 @@ process_threads(thread_master_t *m)
 		/* If we are shutting down, and the shutdown timer is not running and
 		 * all children have terminated, then we can terminate */
 		if (shutting_down && !m->shutdown_timer_running && !m->child.rb_node)
-			return;
+			break;
 
 		/* If daemon hanging event is received stop processing */
 		if (thread_type == THREAD_TERMINATE)
-			return;
+			break;
 	}
 }
 

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -1319,7 +1319,7 @@ thread_add_timer(thread_master_t *m, int (*func) (thread_t *), void *arg, unsign
 	return thread;
 }
 
-static void
+void
 timer_thread_update_timeout(thread_t *thread, unsigned long timer)
 {
 	timeval_t sands;

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -87,13 +87,6 @@ static rb_root_t funcs = RB_ROOT;
 #endif
 
 
-#ifdef _WITH_LVS_
-#include "../keepalived/include/check_daemon.h"
-#endif
-#ifdef _WITH_VRRP_
-#include "../keepalived/include/vrrp_daemon.h"
-#endif
-
 /* Function that returns prog_name if pid is a known child */
 static char const * (*child_finder_name)(pid_t);
 

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -119,6 +119,9 @@ get_thread_type_str(thread_type_t id)
 	if (id == THREAD_WRITE_ERROR) return "WRITE_ERROR";
 	if (id == THREAD_IF_UP) return "IF_UP";
 	if (id == THREAD_IF_DOWN) return "IF_DOWN";
+#ifdef USE_SIGNAL_THREADS
+	if (id == THREAD_SIGNAL) return "SIGNAL";
+#endif
 
 	return "unknown";
 }

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -650,7 +650,7 @@ thread_event_set(thread_t *thread)
 	return 0;
 }
 
-int
+static int
 thread_event_cancel(thread_t *thread)
 {
 	thread_event_t *event = thread->event;
@@ -1238,6 +1238,19 @@ thread_del_write(thread_t *thread)
 		return -1;
 
 	return 0;
+}
+
+void
+thread_close_fd(thread_t *thread)
+{
+	if (thread->u.fd == -1)
+		return;
+
+	if (thread->event)
+		thread_event_cancel(thread);
+
+	close(thread->u.fd);
+	thread->u.fd = -1;
 }
 
 /* Add timer event thread. */

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -571,7 +571,9 @@ thread_events_resize(thread_master_t *m, int delta)
 	new_size = ((m->epoll_count / THREAD_EPOLL_REALLOC_THRESH) + 1);
 	new_size *= THREAD_EPOLL_REALLOC_THRESH;
 
-	m->epoll_events = REALLOC(m->epoll_events, new_size * sizeof(struct epoll_event));
+	if (m->epoll_events)
+		FREE(m->epoll_events);
+	m->epoll_events = MALLOC(new_size * sizeof(struct epoll_event));
 	if (!m->epoll_events) {
 		m->epoll_size = 0;
 		return -1;
@@ -929,6 +931,10 @@ thread_cleanup_master(thread_master_t * m)
 
 	/* Clean garbage */
 	thread_clean_unuse(m);
+
+	FREE(m->epoll_events);
+	m->epoll_size = 0;
+	m->epoll_count = 0;
 }
 
 /* Stop thread scheduler. */

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -39,10 +39,13 @@
 #include <errno.h>
 #include <sys/wait.h>
 #include <sys/timerfd.h>
+#include <sys/epoll.h>
 #include <unistd.h>
 #ifdef HAVE_SIGNALFD
 #include <sys/signalfd.h>
 #endif
+#include <sys/utsname.h>
+#include <linux/version.h>
 
 #include "scheduler.h"
 #include "memory.h"
@@ -51,8 +54,9 @@
 #include "logger.h"
 #include "bitops.h"
 #include "git-commit.h"
-#include <sys/utsname.h>
-#include <linux/version.h>
+#if !HAVE_EPOLL_CREATE1 || !defined TFD_NONBLOCK
+#include "old_socket.h"
+#endif
 
 /* global vars */
 thread_master_t *master = NULL;
@@ -85,7 +89,116 @@ static void (*child_remover)(thread_t *);
 static void (*child_finder_destroy)(void);
 static size_t child_finder_list_size;
 
-static int thread_timerfd_handler(thread_t *);
+#ifdef _TIMER_DEBUG_
+static const char *
+get_thread_type_str(thread_type_t id)
+{
+	if (id == THREAD_READ) return "READ";
+	if (id == THREAD_WRITE) return "WRITE";
+	if (id == THREAD_TIMER) return "TIMER";
+	if (id == THREAD_EVENT) return "EVENT";
+	if (id == THREAD_CHILD) return "CHILD";
+	if (id == THREAD_READY) return "READY";
+	if (id == THREAD_UNUSED) return "UNUSED";
+	if (id == THREAD_WRITE_TIMEOUT) return "WRITE_TIMEOUT";
+	if (id == THREAD_READ_TIMEOUT) return "READ_TIMEOUT";
+	if (id == THREAD_CHILD_TIMEOUT) return "CHILD_TIMEOUT";
+	if (id == THREAD_TERMINATE) return "TERMINATE";
+	if (id == THREAD_READY_FD) return "READY_FD";
+
+	return "unknown";
+}
+#endif
+
+/* Update timer value */
+static void
+thread_update_timer(rb_root_t *root, timeval_t *timer_min)
+{
+	thread_t *first;
+
+	if (!root->rb_node)
+		return;
+
+	first = rb_entry(rb_first(root), thread_t, n);
+	if (!first)
+		return;
+
+	if (first->sands.tv_sec == TIMER_DISABLED)
+		return;
+
+	if (!timerisset(timer_min) ||
+	    timercmp(&first->sands, timer_min, <=))
+		*timer_min = first->sands;
+}
+
+/* Compute the wait timer. Take care of timeouted fd */
+static void
+thread_set_timer(thread_master_t *m)
+{
+	timeval_t timer_wait;
+	struct itimerspec its;
+
+	/* Prepare timer */
+	timerclear(&timer_wait);
+	thread_update_timer(&m->timer, &timer_wait);
+	thread_update_timer(&m->write, &timer_wait);
+	thread_update_timer(&m->read, &timer_wait);
+	thread_update_timer(&m->child, &timer_wait);
+
+	if (timerisset(&timer_wait)) {
+		/* Re-read the current time to get the maximum accuracy */
+		set_time_now();
+
+		/* Take care about monotonic clock */
+		timersub(&timer_wait, &time_now, &timer_wait);
+
+		if (timer_wait.tv_sec < 0) {
+			/* This will disable the timerfd */
+			timerclear(&timer_wait);
+		}
+	} else {
+		/* set timer to a VERY long time */
+		timer_wait.tv_sec = LONG_MAX;
+		timer_wait.tv_usec = 0;
+	}
+
+	its.it_value.tv_sec = timer_wait.tv_sec;
+	if (!timerisset(&timer_wait)) {
+		/* We really want to avoid doing the select since
+		 * testing shows it takes about 13 microseconds
+		 * for the timer to expire. */
+		its.it_value.tv_nsec = 1;
+	}
+	else
+		its.it_value.tv_nsec = timer_wait.tv_usec * 1000;
+
+	/* We don't want periodic timer expiry */
+	its.it_interval.tv_sec = its.it_interval.tv_nsec = 0;
+
+	timerfd_settime(m->timer_fd, 0, &its, NULL);
+
+#ifdef _EPOLL_DEBUG_
+	if (prog_type == PROG_TYPE_VRRP)
+		log_message(LOG_INFO, "setting timer_fd %lu.%9.9ld", its.it_value.tv_sec, its.it_value.tv_nsec);
+#endif
+}
+
+static int
+thread_timerfd_handler(thread_t *thread)
+{
+	thread_master_t *m = thread->master;
+	uint64_t expired;
+	ssize_t len;
+
+	len = read(m->timer_fd, &expired, sizeof(expired));
+	if (len < 0)
+		log_message(LOG_ERR, "scheduler: Error reading on timerfd fd:%d (%m)", m->timer_fd);
+
+	/* Register next timerfd thread */
+	m->timer_thread = thread_add_read(m, thread_timerfd_handler, NULL, m->timer_fd, TIMER_NEVER);
+
+	return 0;
+}
 
 static size_t
 get_pid_hash(pid_t pid)
@@ -109,8 +222,7 @@ default_child_finder(pid_t pid)
 	if (LIST_ISEMPTY(l))
 		return NULL;
 
-	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
-		thread = ELEMENT_DATA(e);
+	LIST_FOREACH(l, thread, e) {
 		if (thread->u.c.pid == pid)
 			return thread;
 	}
@@ -357,6 +469,155 @@ report_child_status(int status, pid_t pid, char const *prog_name)
 }
 #endif
 
+/* epoll related */
+static int
+thread_events_resize(thread_master_t *m, int delta)
+{
+	unsigned int new_size;
+
+	m->epoll_count += delta;
+	if (m->epoll_count < m->epoll_size)
+		return 0;
+
+	new_size = ((m->epoll_count / THREAD_EPOLL_REALLOC_THRESH) + 1);
+	new_size *= THREAD_EPOLL_REALLOC_THRESH;
+
+	m->epoll_events = REALLOC(m->epoll_events, new_size * sizeof(struct epoll_event));
+	if (!m->epoll_events) {
+		m->epoll_size = 0;
+		return -1;
+	}
+
+	m->epoll_size = new_size;
+	return 0;
+}
+
+static inline int
+thread_event_cmp(const thread_event_t *event1, const thread_event_t *event2)
+{
+	if (event1->fd < event2->fd)
+		return -1;
+	if (event1->fd > event2->fd)
+		return 1;
+	return 0;
+}
+
+static thread_event_t *
+thread_event_new(thread_master_t *m, int fd)
+{
+	thread_event_t *event;
+
+	event = (thread_event_t *) MALLOC(sizeof(thread_event_t));
+	if (!event)
+		return NULL;
+
+	if (thread_events_resize(m, 1) < 0) {
+		FREE(event);
+		return NULL;
+	}
+
+	event->fd = fd;
+
+	rb_insert_sort(&m->io_events, event, n, thread_event_cmp);
+
+	return event;
+}
+
+static thread_event_t *
+thread_event_get(thread_master_t *m, int fd)
+{
+	thread_event_t event = { .fd = fd };
+
+	return rb_search(&m->io_events, &event, n, thread_event_cmp);
+}
+
+static int
+thread_event_set(thread_t *thread)
+{
+	thread_event_t *event = thread->event;
+	thread_master_t *m = thread->master;
+	struct epoll_event ev;
+	int op = EPOLL_CTL_ADD;
+
+	memset(&ev, 0, sizeof(struct epoll_event));
+	ev.data.ptr = event;
+	if (__test_bit(THREAD_FL_READ_BIT, &event->flags))
+		ev.events |= EPOLLIN | EPOLLHUP | EPOLLERR;
+
+	if (__test_bit(THREAD_FL_WRITE_BIT, &event->flags))
+		ev.events |= EPOLLOUT;
+
+	if (__test_bit(THREAD_FL_EPOLL_BIT, &event->flags))
+		op = EPOLL_CTL_MOD;
+
+	if (epoll_ctl(m->epoll_fd, op, event->fd, &ev) < 0) {
+		log_message(LOG_INFO, "scheduler: Error performing control on EPOLL instance (%m)");
+		return -1;
+	}
+
+	__set_bit(THREAD_FL_EPOLL_BIT, &event->flags);
+	return 0;
+}
+
+int
+thread_event_cancel(thread_t *thread)
+{
+	thread_event_t *event = thread->event;
+	thread_master_t *m = thread->master;
+
+	if (!event) {
+		log_message(LOG_INFO, "scheduler: Error performing DEL op no event linked?!");
+		return -1;
+	}
+
+	if (m->epoll_fd != -1 && epoll_ctl(m->epoll_fd, EPOLL_CTL_DEL, event->fd, NULL) < 0) {
+		log_message(LOG_INFO, "scheduler: Error performing DEL op for fd:%d (%m)", event->fd);
+		return -1;
+	}
+
+	rb_erase(&event->n, &m->io_events);
+	m->current_event = NULL;
+	thread->event = NULL;
+	FREE(event);
+	return 0;
+}
+
+static int
+thread_event_del(thread_t *thread, unsigned flag)
+{
+	thread_event_t *event = thread->event;
+	int ret;
+
+	if (flag == THREAD_FL_EPOLL_READ_BIT &&
+	    __test_bit(THREAD_FL_EPOLL_READ_BIT, &event->flags)) {
+		__clear_bit(THREAD_FL_READ_BIT, &event->flags);
+		if (!__test_bit(THREAD_FL_EPOLL_WRITE_BIT, &event->flags))
+			return thread_event_cancel(thread);
+
+		ret = thread_event_set(thread);
+		if (ret < 0)
+			return -1;
+		event->read = NULL;
+		__clear_bit(THREAD_FL_EPOLL_READ_BIT, &event->flags);
+		return 0;
+	}
+
+	if (flag == THREAD_FL_EPOLL_WRITE_BIT &&
+		   __test_bit(THREAD_FL_EPOLL_WRITE_BIT, &event->flags)) {
+		__clear_bit(THREAD_FL_WRITE_BIT, &event->flags);
+		if (!__test_bit(THREAD_FL_EPOLL_READ_BIT, &event->flags))
+			return thread_event_cancel(thread);
+
+		ret = thread_event_set(thread);
+		if (ret < 0)
+			return -1;
+		event->write = NULL;
+		__clear_bit(THREAD_FL_EPOLL_WRITE_BIT, &event->flags);
+	}
+
+	return 0;
+}
+
 /* Make thread master. */
 thread_master_t *
 thread_make_master(void)
@@ -364,6 +625,32 @@ thread_make_master(void)
 	thread_master_t *new;
 
 	new = (thread_master_t *) MALLOC(sizeof (thread_master_t));
+
+#if HAVE_EPOLL_CREATE1
+	new->epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+#else
+	new->epoll_fd = epoll_create(0);
+#endif
+	if (new->epoll_fd < 0) {
+		log_message(LOG_INFO, "scheduler: Error creating EPOLL instance (%m)");
+		FREE(new);
+		return NULL;
+	}
+
+#if !HAVE_EPOLL_CREATE1
+	if (set_sock_flags(new->epoll_fd, F_SETFD, FD_CLOEXEC))
+		log_message(LOG_INFO, "Unable to set CLOEXEC on epoll_fd - %s (%d)", strerror(errno), errno);
+#endif
+
+	new->read = RB_ROOT;
+	new->write = RB_ROOT;
+	new->timer = RB_ROOT;
+	new->child = RB_ROOT;
+	new->io_events = RB_ROOT;
+	INIT_LIST_HEAD(&new->event);
+	INIT_LIST_HEAD(&new->signal);
+	INIT_LIST_HEAD(&new->ready);
+	INIT_LIST_HEAD(&new->unuse);
 
 	/* Register timerfd thread */
 	new->timer_fd = timerfd_create(CLOCK_MONOTONIC,
@@ -387,135 +674,118 @@ thread_make_master(void)
 		log_message(LOG_INFO, "Unable to set CLOEXEC on timer_fd - %s (%d)", strerror(errno), errno);
 #endif
 
-	thread_add_read(new, thread_timerfd_handler, NULL, new->timer_fd, TIMER_NEVER);
+	signal_handler_init();
+
+	new->timer_thread = thread_add_read(new, thread_timerfd_handler, NULL, new->timer_fd, TIMER_NEVER);
+
+	add_signal_read_thread(new);
 
 	return new;
 }
 
-/* Add a new thread to the list. */
-static void
-thread_list_add(thread_list_t * list, thread_t * thread)
+/* Dump rbtree */
+int
+thread_rb_dump(rb_root_t *root, const char *tree)
 {
-	thread->next = NULL;
-	thread->prev = list->tail;
-	if (list->tail)
-		list->tail->next = thread;
-	else
-		list->head = thread;
-	list->tail = thread;
-	list->count++;
+	thread_t *thread;
+	int i = 1;
+
+	log_message(LOG_INFO, "----[ Begin rb_dump %s ]----", tree);
+	rb_for_each_entry(thread, root, n)
+		log_message(LOG_INFO, "#%.2d Thread timer: %lu.%6.6ld", i++, thread->sands.tv_sec, thread->sands.tv_usec);
+	log_message(LOG_INFO, "----[ End rb_dump ]----");
+
+	return 0;
 }
 
-/* Add a new thread to the list. */
-static void
-thread_list_add_before(thread_list_t * list, thread_t * point, thread_t * thread)
+int
+thread_list_dump(list_head_t *l, const char *list)
 {
-	thread->next = point;
-	thread->prev = point->prev;
-	if (point->prev)
-		point->prev->next = thread;
-	else
-		list->head = thread;
-	point->prev = thread;
-	list->count++;
-}
+	thread_t *thread;
+	int i = 1;
 
-/* Add a thread in the list sorted by timeval */
-static void
-thread_list_add_timeval(thread_list_t * list, thread_t * thread)
-{
-	thread_t *tt;
-
-	if (thread->sands.tv_sec == TIMER_DISABLED) {
-		thread_list_add(list, thread);
-		return;
+	log_message(LOG_INFO, "----[ Begin list_dump %s ]----", list);
+	list_for_each_entry(thread, l, next) {
+		log_message(LOG_INFO, "#%.2d Thread:%p id:%ld sands: %lu.%6.6ld",
+		       i++, thread, thread->id, thread->sands.tv_sec, thread->sands.tv_usec);
+//		if (i > 10) break;
 	}
+	log_message(LOG_INFO, "----[ End list_dump ]----");
 
-	for (tt = list->head; tt; tt = tt->next) {
-		if (tt->sands.tv_sec == TIMER_DISABLED || timercmp(&thread->sands, &tt->sands, <=))
-			break;
+	return 0;
+}
+
+/* Timer cmp helper */
+static int
+thread_timer_cmp(thread_t *t1, thread_t *t2)
+{
+	if (t1->sands.tv_sec != t2->sands.tv_sec) {
+		if (t1->sands.tv_sec == TIMER_DISABLED)
+			return 1;
+		if (t2->sands.tv_sec == TIMER_DISABLED)
+			return -1;
+		return t1->sands.tv_sec - t2->sands.tv_sec;
 	}
-
-	if (tt)
-		thread_list_add_before(list, tt, thread);
-	else
-		thread_list_add(list, thread);
-}
-
-/* Delete a thread from the list. */
-static thread_t *
-thread_list_delete(thread_list_t * list, thread_t * thread)
-{
-	if (thread->next)
-		thread->next->prev = thread->prev;
-	else
-		list->tail = thread->prev;
-	if (thread->prev)
-		thread->prev->next = thread->next;
-	else
-		list->head = thread->next;
-	thread->next = thread->prev = NULL;
-	list->count--;
-	return thread;
-}
-
-static void
-thread_list_make_ready(thread_list_t *list, thread_t *thread, thread_master_t *m, thread_type_t type)
-{
-	thread_list_delete(list, thread);
-	thread->type = type;
-	thread_list_add(&m->ready, thread);
+	return t1->sands.tv_usec - t2->sands.tv_usec;
 }
 
 /* Free all unused thread. */
 static void
 thread_clean_unuse(thread_master_t * m)
 {
-	thread_t *thread;
+	thread_t *thread, *thread_tmp;
+	list_head_t *l = &m->unuse;
 
-	thread = m->unuse.head;
-	while (thread) {
-		thread_t *t;
-
-		t = thread;
-		thread = t->next;
-
-		thread_list_delete(&m->unuse, t);
+	list_for_each_entry_safe(thread, thread_tmp, l, next) {
+		list_head_del(&thread->next);
 
 		/* free the thread */
-		FREE(t);
+		FREE(thread);
 		m->alloc--;
 	}
+
+	INIT_LIST_HEAD(l);
 }
 
 /* Move thread to unuse list. */
 static void
-thread_add_unuse(thread_master_t * m, thread_t * thread)
+thread_add_unuse(thread_master_t *m, thread_t *thread)
 {
 	assert(m != NULL);
-	assert(thread->next == NULL);
-	assert(thread->prev == NULL);
 	assert(thread->type == THREAD_UNUSED);
-	thread_list_add(&m->unuse, thread);
+	thread->event = NULL;
+	INIT_LIST_HEAD(&thread->next);
+	list_add_tail(&thread->next, &m->unuse);
 }
 
 /* Move list element to unuse queue */
 static void
-thread_destroy_list(thread_master_t *m, thread_list_t *thread_list)
+thread_destroy_list(thread_master_t *m, list_head_t *l)
 {
-	thread_t *thread;
+	thread_t *thread, *thread_tmp;
 
-	thread = thread_list->head;
+	list_for_each_entry_safe(thread, thread_tmp, l, next) {
+		if (thread->event) {
+			thread_del_read(thread);
+			thread_del_write(thread);
+		}
+		list_head_del(&thread->next);
+		thread->type = THREAD_UNUSED;
+		INIT_LIST_HEAD(&thread->next);
+		list_add_tail(&thread->next, &m->unuse);
+	}
+}
 
-	while (thread) {
-		thread_t *t;
+static void
+thread_destroy_rb(thread_master_t *m, rb_root_t *root)
+{
+	thread_t *thread, *thread_tmp;
 
-		t = thread;
-		thread = t->next;
-
-		thread_list_delete(thread_list, t);
-		t->type = THREAD_UNUSED;
-		thread_add_unuse(m, t);
+	rb_for_each_entry_safe(thread, thread_tmp, root, n) {
+		rb_erase(&thread->n, root);
+		thread->type = THREAD_UNUSED;
+		INIT_LIST_HEAD(&thread->next);
+		list_add_tail(&thread->next, &m->unuse);
 	}
 }
 
@@ -524,89 +794,126 @@ void
 thread_cleanup_master(thread_master_t * m)
 {
 	/* Unuse current thread lists */
-	thread_destroy_list(m, &m->read);
-	thread_destroy_list(m, &m->write);
-	thread_destroy_list(m, &m->timer);
-	thread_destroy_list(m, &m->child);
+	thread_destroy_rb(m, &m->read);
+	thread_destroy_rb(m, &m->write);
+	thread_destroy_rb(m, &m->timer);
+	thread_destroy_rb(m, &m->child);
 	thread_destroy_list(m, &m->event);
+	thread_destroy_list(m, &m->signal);
 	thread_destroy_list(m, &m->ready);
 
 	destroy_child_finder();
 
-	/* Clear all FDs */
-	FD_ZERO(&m->readfd);
-	FD_ZERO(&m->writefd);
-
 	/* Clean garbage */
 	thread_clean_unuse(m);
-
-	memset(m, 0, sizeof(*m));
 }
 
 /* Stop thread scheduler. */
 void
 thread_destroy_master(thread_master_t * m)
 {
-	if (m->timer_fd)
+	if (m->epoll_fd != -1) {
+		close(m->epoll_fd);
+		m->epoll_fd = -1;
+	}
+
+	if (m->timer_fd != -1)
 		close(m->timer_fd);
 
+	if (signal_rfd() != -1)
+		signal_handler_destroy();
+
 	thread_cleanup_master(m);
+
 	FREE(m);
 }
 
 /* Delete top of the list and return it. */
 static thread_t *
-thread_trim_head(thread_list_t * list)
+thread_trim_head(list_head_t *l)
 {
-	if (list->head)
-		return thread_list_delete(list, list->head);
-	return NULL;
+	thread_t *thread;
+
+	if (list_empty(l))
+		return NULL;
+
+	thread = list_first_entry(l, thread_t, next);
+	list_del_init(&thread->next);
+	return thread;
 }
 
 /* Make new thread. */
 static thread_t *
-thread_new(thread_master_t * m)
+thread_new(thread_master_t *m)
 {
 	thread_t *new;
 
 	/* If one thread is already allocated return it */
-	if (m->unuse.head) {
-		new = thread_trim_head(&m->unuse);
-		memset(new, 0, sizeof (thread_t));
+	new = thread_trim_head(&m->unuse);
+	if (new) {
+	//	memset(new, 0, sizeof(thread_t));
+		INIT_LIST_HEAD(&new->next);
 		return new;
 	}
 
-	new = (thread_t *) MALLOC(sizeof (thread_t));
+	new = (thread_t *) MALLOC(sizeof(thread_t));
+	INIT_LIST_HEAD(&new->next);
 	m->alloc++;
 	return new;
 }
 
 /* Add new read thread. */
 thread_t *
-thread_add_read(thread_master_t * m, int (*func) (thread_t *)
-		, void *arg, int fd, unsigned long timer)
+thread_add_read(thread_master_t *m, int (*func) (thread_t *), void *arg, int fd, unsigned long timer)
 {
+	thread_event_t *event;
 	thread_t *thread;
+	int ret;
 
 	assert(m != NULL);
 
-	if (FD_ISSET(fd, &m->readfd)) {
-		log_message(LOG_WARNING, "There is already read fd [%d]", fd);
+	/* I feel lucky ! :D */
+	if (m->current_event && m->current_event->fd == fd) {
+		event = m->current_event;
+		goto update;
+	}
+
+	event = thread_event_get(m, fd);
+	if (event && __test_bit(THREAD_FL_READ_BIT, &event->flags) && event->read) {
+		log_message(LOG_INFO, "scheduler: There is already read event %p (read %p) registered on fd [%d]", event, event->read, fd);
 		return NULL;
 	}
 
+	if (!event) {
+		event = thread_event_new(m, fd);
+		if (!event) {
+			log_message(LOG_INFO, "scheduler: Cant allocate read event for fd [%d](%m)", fd);
+			return NULL;
+		}
+	}
+
+  update:
 	thread = thread_new(m);
 	thread->type = THREAD_READ;
-	thread->id = 0;
 	thread->master = m;
 	thread->func = func;
 	thread->arg = arg;
-	FD_SET(fd, &m->readfd);
 	thread->u.fd = fd;
+	thread->event = event;
 
-	/* Ensure we can be efficient with select */
-	if (fd > m->max_fd)
-		m->max_fd = fd;
+	/* Set & flag event */
+	__set_bit(THREAD_FL_READ_BIT, &event->flags);
+	event->read = thread;
+	if (!__test_bit(THREAD_FL_EPOLL_READ_BIT, &event->flags)) {
+		ret = thread_event_set(thread);
+		if (ret < 0) {
+			log_message(LOG_INFO, "scheduler: Cant register read event for fd [%d](%m)", fd);
+			thread->type = THREAD_UNUSED;
+			thread_add_unuse(m, thread);
+			return NULL;
+		}
+		__set_bit(THREAD_FL_EPOLL_READ_BIT, &event->flags);
+	}
 
 	/* Compute read timeout value */
 	if (timer == TIMER_NEVER)
@@ -617,38 +924,76 @@ thread_add_read(thread_master_t * m, int (*func) (thread_t *)
 	}
 
 	/* Sort the thread. */
-	thread_list_add_timeval(&m->read, thread);
+	rb_insert_sort(&m->read, thread, n, thread_timer_cmp);
 
 	return thread;
+}
+
+int
+thread_del_read(thread_t *thread)
+{
+	thread_event_t *event;
+	int ret;
+
+	if (!thread)
+		return -1;
+
+	event = thread->event;
+	if (!event)
+		return -1;
+
+	ret = thread_event_del(thread, THREAD_FL_EPOLL_READ_BIT);
+	if (ret < 0)
+		return -1;
+
+	return 0;
+}
+
+static void
+thread_del_read_fd(thread_master_t *m, int fd)
+{
+	thread_event_t *event;
+
+	event = thread_event_get(m, fd);
+	if (!event || !event->read)
+		return;
+
+	thread_del_read(event->read);
 }
 
 static void
 thread_read_requeue(thread_master_t *m, int fd, timeval_t new_sands)
 {
-	thread_t *tt;
-	thread_t *insert = NULL;
+	thread_t *thread;
+	thread_t *prev, *next;
+	rb_node_t *prev_node, *next_node;
+	thread_event_t *event;
 
-	for (tt = m->read.head; tt; tt = tt->next) {
-		if (!insert && timercmp(&new_sands, &tt->sands, <=))
-			insert = tt;
-		if (tt->u.fd == fd)
-			break;
-	}
-
-	if (!tt)
+	event = thread_event_get(m, fd);
+	if (!event || !event->read)
 		return;
 
-	tt->sands = new_sands;
+	thread = event->read;
 
-	if (tt == insert)
+	thread->sands = new_sands;
+
+	prev_node = rb_prev(&thread->n);
+	next_node = rb_next(&thread->n);
+
+	if (!prev_node && !next_node)
 		return;
 
-	thread_list_delete(&m->read, tt);
+	prev = rb_entry(prev_node, thread_t, n);
+	next = rb_entry(next_node, thread_t, n);
 
-	if (insert)
-		thread_list_add_before(&m->read, insert, tt);
-	else
-		thread_list_add_timeval(&m->read, tt);
+	/* If new timer is between our predecessor and sucessor, it can stay where it is */
+	if ((!prev || timercmp(&prev->sands, &new_sands, <=)) &&
+	    (!next || timercmp(&next->sands, &new_sands, >=)))
+		return;
+
+	/* Can this be optimised? */
+	rb_erase(&thread->n, &thread->master->read);
+	rb_insert_sort(&thread->master->read, thread, n, thread_timer_cmp);
 }
 
 void
@@ -661,30 +1006,56 @@ thread_requeue_read(thread_master_t *m, int fd, unsigned long timer)
 
 /* Add new write thread. */
 thread_t *
-thread_add_write(thread_master_t * m, int (*func) (thread_t *)
-		 , void *arg, int fd, unsigned long timer)
+thread_add_write(thread_master_t *m, int (*func) (thread_t *), void *arg, int fd, unsigned long timer)
 {
+	thread_event_t *event;
 	thread_t *thread;
+	int ret;
 
 	assert(m != NULL);
 
-	if (FD_ISSET(fd, &m->writefd)) {
-		log_message(LOG_WARNING, "There is already write fd [%d]", fd);
+	/* I feel lucky ! :D */
+	if (m->current_event && m->current_event->fd == fd) {
+		event = m->current_event;
+		goto update;
+	}
+
+	event = thread_event_get(m, fd);
+	if (event && __test_bit(THREAD_FL_WRITE_BIT, &event->flags) && event->write) {
+		log_message(LOG_INFO, "scheduler: There is already write event registered on fd [%d]", fd);
 		return NULL;
 	}
 
+	if (!event) {
+		event = thread_event_new(m, fd);
+		if (!event) {
+			log_message(LOG_INFO, "scheduler: Cant allocate write event for fd [%d](%m)", fd);
+			return NULL;
+		}
+	}
+
+  update:
 	thread = thread_new(m);
 	thread->type = THREAD_WRITE;
-	thread->id = 0;
 	thread->master = m;
 	thread->func = func;
 	thread->arg = arg;
-	FD_SET(fd, &m->writefd);
 	thread->u.fd = fd;
+	thread->event = event;
 
-	/* Ensure we can be efficient with select */
-	if (fd > m->max_fd)
-		m->max_fd = fd;
+	/* Set & flag event */
+	__set_bit(THREAD_FL_WRITE_BIT, &event->flags);
+	event->write = thread;
+	if (!__test_bit(THREAD_FL_EPOLL_WRITE_BIT, &event->flags)) {
+		ret = thread_event_set(thread);
+		if (ret < 0) {
+			log_message(LOG_INFO, "scheduler: Cant register write event for fd [%d](%m)" , fd);
+			thread->type = THREAD_UNUSED;
+			thread_add_unuse(m, thread);
+			return NULL;
+		}
+		__set_bit(THREAD_FL_EPOLL_WRITE_BIT, &event->flags);
+	}
 
 	/* Compute write timeout value */
 	if (timer == TIMER_NEVER)
@@ -695,15 +1066,34 @@ thread_add_write(thread_master_t * m, int (*func) (thread_t *)
 	}
 
 	/* Sort the thread. */
-	thread_list_add_timeval(&m->write, thread);
+	rb_insert_sort(&m->write, thread, n, thread_timer_cmp);
 
 	return thread;
 }
 
+int
+thread_del_write(thread_t *thread)
+{
+	thread_event_t *event;
+	int ret;
+
+	if (!thread)
+		return -1;
+
+	event = thread->event;
+	if (!event)
+		return -1;
+
+	ret = thread_event_del(thread, THREAD_FL_EPOLL_WRITE_BIT);
+	if (ret < 0)
+		return -1;
+
+	return 0;
+}
+
 /* Add timer event thread. */
 thread_t *
-thread_add_timer(thread_master_t * m, int (*func) (thread_t *)
-		 , void *arg, unsigned long timer)
+thread_add_timer(thread_master_t *m, int (*func) (thread_t *), void *arg, unsigned long timer)
 {
 	thread_t *thread;
 
@@ -711,7 +1101,6 @@ thread_add_timer(thread_master_t * m, int (*func) (thread_t *)
 
 	thread = thread_new(m);
 	thread->type = THREAD_TIMER;
-	thread->id = 0;
 	thread->master = m;
 	thread->func = func;
 	thread->arg = arg;
@@ -725,14 +1114,47 @@ thread_add_timer(thread_master_t * m, int (*func) (thread_t *)
 	}
 
 	/* Sort by timeval. */
-	thread_list_add_timeval(&m->timer, thread);
+	rb_insert_sort(&m->timer, thread, n, thread_timer_cmp);
 
 	return thread;
 }
 
+static void
+timer_thread_update_timeout(thread_t *thread, unsigned long timer)
+{
+	timeval_t sands;
+	thread_t *prev, *next;
+	rb_node_t *prev_node, *next_node;
+
+	set_time_now();
+	sands = timer_add_long(time_now, timer);
+
+	if (timercmp(&thread->sands, &sands, ==))
+		return;
+
+	thread->sands = sands;
+
+	prev_node = rb_prev(&thread->n);
+	next_node = rb_next(&thread->n);
+
+	if (!prev_node && !next_node)
+		return;
+
+	prev = rb_entry(prev_node, thread_t, n);
+	next = rb_entry(next_node, thread_t, n);
+
+	/* If new timer is between our predecessor and sucessor, it can stay where it is */
+	if ((!prev || timercmp(&prev->sands, &sands, <=)) &&
+	    (!next || timercmp(&next->sands, &sands, >=)))
+		return;
+
+	/* Can this be optimised? */
+	rb_erase(&thread->n, &thread->master->timer);
+	rb_insert_sort(&thread->master->timer, thread, n, thread_timer_cmp);
+}
+
 thread_t *
-thread_add_timer_shutdown(thread_master_t *m, int(*func)(thread_t *),
-			  void *arg, unsigned long timer)
+thread_add_timer_shutdown(thread_master_t *m, int(*func)(thread_t *), void *arg, unsigned long timer)
 {
 	thread_t *thread = thread_add_timer(m, func, arg, timer);
 
@@ -743,8 +1165,7 @@ thread_add_timer_shutdown(thread_master_t *m, int(*func)(thread_t *),
 
 /* Add a child thread. */
 thread_t *
-thread_add_child(thread_master_t * m, int (*func) (thread_t *)
-		 , void * arg, pid_t pid, unsigned long timer)
+thread_add_child(thread_master_t * m, int (*func) (thread_t *), void * arg, pid_t pid, unsigned long timer)
 {
 	thread_t *thread;
 
@@ -752,7 +1173,6 @@ thread_add_child(thread_master_t * m, int (*func) (thread_t *)
 
 	thread = thread_new(m);
 	thread->type = THREAD_CHILD;
-	thread->id = 0;
 	thread->master = m;
 	thread->func = func;
 	thread->arg = arg;
@@ -768,8 +1188,10 @@ thread_add_child(thread_master_t * m, int (*func) (thread_t *)
 	}
 
 	/* Sort by timeval. */
-	thread_list_add_timeval(&m->child, thread);
+// We may want an rbtree for pid
+	rb_insert_sort(&m->child, thread, n, thread_timer_cmp);
 
+// Do we need this?
 	if (child_adder)
 		child_adder(thread);
 
@@ -781,8 +1203,9 @@ thread_children_reschedule(thread_master_t *m, int (*func)(thread_t *), unsigned
 {
 	thread_t *thread;
 
+// What is this used for ??
 	set_time_now();
-	for (thread = m->child.head; thread; thread = thread->next) {
+	rb_for_each_entry(thread, &m->child, n) {
 		thread->func = func;
 		thread->sands = timer_add_long(time_now, timer);
 	}
@@ -790,8 +1213,7 @@ thread_children_reschedule(thread_master_t *m, int (*func)(thread_t *), unsigned
 
 /* Add simple event thread. */
 thread_t *
-thread_add_event(thread_master_t * m, int (*func) (thread_t *)
-		 , void *arg, int val)
+thread_add_event(thread_master_t * m, int (*func) (thread_t *), void *arg, int val)
 {
 	thread_t *thread;
 
@@ -799,12 +1221,12 @@ thread_add_event(thread_master_t * m, int (*func) (thread_t *)
 
 	thread = thread_new(m);
 	thread->type = THREAD_EVENT;
-	thread->id = 0;
 	thread->master = m;
 	thread->func = func;
 	thread->arg = arg;
 	thread->u.val = val;
-	thread_list_add(&m->event, thread);
+	INIT_LIST_HEAD(&thread->next);
+	list_add_tail(&thread->next, &m->event);
 
 	return thread;
 }
@@ -819,12 +1241,12 @@ thread_add_generic_terminate_event(thread_master_t * m, thread_type_t type, int 
 
 	thread = thread_new(m);
 	thread->type = type;
-	thread->id = 0;
 	thread->master = m;
 	thread->func = func;
 	thread->arg = NULL;
 	thread->u.val = 0;
-	thread_list_add(&m->event, thread);
+	INIT_LIST_HEAD(&thread->next);
+	list_add_tail(&thread->next, &m->event);
 
 	return thread;
 }
@@ -841,80 +1263,97 @@ thread_add_start_terminate_event(thread_master_t *m, int(*func)(thread_t *))
 	return thread_add_generic_terminate_event(m, THREAD_TERMINATE_START, func);
 }
 
-/* Cancel thread from scheduler. */
-int
-thread_cancel(thread_t * thread)
+// TODO
+#if 0
+/* Add signal thread. */
+thread_t *
+thread_add_signal(thread_master_t *m, int (*func) (thread_t *), void *arg, int val)
 {
+	thread_t *thread;
+	sigset_t mask;
+
+	assert(m != NULL);
+
+	thread = thread_new(m);
+	thread->type = THREAD_SIGNAL;
+	thread->master = m;
+	thread->func = func;
+	thread->arg = arg;
+	thread->u.val = val;
+	INIT_LIST_HEAD(&thread->next);
+	list_add_tail(&thread->next, &m->signal);
+
+	/* Update signalfd accordingly */
+	sigemptyset(&mask);
+	sigaddset(&mask, val);
+	sigorset(&mask, &mask, &m->signal_mask);
+	if (!memcmp(&m->signal_mask, &mask, sizeof(mask)))
+		return thread;
+	m->signal_mask = mask;
+	sigprocmask(SIG_BLOCK, &mask, NULL);
+	signalfd(m->signal_fd, &mask, SFD_NONBLOCK);
+
+	return thread;
+}
+#endif
+
+/* Cancel thread from scheduler. */
+void
+thread_cancel(thread_t *thread)
+{
+	thread_master_t *m;
+
 	if (!thread)
-		return -1;
+		return;
+
+	m = thread->master;
 
 	switch (thread->type) {
 	case THREAD_READ:
-		assert(FD_ISSET(thread->u.fd, &thread->master->readfd));
-		FD_CLR(thread->u.fd, &thread->master->readfd);
-		if (thread->master->max_fd == thread->u.fd) {
-			/* Recalculate max_fd */
-			while (thread->master->max_fd &&
-			       !FD_ISSET(thread->master->max_fd, &thread->master->readfd) &&
-			       !FD_ISSET(thread->master->max_fd, &thread->master->writefd))
-				thread->master->max_fd--;
-		}
-		thread_list_delete(&thread->master->read, thread);
+		thread_event_del(thread, THREAD_FL_EPOLL_READ_BIT);
+		rb_erase(&thread->n, &m->read);
 		break;
 	case THREAD_WRITE:
-		assert(FD_ISSET(thread->u.fd, &thread->master->writefd));
-		FD_CLR(thread->u.fd, &thread->master->writefd);
-		if (thread->master->max_fd == thread->u.fd) {
-			/* Recalculate max_fd */
-			while (thread->master->max_fd &&
-			       !FD_ISSET(thread->master->max_fd, &thread->master->readfd) &&
-			       !FD_ISSET(thread->master->max_fd, &thread->master->writefd))
-				thread->master->max_fd--;
-		}
-		thread_list_delete(&thread->master->write, thread);
+		thread_event_del(thread, THREAD_FL_EPOLL_WRITE_BIT);
+		rb_erase(&thread->n, &m->write);
 		break;
 	case THREAD_TIMER:
-		thread_list_delete(&thread->master->timer, thread);
+		rb_erase(&thread->n, &m->timer);
 		break;
 	case THREAD_CHILD:
 		/* Does this need to kill the child, or is that the
 		 * caller's job?
 		 * This function is currently unused, so leave it for now.
 		 */
-		thread_list_delete(&thread->master->child, thread);
+		rb_erase(&thread->n, &m->child);
 		break;
 	case THREAD_EVENT:
-		thread_list_delete(&thread->master->event, thread);
-		break;
 	case THREAD_READY:
 	case THREAD_READY_FD:
 	case THREAD_READ_TIMEOUT:
 	case THREAD_WRITE_TIMEOUT:
 	case THREAD_CHILD_TIMEOUT:
-		thread_list_delete(&thread->master->ready, thread);
+		list_head_del(&thread->next);
 		break;
 	default:
 		break;
 	}
 
 	thread->type = THREAD_UNUSED;
-	thread_add_unuse(thread->master, thread);
-	return 0;
+	thread_add_unuse(m, thread);
 }
 
 void
 thread_cancel_read(thread_master_t *m, int fd)
 {
-	thread_t *thread;
+	thread_t *thread, *thread_tmp;
 
-	thread = m->read.head;
-	while (thread) {
-		thread_t *t = thread;
-		thread = t->next;
-
-		if (t->u.fd == fd) {
-			thread_cancel(t);
-			return;
+	rb_for_each_entry_safe(thread, thread_tmp, &m->read, n) {
+		if (thread->u.fd == fd) {
+			if (thread->event->write)
+				thread_cancel(thread->event->write);
+			thread_cancel(thread);
+			break;
 		}
 	}
 }
@@ -922,339 +1361,326 @@ thread_cancel_read(thread_master_t *m, int fd)
 #ifdef _INCLUDE_UNUSED_CODE_
 /* Delete all events which has argument value arg. */
 void
-thread_cancel_event(thread_master_t * m, void *arg)
+thread_cancel_event(thread_master_t *m, void *arg)
 {
-	thread_t *thread;
+	thread_t *thread, *thread_tmp;
+	list_head_t *l = &m->event;
 
-	thread = m->event.head;
-	while (thread) {
-		thread_t *t;
-
-		t = thread;
-		thread = t->next;
-
-		if (t->arg == arg) {
-			thread_list_delete(&m->event, t);
-			t->type = THREAD_UNUSED;
-			thread_add_unuse(m, t);
+// Why doesn't this use thread_cancel() above
+	list_for_each_entry_safe(thread, thread_tmp, l, next) {
+		if (thread->arg == arg) {
+			list_head_del(&thread->next);
+			thread->type = THREAD_UNUSED;
+			thread_add_unuse(m, thread);
 		}
 	}
 }
 #endif
 
-/* Update timer value */
-static void
-thread_update_timer(thread_list_t *list, timeval_t *timer_min)
-{
-	if (!list->head)
-		return;
-
-	if (list->head->sands.tv_sec == TIMER_DISABLED)
-		return;
-
-	if (!timerisset(timer_min) ||
-	    timercmp(&list->head->sands, timer_min, <=))
-		*timer_min = list->head->sands;
-}
-
-/* Compute the wait timer. Take care of timeouted fd */
-static void
-thread_set_timer(thread_master_t *m)
-{
-	timeval_t timer_wait;
-	struct itimerspec its;
-
-	/* Prepare timer */
-	timerclear(&timer_wait);
-	thread_update_timer(&m->timer, &timer_wait);
-	thread_update_timer(&m->write, &timer_wait);
-	thread_update_timer(&m->read, &timer_wait);
-	thread_update_timer(&m->child, &timer_wait);
-
-	if (timerisset(&timer_wait)) {
-		/* Re-read the current time to get the maximum accuracy */
-		set_time_now();
-
-		/* Take care about monotonic clock */
-		timersub(&timer_wait, &time_now, &timer_wait);
-
-		if (timer_wait.tv_sec < 0) {
-			/* This will disable the timerfd */
-			timerclear(&timer_wait);
-		}
-	} else {
-		/* set timer to a VERY long time */
-		timer_wait.tv_sec = LONG_MAX;
-		timer_wait.tv_usec = 0;
-	}
-
-	its.it_value.tv_sec = timer_wait.tv_sec;
-	if (!timerisset(&timer_wait)) {
-		/* We really want to avoid doing the select since
-		 * testing shows it takes about 13 microseconds
-		 * for the timer to expire. */
-		its.it_value.tv_nsec = 1;
-	}
-	else
-		its.it_value.tv_nsec = timer_wait.tv_usec * 1000;
-
-	/* We don't want periodic timer expiry */
-	its.it_interval.tv_sec = its.it_interval.tv_nsec = 0;
-
-	timerfd_settime(m->timer_fd, 0, &its, NULL);
-
-#ifdef _SELECT_DEBUG_
-	if (prog_type == PROG_TYPE_VRRP)
-		log_message(LOG_INFO, "setting timer_fd %lu.%9.9ld", its.it_value.tv_sec, its.it_value.tv_nsec);
-#endif
-}
-
+/* Move ready thread into ready queue */
 static int
-thread_timerfd_handler(thread_t *thread)
+thread_move_ready(thread_master_t *m, rb_root_t *root, thread_t *thread, int type)
 {
-	thread_master_t *m = thread->master;
-	uint64_t expired;
-	ssize_t len;
+	rb_erase(&thread->n, root);
+	INIT_LIST_HEAD(&thread->next);
+	list_add_tail(&thread->next, &m->ready);
+	if (thread->type != THREAD_TIMER_SHUTDOWN)
+		thread->type = type;
+	return 0;
+}
 
-	len = read(m->timer_fd, &expired, sizeof(expired));
-	if (len < 0)
-		log_message(LOG_ERR, "scheduler: Error reading on timerfd fd:%d (%m)", m->timer_fd);
+/* Move ready thread into ready queue */
+static int
+thread_rb_move_ready(thread_master_t *m, rb_root_t *root, int type)
+{
+	thread_t *thread, *thread_tmp;
 
-	/* Register next timerfd thread */
-	thread_add_read(m, thread_timerfd_handler, NULL, m->timer_fd, TIMER_NEVER);
+	rb_for_each_entry_safe(thread, thread_tmp, root, n) {
+		if (thread->sands.tv_sec != TIMER_DISABLED && timercmp(&time_now, &thread->sands, >=))
+			thread_move_ready(m, root, thread, type);
+	}
 
 	return 0;
 }
 
-/* Fetch next ready thread. */
-static thread_list_t *
-thread_fetch_next_queue(thread_master_t *m)
+#ifdef _WITH_SNMP_
+static int
+snmp_read_thread(thread_t *thread)
 {
-	int num_fds;
-	int sav_errno;
-	int last_select_errno = 0;
-	thread_t *thread;
-	thread_t *t;
-	fd_set readfd;
-	fd_set writefd;
-	int fdsetsize;
-#ifdef _WITH_SNMP_
-	int snmpblock;
-	timeval_t snmp_timer_wait;
+	fd_set snmp_fdset;
+
+	FD_ZERO(&snmp_fdset);
+	FD_SET(thread->u.fd, &snmp_fdset);
+
+	snmp_read(&snmp_fdset);
+	netsnmp_check_outstanding_agent_requests();
+
+	thread_add_read(thread->master, snmp_read_thread, thread->arg, thread->u.fd, TIMER_NEVER);
+
+	return 0;
+}
+
+int
+snmp_timeout_thread(thread_t *thread)
+{
+	snmp_timeout();
+	run_alarms();
+	netsnmp_check_outstanding_agent_requests();
+
+	thread->master->snmp_timer_thread = thread_add_timer(thread->master, snmp_timeout_thread, thread->arg, TIMER_NEVER);
+
+	return 0;
+}
+
+// See https://vincent.bernat.im/en/blog/2012-snmp-event-loop
+static void
+snmp_epoll_info(thread_master_t *m)
+{
+	fd_set snmp_fdset;
+	int fdsetsize = 0;
+	int max_fdsetsize;
+	struct timeval snmp_timer_wait = { .tv_sec = TIMER_DISABLED };
+	int snmpblock = true;
+	unsigned long *old_set, *new_set;	// Must be unsigned for ffsl() to work for us
+	unsigned long diff;
+	int i;
+	int fd;
+	int bit;
+
+#if 0
+// TODO
+#if sizeof fd_mask  != sizeof diff
+#error "snmp_epoll_info sizeof(fd_mask) does not match old_set/new_set/diff"
 #endif
-	bool timer_expired;
-	bool timers_done;
+#endif
 
-	assert(m != NULL);
+	FD_ZERO(&snmp_fdset);
 
-
-	/* If there is event process it first. */
-	if (m->event.head)
-		return &m->event;
-
-	/* If there are ready threads process them */
-	if (m->ready.head)
-		return &m->ready;
-
-retry:
-	/* Calculate and set select wait timer. Take care of timeouted fd.  */
-	thread_set_timer(m);
-
-	/* Call select function. */
-	readfd = m->readfd;
-	writefd = m->writefd;
-
-	/* Recalculate max_fd if necessary */
-	while (!FD_ISSET(m->max_fd, &m->readfd) &&
-	       !FD_ISSET(m->max_fd, &m->writefd) &&
-	       m->max_fd)
-		m->max_fd--;
-
-	fdsetsize = m->max_fd + 1;
-
-#ifdef _WITH_SNMP_
 	/* When SNMP is enabled, we may have to select() on additional
 	 * FD. snmp_select_info() will add them to `readfd'. The trick
 	 * with this function is its last argument. We need to set it
 	 * true to set its own timer that we then compare against ours. */
-	if (snmp_running) {
-		snmpblock = true;
-		snmp_select_info(&fdsetsize, &readfd, &snmp_timer_wait, &snmpblock);
-		if (snmpblock)
-			snmp_timer_wait.tv_sec = LONG_MAX;
+	snmp_select_info(&fdsetsize, &snmp_fdset, &snmp_timer_wait, &snmpblock);
+
+	if (snmpblock)
+		snmp_timer_wait.tv_sec = TIMER_DISABLED;
+	timer_thread_update_timeout(m->snmp_timer_thread, timer_long(snmp_timer_wait));
+
+	max_fdsetsize = m->snmp_fdsetsize > fdsetsize ? m->snmp_fdsetsize : fdsetsize;
+	if (!max_fdsetsize)
+		return;
+
+	for (i = 0, old_set = (unsigned long *)&m->snmp_fdset, new_set = (unsigned long *)&snmp_fdset; i <= max_fdsetsize / (int)sizeof(*new_set); i++, old_set++, new_set++) {
+		if (*old_set == *new_set)
+			continue;
+
+		diff = *old_set ^ *new_set;
+		fd = i * sizeof(*old_set) * CHAR_BIT - 1;
+		do {
+			bit = ffsl(diff);
+			diff >>= bit;
+			fd += bit;
+			if (FD_ISSET(fd, &snmp_fdset)) {
+				/* Add the fd */
+				thread_add_read(m, snmp_read_thread, 0, fd, TIMER_NEVER);
+				FD_SET(fd, &m->snmp_fdset);
+			} else {
+				/* Remove the fd */
+				thread_del_read_fd(m, fd);
+				FD_CLR(fd, &m->snmp_fdset);
+			}
+		} while (diff);
 	}
-	else {
-		snmp_timer_wait.tv_sec = LONG_MAX;
-		snmp_timer_wait.tv_usec = 0;
+	m->snmp_fdsetsize = fdsetsize;
+}
+#endif
+
+/* Fetch next ready thread. */
+static list_head_t *
+thread_fetch_next_queue(thread_master_t *m)
+{
+	int sav_errno;
+	int last_epoll_errno = 0;
+	int ret;
+	int i;
+
+	assert(m != NULL);
+
+	/* If there is event process it first. */
+	if (m->event.next != &m->event)
+		return &m->event;
+
+	/* If there are ready threads process them */
+	if (m->ready.next != &m->ready)
+		return &m->ready;
+
+#if 0	// NEW
+	/* If there is event process it first. */
+	while ((thread = thread_trim_head(&m->event))) {
+		*fetch = *thread;
+		m->current_event = thread->event;
+
+		/* If daemon hanging event is received return NULL pointer */
+		if (thread->type == THREAD_TERMINATE) {
+			thread->type = THREAD_UNUSED;
+			thread_add_unuse(m, thread);
+			return NULL;
+		}
+		thread->type = THREAD_UNUSED;
+		thread_add_unuse(m, thread);
+		return fetch;
+	}
+
+	/* If there is ready threads process them */
+	while ((thread = thread_trim_head(&m->ready))) {
+		*fetch = *thread;
+		m->current_event = thread->event;
+		thread->type = THREAD_UNUSED;
+		thread_add_unuse(m, thread);
+		return fetch;
 	}
 #endif
 
-#ifdef _SELECT_DEBUG_
+retry:
+#ifdef _WITH_SNMP_
+	if (snmp_running)
+		snmp_epoll_info(m);
+#endif
+
+	/* Calculate and set select wait timer. Take care of timeouted fd.  */
+	thread_set_timer(m);
+
+#ifdef _EPOLL_DEBUG_
 	if (prog_type == PROG_TYPE_VRRP)
-#ifdef _WITH_SNMP_
-		log_message(LOG_INFO, "select with snmp timer %lu.%6.6ld, fdsetsize %d, readfds 0x%lx", snmp_timer_wait.tv_sec, snmp_timer_wait.tv_usec, fdsetsize, readfd.fds_bits[0]);
-#else
-		log_message(LOG_INFO, "select with fdsetsize %d, readfds 0x%lx", fdsetsize, readfd.fds_bits[0]);
-#endif
+		log_message(LOG_INFO, "calling epoll_wait");
+	thread_rb_dump(&m->read, "read");
+	thread_rb_dump(&m->write, "write");
+	thread_rb_dump(&m->child, "child");
+	thread_rb_dump(&m->timer, "timer");
+	thread_list_dump(&m->event, "event");
+	thread_list_dump(&m->ready, "ready");
+	thread_list_dump(&m->signal, "signal");
+	thread_list_dump(&m->unuse, "unuse");
 #endif
 
-	errno = 0;
-	num_fds = select(fdsetsize, &readfd, &writefd, NULL,
-#ifdef _WITH_SNMP_
-							     &snmp_timer_wait
-#else
-							     NULL
-#endif
-									     );
-
-	/* we have to save errno here because the next syscalls will set it */
+	/* Call epoll function. */
+	ret = epoll_wait(m->epoll_fd, m->epoll_events, m->epoll_count, -1);
 	sav_errno = errno;
 
-#ifdef _SELECT_DEBUG_
+#ifdef _EPOLL_DEBUG_
 	if (prog_type == PROG_TYPE_VRRP)
-#ifdef _WITH_SNMP_
-		log_message(LOG_INFO, "Select returned %d, errno %d, readfd 0x%lx, writefd 0x%lx, timer expired %d, snmp timer %lu.%6.6ld", num_fds, sav_errno, readfd.fds_bits[0], writefd.fds_bits[0], FD_ISSET(m->timer_fd, &readfd), snmp_timer_wait.tv_sec, snmp_timer_wait.tv_usec);
-#else
-		log_message(LOG_INFO, "Select returned %d, errno %d, readfd 0x%lx, writefd 0x%lx, timer expired %d", num_fds, sav_errno, readfd.fds_bits[0], writefd.fds_bits[0], FD_ISSET(m->timer_fd, &readfd));
-#endif
+		log_message(LOG_INFO, "epoll_wait returned %d, errno %d", ret, sav_errno);
 #endif
 
-	if (num_fds < 0) {
+	if (ret < 0) {
 		if (sav_errno == EINTR)
 			goto retry;
 
 		/* Real error. */
-		if (sav_errno != last_select_errno) {
+		if (sav_errno != last_epoll_errno) {
 			/* Log the error first time only */
-			log_message(LOG_INFO, "select error: %s", strerror(sav_errno));
-			last_select_errno = sav_errno;
+			log_message(LOG_INFO, "scheduler: epoll_wait error: %s", strerror(sav_errno));
+			last_epoll_errno = sav_errno;
 		}
 		assert(0);
 
 		/* Make sure we don't sit it a tight loop */
-		if (sav_errno == EINVAL || sav_errno == ENOMEM)
+		if (sav_errno == EBADF || sav_errno == EFAULT || sav_errno == EINVAL)
 			sleep(1);
 
 		goto retry;
 	}
 
-	/* Handle SNMP stuff */
-#ifdef _WITH_SNMP_
-	if (snmp_running) {
-		/* We could optimise this by calling snmp_select_info() BEFORE
-		 * setting the timer and fds we want, so we see what snmp wants.
-		 * We would then know if any of snmp's fds were set */
-		if (num_fds > 0)
-			snmp_read(&readfd);
-		else if (!timerisset(&snmp_timer_wait)) {
-			snmp_timeout();
-			run_alarms();
+	/* Handle epoll events */
+	for (i = 0; i < ret; i++) {
+		struct epoll_event *ep_ev;
+		thread_event_t *ev;
+
+		ep_ev = &m->epoll_events[i];
+		ev = ep_ev->data.ptr;
+
+		/* Error */
+// TODO - no thread processing function handles THREAD_READ_ERROR/THREAD_WRITE_ERROR yet
+		if (ep_ev->events & (EPOLLHUP | EPOLLERR | EPOLLRDHUP)) {
+			if (ev->read) {
+				thread_move_ready(m, &m->read, ev->read, THREAD_READ_ERROR);
+				ev->read = NULL;
+			}
+
+			if (ev->write) {
+				thread_move_ready(m, &m->write, ev->write, THREAD_WRITE_ERROR);
+				ev->write = NULL;
+			}
+
+			continue;
+		}
+
+		/* READ */
+		if (ep_ev->events & EPOLLIN) {
+			if (!ev->read) {
+				log_message(LOG_INFO, "scheduler: No read thread bound on fd:%d (fl:0x%.4X)"
+					      , ev->fd, ep_ev->events);
+				assert(0);
+			}
+			thread_move_ready(m, &m->read, ev->read, THREAD_READY_FD);
+			ev->read = NULL;
+		}
+
+		/* WRITE */
+		if (ep_ev->events & EPOLLOUT) {
+			if (!ev->write) {
+				log_message(LOG_INFO, "scheduler: No write thread bound on fd:%d (fl:0x%.4X)"
+					      , ev->fd, ep_ev->events);
+				assert(0);
+			}
+			thread_move_ready(m, &m->write, ev->write, THREAD_READY_FD);
+			ev->write = NULL;
 		}
 	}
-#endif
-
-	timer_expired = FD_ISSET(m->timer_fd, &readfd);
 
 	/* Update current time */
 	set_time_now();
 
-	if (timer_expired) {
-		/* Timeout children */
-		thread = m->child.head;
-		while (thread) {
-			t = thread;
-			thread = t->next;
-
-			if (t->sands.tv_sec == TIMER_DISABLED)
-				break;
-
-			if (timercmp(&time_now, &t->sands, >=)) {
-				thread_list_make_ready(&m->child, t, m, THREAD_CHILD_TIMEOUT);
-				if (child_remover)
-					child_remover(t);
-			}
-			else
-				break;
-		}
-	}
-
-	/* Read thread. */
-	thread = m->read.head;
-	timers_done = !timer_expired;
-	while (thread && (num_fds || !timers_done)) {
-		t = thread;
-		thread = t->next;
-
-		if (num_fds && FD_ISSET(t->u.fd, &readfd)) {
-			assert(FD_ISSET(t->u.fd, &m->readfd));
-			num_fds--;
-			FD_CLR(t->u.fd, &m->readfd);
-			thread_list_make_ready(&m->read, t, m, THREAD_READY_FD);
-		} else if (!timers_done &&
-			   t->sands.tv_sec != TIMER_DISABLED &&
-			   timercmp(&time_now, &t->sands, >=)) {
-			FD_CLR(t->u.fd, &m->readfd);
-			thread_list_make_ready(&m->read, t, m, THREAD_READ_TIMEOUT);
-		}
-		else
-			timers_done = true;
-	}
-
-	/* Write thread. */
-	thread = m->write.head;
-	timers_done = !timer_expired;
-	while (thread && (num_fds || !timers_done)) {
-		t = thread;
-		thread = t->next;
-
-		if (num_fds && FD_ISSET(t->u.fd, &writefd)) {
-			assert(FD_ISSET(t->u.fd, &writefd));
-			num_fds--;
-			FD_CLR(t->u.fd, &m->writefd);
-			thread_list_make_ready(&m->write, t, m, THREAD_READY_FD);
-		} else if (!timers_done &&
-			   t->sands.tv_sec != TIMER_DISABLED &&
-			   timercmp(&time_now, &t->sands, >=)) {
-			FD_CLR(t->u.fd, &m->writefd);
-			thread_list_make_ready(&m->write, t, m, THREAD_WRITE_TIMEOUT);
-		}
-		else
-			timers_done = true;
-	}
-	/* Exception thead. */
-	/*... */
-
-	/* Timer update. */
-	if (timer_expired) {
-		thread = m->timer.head;
-		while (thread) {
-			t = thread;
-			thread = t->next;
-
-			if (timercmp(&time_now, &t->sands, >=))
-				thread_list_make_ready(&m->timer, t, m, t->type);
-			else
-				break;
-		}
-	}
-
-#ifdef _WITH_SNMP_
-	if (snmp_running)
-		netsnmp_check_outstanding_agent_requests();
-#endif
+	/* Read, Write, Timer thead. */
+	thread_rb_move_ready(m, &m->read, THREAD_READ_TIMEOUT);
+	thread_rb_move_ready(m, &m->write, THREAD_WRITE_TIMEOUT);
+	thread_rb_move_ready(m, &m->timer, THREAD_READY);
+	thread_rb_move_ready(m, &m->child, THREAD_CHILD_TIMEOUT);
 
 	/* There is no ready thread. */
-	if (!m->ready.head)
+	if (m->ready.next == &m->ready)
 		goto retry;
 
 	return &m->ready;
+}
+
+/* Make unique thread id for non pthread version of thread manager. */
+static inline unsigned long
+thread_get_id(thread_master_t *m)
+{
+	return m->id++;
+}
+
+/* Call thread ! */
+static inline void
+thread_call(thread_t * thread)
+{
+#ifdef _TIMER_DEBUG_
+#ifndef _DEBUG_
+	if (prog_type == PROG_TYPE_VRRP)
+#endif
+		log_message(LOG_INFO, "Calling thread function, type %s, addr 0x%p, val/fd/pid %d, status %d", get_thread_type_str(thread->type), thread->func, thread->u.val, thread->u.c.status);
+#endif
+
+	thread->id = thread_get_id(thread->master);
+	(*thread->func) (thread);
 }
 
 void
 process_threads(thread_master_t *m)
 {
 	thread_t* thread;
-	thread_list_t* thread_list;
+	list_head_t *thread_list;
 	int thread_type;
 
 	/*
@@ -1280,6 +1706,7 @@ process_threads(thread_master_t *m)
 		thread = thread_trim_head(thread_list);
 		/* If we are shutting down, only process relevant thread types */
 		if (!shutting_down ||
+// TODO - the next test will no longer work since timer will now match as well as signal and interfaces in fault state
 (thread->type == THREAD_READY_FD && thread->sands.tv_sec == TIMER_DISABLED) ||
 		    thread->type == THREAD_CHILD ||
 		    thread->type == THREAD_CHILD_TIMEOUT ||
@@ -1288,15 +1715,19 @@ process_threads(thread_master_t *m)
 			if (thread->func)
 				thread_call(thread);
 
-			if (!shutting_down && thread->type == THREAD_TERMINATE_START)
-{
+			if (thread->type == THREAD_TERMINATE_START)
 				shutting_down = true;
-}
 		}
 
+		m->current_event = (thread->type == THREAD_READY_FD) ? thread->event : NULL;
 		thread_type = thread->type;
 		thread->type = THREAD_UNUSED;
 		thread_add_unuse(master, thread);
+
+		/* If we are shutting down, and the shutdown timer is not running and
+		 * all children have terminated, then we can terminate */
+		if (shutting_down && !m->shutdown_timer_running && !m->child.rb_node)
+			return;
 
 		/* If daemon hanging event is received stop processing */
 		if (thread_type == THREAD_TERMINATE)
@@ -1319,7 +1750,7 @@ process_child_termination(pid_t pid, int status)
 	if (child_finder)
 		thread = child_finder(pid);
 	else {
-		for (thread = m->child.head; thread; thread = thread->next) {
+		rb_for_each_entry(thread, &m->child, n) {
 			if (pid == thread->u.c.pid)
 				break;
 		}
@@ -1328,7 +1759,6 @@ process_child_termination(pid_t pid, int status)
 	if (!thread)
 		return;
 
-	thread_list_delete(&m->child, thread);
 	thread->u.c.status = status;
 	if (child_remover)
 		child_remover(thread);
@@ -1336,11 +1766,12 @@ process_child_termination(pid_t pid, int status)
 	if (permanent_vrrp_checker_error)
 	{
 		/* The child had a permanant error, so no point in respawning */
+		rb_erase(&thread->n, &m->child);
 		thread->type = THREAD_UNUSED;
-		thread_list_add(&m->unuse, thread);
+		thread_add_unuse(m, thread);
 	}
 	else
-		thread_list_add(&m->ready, thread);
+		thread_move_ready(m, &m->child, thread, THREAD_CHILD);
 }
 
 /* Synchronous signal handler to reap child processes */
@@ -1361,54 +1792,22 @@ thread_child_handler(__attribute__((unused)) void *v, __attribute__((unused)) in
 	}
 }
 
-/* Make unique thread id for non pthread version of thread manager. */
-static inline unsigned long
-thread_get_id(void)
-{
-	static unsigned long int counter = 0;
-	return ++counter;
-}
-
-#ifdef _TIMER_DEBUG_
-static const char *
-get_thread_type_str(thread_type_t id)
-{
-	if (id == THREAD_READ) return "READ";
-	if (id == THREAD_WRITE) return "WRITE";
-	if (id == THREAD_TIMER) return "TIMER";
-	if (id == THREAD_EVENT) return "EVENT";
-	if (id == THREAD_CHILD) return "CHILD";
-	if (id == THREAD_READY) return "READY";
-	if (id == THREAD_UNUSED) return "UNUSED";
-	if (id == THREAD_WRITE_TIMEOUT) return "WRITE_TIMEOUT";
-	if (id == THREAD_READ_TIMEOUT) return "READ_TIMEOUT";
-	if (id == THREAD_CHILD_TIMEOUT) return "CHILD_TIMEOUT";
-	if (id == THREAD_TERMINATE) return "TERMINATE";
-	if (id == THREAD_READY_FD) return "READY_FD";
-
-	return "unknown";
-}
-#endif
-
-/* Call thread ! */
 void
-thread_call(thread_t * thread)
+thread_add_base_threads(thread_master_t *m)
 {
-	thread->id = thread_get_id();
-#ifdef _TIMER_DEBUG_
-#ifndef _DEBUG_
-	if (prog_type == PROG_TYPE_VRRP)
+	m->timer_thread = thread_add_read(m, thread_timerfd_handler, NULL, m->timer_fd, TIMER_NEVER);
+	add_signal_read_thread(m);
+#ifdef _WITH_SNMP_
+	m->snmp_timer_thread = thread_add_timer(m, snmp_timeout_thread, 0, TIMER_NEVER);
 #endif
-		log_message(LOG_INFO, "Calling thread function, type %s, addr 0x%p, val/fd/pid %d, status %d", get_thread_type_str(thread->type), thread->func, thread->u.val, thread->u.c.status);
-#endif
-	(*thread->func) (thread);
 }
 
 /* Our infinite scheduling loop */
 void
-launch_scheduler(void)
+launch_thread_scheduler(thread_master_t *m)
 {
-	signal_set(SIGCHLD, thread_child_handler, master);
+// TODO - do this somewhere better
+	signal_set(SIGCHLD, thread_child_handler, m);
 
-	process_threads(master);
+	process_threads(m);
 }

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -184,6 +184,9 @@ extern prog_type_t prog_type;		/* Parent/VRRP/Checker process */
 #ifdef _WITH_SNMP_
 extern bool snmp_running;
 #endif
+#ifdef _EPOLL_DEBUG_
+extern bool epoll_debug;
+#endif
 
 /* Prototypes. */
 extern void set_child_finder_name(char const * (*)(pid_t));
@@ -218,4 +221,12 @@ extern void process_threads(thread_master_t *);
 extern void thread_child_handler(void *, int);
 extern void thread_add_base_threads(thread_master_t *);
 extern void launch_thread_scheduler(thread_master_t *);
+#ifdef _EPOLL_DEBUG_
+extern const char *get_signal_function_name(void (*)(void *, int));
+extern void register_signal_handler_address(const char *, void (*)(void *, int));
+extern void register_thread_address(const char *, int (*)(thread_t *));
+extern void deregister_thread_addresses(void);
+extern void register_scheduler_addresses(void);
+#endif
+
 #endif

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -198,7 +198,6 @@ extern void log_command_line(unsigned);
 #ifndef _DEBUG_
 extern bool report_child_status(int, pid_t, const char *);
 #endif
-extern int thread_event_cancel(thread_t *);
 extern thread_master_t *thread_make_master(void);
 extern thread_t *thread_add_terminate_event(thread_master_t *);
 extern thread_t *thread_add_start_terminate_event(thread_master_t *, int (*)(thread_t *));
@@ -208,7 +207,8 @@ extern thread_t *thread_add_read(thread_master_t *, int (*) (thread_t *), void *
 extern int thread_del_read(thread_t *);
 extern void thread_requeue_read(thread_master_t *, int, unsigned long);
 extern thread_t *thread_add_write(thread_master_t *, int (*) (thread_t *), void *, int, unsigned long);
-extern int thread_del_write(thread_t *thread);
+extern int thread_del_write(thread_t *);
+extern void thread_close_fd(thread_t *);
 extern thread_t *thread_add_timer(thread_master_t *, int (*) (thread_t *), void *, unsigned long);
 extern thread_t *thread_add_timer_shutdown(thread_master_t *, int (*) (thread_t *), void *, unsigned long);
 extern thread_t *thread_add_child(thread_master_t *, int (*) (thread_t *), void *, pid_t, unsigned long);

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -56,7 +56,10 @@ typedef enum {
 	THREAD_READ_ERROR,
 	THREAD_WRITE_ERROR,
 	THREAD_IF_UP,
-	THREAD_IF_DOWN
+	THREAD_IF_DOWN,
+#ifdef USE_SIGNAL_THREADS
+	THREAD_SIGNAL,
+#endif
 } thread_type_t;
 
 /* Thread Event flags */
@@ -69,7 +72,7 @@ enum thread_flags {
 };
 
 /* epoll def */
-#define THREAD_EPOLL_REALLOC_THRESH	1024
+#define THREAD_EPOLL_REALLOC_THRESH	64
 
 /* Thread itself. */
 typedef struct _thread {
@@ -89,8 +92,10 @@ typedef struct _thread {
 	} u;
 	struct _thread_event *event;	/* Thread Event back-pointer */
 
-	rb_node_t n;
-	list_head_t next;
+	union {
+		rb_node_t n;
+		list_head_t next;
+	};
 } thread_t;
 
 /* Thread Event */
@@ -110,8 +115,9 @@ typedef struct _thread_master {
 	rb_root_t		timer;
 	rb_root_t		child;
 	list_head_t		event;
-// TODO
-	list_head_t signal;
+#ifdef USE_SIGNAL_THREADS
+	list_head_t 		signal;
+#endif
 	list_head_t		ready;
 	list_head_t		unuse;
 // Can we stop using this?

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -210,6 +210,7 @@ extern thread_t *thread_add_write(thread_master_t *, int (*) (thread_t *), void 
 extern int thread_del_write(thread_t *);
 extern void thread_close_fd(thread_t *);
 extern thread_t *thread_add_timer(thread_master_t *, int (*) (thread_t *), void *, unsigned long);
+extern void timer_thread_update_timeout(thread_t *, unsigned long);
 extern thread_t *thread_add_timer_shutdown(thread_master_t *, int (*) (thread_t *), void *, unsigned long);
 extern thread_t *thread_add_child(thread_master_t *, int (*) (thread_t *), void *, pid_t, unsigned long);
 extern void thread_children_reschedule(thread_master_t *, int (*) (thread_t *), unsigned long);

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -190,7 +190,7 @@ extern prog_type_t prog_type;		/* Parent/VRRP/Checker process */
 #ifdef _WITH_SNMP_
 extern bool snmp_running;
 #endif
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern bool epoll_debug;
 #endif
 
@@ -207,6 +207,9 @@ extern bool report_child_status(int, pid_t, const char *);
 extern thread_master_t *thread_make_master(void);
 extern thread_t *thread_add_terminate_event(thread_master_t *);
 extern thread_t *thread_add_start_terminate_event(thread_master_t *, int (*)(thread_t *));
+#ifdef THREAD_DUMP
+extern void dump_thread_data(thread_master_t *, FILE *);
+#endif
 extern void thread_cleanup_master(thread_master_t *);
 extern void thread_destroy_master(thread_master_t *);
 extern thread_t *thread_add_read(thread_master_t *, int (*) (thread_t *), void *, int, unsigned long);
@@ -228,7 +231,7 @@ extern void process_threads(thread_master_t *);
 extern void thread_child_handler(void *, int);
 extern void thread_add_base_threads(thread_master_t *);
 extern void launch_thread_scheduler(thread_master_t *);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern const char *get_signal_function_name(void (*)(void *, int));
 extern void register_signal_handler_address(const char *, void (*)(void *, int));
 extern void register_thread_address(const char *, int (*)(thread_t *));

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <sys/timerfd.h>
 
 #include "timer.h"
 #include "list.h"
@@ -88,9 +89,16 @@ typedef struct _thread_master {
 	thread_list_t ready;
 	thread_list_t unuse;
 	list child_pid_index;
+
+	/* select related */
 	fd_set readfd;
 	fd_set writefd;
 	int max_fd;
+
+	/* timer related */
+	int timer_fd;
+
+	/* local data */
 	unsigned long alloc;
 	bool shutdown_timer_running;
 } thread_master_t;

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -1,21 +1,21 @@
 /*
- * Soft:        Keepalived is a failover program for the LVS project
- *              <www.linuxvirtualserver.org>. It monitor & manipulate
- *              a loadbalanced server pool using multi-layer checks.
+ * Soft:	Keepalived is a failover program for the LVS project
+ *		<www.linuxvirtualserver.org>. It monitor & manipulate
+ *		a loadbalanced server pool using multi-layer checks.
  *
- * Part:        scheduler.c include file.
+ * Part:	scheduler.c include file.
  *
- * Author:      Alexandre Cassen, <acassen@linux-vs.org>
+ * Author:	Alexandre Cassen, <acassen@linux-vs.org>
  *
- *              This program is distributed in the hope that it will be useful,
- *              but WITHOUT ANY WARRANTY; without even the implied warranty of
- *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *              See the GNU General Public License for more details.
+ *		This program is distributed in the hope that it will be useful,
+ *		but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *		See the GNU General Public License for more details.
  *
- *              This program is free software; you can redistribute it and/or
- *              modify it under the terms of the GNU General Public License
- *              as published by the Free Software Foundation; either version
- *              2 of the License, or (at your option) any later version.
+ *		This program is free software; you can redistribute it and/or
+ *		modify it under the terms of the GNU General Public License
+ *		as published by the Free Software Foundation; either version
+ *		2 of the License, or (at your option) any later version.
  *
  * Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
  */
@@ -61,22 +61,22 @@ typedef enum {
 
 /* Thread Event flags */
 enum thread_flags {
-        THREAD_FL_READ_BIT,
-        THREAD_FL_WRITE_BIT,
-        THREAD_FL_EPOLL_BIT,
-        THREAD_FL_EPOLL_READ_BIT,
-        THREAD_FL_EPOLL_WRITE_BIT,
+	THREAD_FL_READ_BIT,
+	THREAD_FL_WRITE_BIT,
+	THREAD_FL_EPOLL_BIT,
+	THREAD_FL_EPOLL_READ_BIT,
+	THREAD_FL_EPOLL_WRITE_BIT,
 };
 
 /* epoll def */
-#define THREAD_EPOLL_REALLOC_THRESH     1024
+#define THREAD_EPOLL_REALLOC_THRESH	1024
 
 /* Thread itself. */
 typedef struct _thread {
 	unsigned long id;
 	thread_type_t type;		/* thread type */
 	struct _thread_master *master;	/* pointer to the struct thread_master. */
-	int (*func) (struct _thread *);	/* event function */
+	int (*func)(struct _thread *);	/* event function */
 	void *arg;			/* event argument */
 	timeval_t sands;		/* rest of time sands value. */
 	union {
@@ -87,20 +87,20 @@ typedef struct _thread {
 			int status;	/* return status of the process */
 		} c;
 	} u;
-	struct _thread_event    *event;                         /* Thread Event back-pointer */
+	struct _thread_event *event;	/* Thread Event back-pointer */
 
-	rb_node_t               n;
-	list_head_t             next;
+	rb_node_t n;
+	list_head_t next;
 } thread_t;
 
 /* Thread Event */
 typedef struct _thread_event {
-	thread_t                *read;
-	thread_t                *write;
-	unsigned long           flags;
-	int                     fd;
+	thread_t		*read;
+	thread_t		*write;
+	unsigned long		flags;
+	int			fd;
 
-	rb_node_t               n;
+	rb_node_t		n;
 } thread_event_t;
 
 /* Master of the threads. */
@@ -118,12 +118,12 @@ typedef struct _thread_master {
 	list child_pid_index;
 
 	/* epoll related */
-	rb_root_t               io_events;
-	struct epoll_event      *epoll_events;
-	thread_event_t          *current_event;
-	unsigned int            epoll_size;
-	unsigned int            epoll_count;
-	int                     epoll_fd;
+	rb_root_t		io_events;
+	struct epoll_event	*epoll_events;
+	thread_event_t		*current_event;
+	unsigned int		epoll_size;
+	unsigned int		epoll_count;
+	int			epoll_fd;
 
 	/* timer related */
 	int			timer_fd;

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -318,6 +318,12 @@ signal_run_callback(__attribute__((unused)) thread_t *thread)
 #else
 	while (read(signal_pipe[0], &sig, sizeof(int)) == sizeof(int)) {
 #endif
+
+#ifdef _EPOLL_DEBUG_
+		if (epoll_debug)
+			log_message(LOG_INFO, "Signal %d, func %s()", sig, get_signal_function_name(signal_handler_func[sig-1]));
+#endif
+
 		if (sig >= 1 && sig <= SIG_MAX && signal_handler_func[sig-1])
 			signal_handler_func[sig-1](signal_v[sig-1], sig);
 	}
@@ -536,6 +542,9 @@ void
 set_sigxcpu_handler(void)
 {
 	signal_set(SIGXCPU, log_sigxcpu, NULL);
+#ifdef _EPOLL_DEBUG_
+	register_signal_handler_address("log_sigxcpu", log_sigxcpu);
+#endif
 }
 #endif
 
@@ -557,3 +566,11 @@ void signal_fd_close(int min_fd)
 	}
 #endif
 }
+
+#ifdef _EPOLL_DEBUG_
+void
+register_signal_thread_addresses(void)
+{
+        register_thread_address("signal_run_callback", signal_run_callback);
+}
+#endif

--- a/lib/signals.c
+++ b/lib/signals.c
@@ -560,7 +560,7 @@ void
 set_sigxcpu_handler(void)
 {
 	signal_set(SIGXCPU, log_sigxcpu, NULL);
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 	register_signal_handler_address("log_sigxcpu", log_sigxcpu);
 #endif
 }
@@ -585,7 +585,7 @@ void signal_fd_close(int min_fd)
 #endif
 }
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 void
 register_signal_thread_addresses(void)
 {

--- a/lib/signals.h
+++ b/lib/signals.h
@@ -57,4 +57,8 @@ extern void set_sigxcpu_handler(void);
 extern int signal_rfd(void);
 extern void signal_fd_close(int);
 
+#ifdef _EPOLL_DEBUG_
+extern void register_signal_thread_addresses(void);
+#endif
+
 #endif

--- a/lib/signals.h
+++ b/lib/signals.h
@@ -57,7 +57,7 @@ extern void set_sigxcpu_handler(void);
 extern int signal_rfd(void);
 extern void signal_fd_close(int);
 
-#ifdef _EPOLL_DEBUG_
+#ifdef THREAD_DUMP
 extern void register_signal_thread_addresses(void);
 #endif
 

--- a/lib/signals.h
+++ b/lib/signals.h
@@ -29,6 +29,8 @@
 #include <signal.h>
 #include <stdbool.h>
 
+#include "scheduler.h"
+
 static inline int
 sigmask_func(int how, const sigset_t *set, sigset_t *oldset)
 {
@@ -44,10 +46,9 @@ extern int get_signum(const char *);
 extern void signal_set(int, void (*) (void *, int), void *);
 extern void signal_ignore(int);
 extern void signal_handler_init(void);
-extern void signal_handler_child_init(void);
 extern void signal_handler_destroy(void);
 extern void signal_handler_script(void);
-extern void add_signal_read_thread(void);
+extern void add_signal_read_thread(thread_master_t *);
 extern void cancel_signal_read_thread(void);
 #if HAVE_DECL_RLIMIT_RTTIME == 1
 extern void set_sigxcpu_handler(void);

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -156,7 +156,8 @@ set_time_now(void)
 
 #ifdef _TIMER_CHECK_
 	unsigned long timediff = (time_now.tv_sec - last_time.tv_sec) * 1000000 + time_now.tv_usec - last_time.tv_usec;
-	log_message(LOG_INFO, "set_time_now called from %s %s:%d, difference %lu usec", file, function, line_no, timediff);
+//	log_message(LOG_INFO, "set_time_now called from %s %s:%d, difference %lu usec", file, function, line_no, timediff);
+	log_message(LOG_INFO, "set_time_now called from %s %s:%d, time %ld.%6.6lu difference %lu usec", file, function, line_no, time_now.tv_sec, time_now.tv_usec, timediff);
 	last_time = time_now;
 #endif
 

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -74,7 +74,8 @@ timer_sub_long(timeval_t a, unsigned long b)
 	return a;
 }
 
-static void set_mono_offset(struct timespec *ts)
+static void
+set_mono_offset(struct timespec *ts)
 {
 	struct timespec realtime, realtime_1, mono_offset;
 
@@ -138,8 +139,8 @@ monotonic_gettimeofday(timeval_t *now)
 		cur_time.tv_nsec -= NSEC_PER_SEC;
 		cur_time.tv_sec++;
 	}
-	now->tv_sec = cur_time.tv_sec;
-	now->tv_usec = cur_time.tv_nsec / 1000;
+
+	TIMESPEC_TO_TIMEVAL(now, &cur_time);
 
 	return 0;
 }
@@ -186,41 +187,3 @@ set_time_now(void)
 
 	return time_now;
 }
-
-/* timer sub from current time */
-timeval_t
-timer_sub_now(timeval_t a)
-{
-	timersub(&a, &time_now, &a);
-
-	return a;
-}
-
-/* timer add to current time */
-timeval_t
-timer_add_now(timeval_t a)
-{
-	/* Init current time if needed */
-	if (!timerisset(&time_now))
-		set_time_now();
-
-	timeradd(&time_now, &a, &a);
-
-	return a;
-}
-
-/* Return time as unsigned long */
-unsigned long
-timer_tol(timeval_t a)
-{
-	return (unsigned long)a.tv_sec * TIMER_HZ + (unsigned long)a.tv_usec;
-}
-
-#ifdef _INCLUDE_UNUSED_CODE_
-/* print timer value */
-void
-timer_dump(timeval_t a)
-{
-	printf("=> %lu (usecs)\n", timer_tol(a));
-}
-#endif

--- a/lib/timer.c
+++ b/lib/timer.c
@@ -27,9 +27,15 @@
 #include <sys/time.h>
 
 #include "timer.h"
+#ifdef _TIMER_CHECK_
+#include "logger.h"
+#endif
 
 /* time_now holds current time */
 timeval_t time_now;
+#ifdef _TIMER_CHECK_
+timeval_t last_time;
+#endif
 
 timeval_t
 timer_add_long(timeval_t a, unsigned long b)
@@ -117,22 +123,42 @@ monotonic_gettimeofday(timeval_t *now)
 
 /* current time */
 timeval_t
+#ifdef _TIMER_CHECK_
+timer_now_r(const char *file, const char *function, int line_no)
+#else
 timer_now(void)
+#endif
 {
 	timeval_t curr_time;
 
 	/* init timer */
 	monotonic_gettimeofday(&curr_time);
 
+#ifdef _TIMER_CHECK_
+	unsigned long timediff = (curr_time.tv_sec - last_time.tv_sec) * 1000000 + curr_time.tv_usec - last_time.tv_usec;
+	log_message(LOG_INFO, "timer_now called from %s %s:%d - difference %lu usec", file, function, line_no, timediff);
+	last_time = curr_time;
+#endif
+
 	return curr_time;
 }
 
 /* sets and returns current time from system time */
 timeval_t
+#ifdef _TIMER_CHECK_
+set_time_now_r(const char *file, const char *function, int line_no)
+#else
 set_time_now(void)
+#endif
 {
 	/* init timer */
 	monotonic_gettimeofday(&time_now);
+
+#ifdef _TIMER_CHECK_
+	unsigned long timediff = (time_now.tv_sec - last_time.tv_sec) * 1000000 + time_now.tv_usec - last_time.tv_usec;
+	log_message(LOG_INFO, "set_time_now called from %s %s:%d, difference %lu usec", file, function, line_no, timediff);
+	last_time = time_now;
+#endif
 
 	return time_now;
 }

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -42,12 +42,43 @@ extern timeval_t time_now;
 
 #define	NSEC_PER_SEC		1000000000U	/* nanoseconds per second. Avoids typos by having a definition */
 
-/* Some useful macros */
-#define timer_long(T) (unsigned long)(((T).tv_sec * TIMER_HZ + (T).tv_usec))
-
 #ifdef _TIMER_CHECK_
 #define timer_now()	timer_now_r((__FILE__), (char *)(__FUNCTION__), (__LINE__))
 #define set_time_now()	set_time_now_r((__FILE__), (char *)(__FUNCTION__), (__LINE__))
+#endif
+
+/* timer sub from current time */
+static inline timeval_t
+timer_sub_now(timeval_t a)
+{
+	timersub(&a, &time_now, &a);
+
+	return a;
+}
+
+/* timer add to current time */
+static inline timeval_t
+timer_add_now(timeval_t a)
+{
+	timeradd(&time_now, &a, &a);
+
+	return a;
+}
+
+/* Return time as unsigned long */
+static inline unsigned long
+timer_long(timeval_t a)
+{
+	return (unsigned long)a.tv_sec * TIMER_HZ + (unsigned long)a.tv_usec;
+}
+
+#ifdef _INCLUDE_UNUSED_CODE_
+/* print timer value */
+static inline void
+timer_dump(timeval_t a)
+{
+	printf("=> %lu (usecs)\n", timer_tol(a));
+}
 #endif
 
 /* prototypes */
@@ -60,11 +91,5 @@ extern timeval_t set_time_now(void);
 #endif
 extern timeval_t timer_add_long(timeval_t, unsigned long);
 extern timeval_t timer_sub_long(timeval_t, unsigned long);
-extern timeval_t timer_sub_now(timeval_t);
-extern timeval_t timer_add_now(timeval_t);
-extern unsigned long timer_tol(timeval_t);
-#ifdef _INCLUDE_UNUSED_CODE_
-extern void timer_dump(timeval_t);
-#endif
 
 #endif

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -43,9 +43,19 @@ extern timeval_t time_now;
 /* Some useful macros */
 #define timer_long(T) (unsigned long)(((T).tv_sec * TIMER_HZ + (T).tv_usec))
 
+#ifdef _TIMER_CHECK_
+#define timer_now()	timer_now_r((__FILE__), (char *)(__FUNCTION__), (__LINE__))
+#define set_time_now()	set_time_now_r((__FILE__), (char *)(__FUNCTION__), (__LINE__))
+#endif
+
 /* prototypes */
+#ifdef _TIMER_CHECK_
+extern timeval_t timer_now_r(const char *, const char *, int);
+extern timeval_t set_time_now_r(const char *, const char *, int);
+#else
 extern timeval_t timer_now(void);
 extern timeval_t set_time_now(void);
+#endif
 extern timeval_t timer_add_long(timeval_t, unsigned long);
 extern timeval_t timer_sub_long(timeval_t, unsigned long);
 extern timeval_t timer_sub_now(timeval_t);

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -46,7 +46,6 @@ extern timeval_t time_now;
 /* prototypes */
 extern timeval_t timer_now(void);
 extern timeval_t set_time_now(void);
-extern timeval_t timer_add_secs(timeval_t, time_t);
 extern timeval_t timer_add_long(timeval_t, unsigned long);
 extern timeval_t timer_sub_long(timeval_t, unsigned long);
 extern timeval_t timer_sub_now(timeval_t);

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -40,6 +40,8 @@ extern timeval_t time_now;
 #define TIMER_NEVER		ULONG_MAX	/* Used with time intervals in TIMER_HZ units */
 #define TIMER_DISABLED		LONG_MIN	/* Value in timeval_t tv_sec */
 
+#define	NSEC_PER_SEC		1000000000U	/* nanoseconds per second. Avoids typos by having a definition */
+
 /* Some useful macros */
 #define timer_long(T) (unsigned long)(((T).tv_sec * TIMER_HZ + (T).tv_usec))
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -60,7 +60,7 @@ unsigned long debug = 0;
 
 /* Display a buffer into a HEXA formated output */
 void
-dump_buffer(char *buff, size_t count, FILE* fp)
+dump_buffer(char *buff, size_t count, FILE* fp, int indent)
 {
 	size_t i, j, c;
 	bool printnext = true;
@@ -73,7 +73,7 @@ dump_buffer(char *buff, size_t count, FILE* fp)
 	for (i = 0; i < c; i++) {
 		if (printnext) {
 			printnext = false;
-			fprintf(fp, "%.4zu ", i & 0xffff);
+			fprintf(fp, "%*s%.4zu ", indent, "", i & 0xffff);
 		}
 		if (i < count)
 			fprintf(fp, "%3.2x", buff[i] & 0xff);

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -32,6 +32,13 @@
 #include <sys/utsname.h>
 #include <stdint.h>
 #include <errno.h>
+#ifdef _WITH_PERF_
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/epoll.h>
+#include <sys/inotify.h>
+#endif
 
 #if !defined _HAVE_LIBIPTC_ || defined _LIBIPTC_DYNAMIC_
 #include <signal.h>
@@ -51,7 +58,7 @@
 #include "signals.h"
 #include "bitops.h"
 #include "parser.h"
-#if !defined _HAVE_LIBIPTC_ || defined _LIBIPTC_DYNAMIC_ || defined _WITH_STACKTRACE_
+#if !defined _HAVE_LIBIPTC_ || defined _LIBIPTC_DYNAMIC_ || defined _WITH_STACKTRACE_ || defined _WITH_PERF_
 #include "logger.h"
 #endif
 #if !defined _HAVE_LIBIPTC_ || defined _LIBIPTC_DYNAMIC_
@@ -138,6 +145,178 @@ write_stacktrace(const char *file_name, const char *str)
 			log_message(LOG_INFO, "  %s", strs[i]);
 		free(strs);
 	}
+}
+#endif
+
+char *
+make_file_name(const char *name, const char *prog, const char *namespace, const char *instance)
+{
+	const char *extn_start;
+	const char *dir_end;
+	size_t len;
+	char *file_name;
+
+	if (!name)
+		return NULL;
+
+	len = strlen(name);
+	if (prog)
+		len += strlen(prog) + 1;
+	if (namespace)
+		len += strlen(namespace) + 1;
+	if (instance)
+		len += strlen(instance) + 1;
+
+	file_name = MALLOC(len + 1);
+	dir_end = strrchr(name, '/');
+	extn_start = strrchr(dir_end ? dir_end : name, '.');
+	strncpy(file_name, name, extn_start ? (size_t)(extn_start - name) : len);
+
+	if (prog) {
+		strcat(file_name, "_");
+		strcat(file_name, prog);
+	}
+	if (namespace) {
+		strcat(file_name, "_");
+		strcat(file_name, namespace);
+	}
+	if (instance) {
+		strcat(file_name, "_");
+		strcat(file_name, instance);
+	}
+	if (extn_start)
+		strcat(file_name, extn_start);
+
+	return file_name;
+}
+
+#if _WITH_PERF_
+void
+run_perf(const char *process, const char *network_namespace, const char *instance_name)
+{
+	int ret;
+	pid_t pid;
+	char *orig_name = NULL;
+	char *new_name;
+	const char *perf_name = "perf.data";
+	int in = -1;
+	int ep = -1;
+
+	do {
+		orig_name = MALLOC(PATH_MAX);
+		if (!getcwd(orig_name, PATH_MAX)) {
+			log_message(LOG_INFO, "Unable to get cwd");
+			break;
+		}
+
+#ifdef IN_CLOEXEC
+		in = inotify_init1(IN_CLOEXEC | IN_NONBLOCK);
+#else
+		if ((in = inotify_init()) != -1) {
+			fcntl(in, F_SETFD, FD_CLOEXEC | fcntl(n, F_GETFD));
+			fcntl(in, F_SETFL, O_NONBLOCK | fcntl(n, F_GETFL));
+		}
+#endif
+		if (in == -1) {
+			log_message(LOG_INFO, "inotify_init failed %d - %m", errno);
+			break;
+		}
+
+		if (inotify_add_watch(in, orig_name, IN_CREATE) == -1) {
+			log_message(LOG_INFO, "inotify_add_watch of %s failed %d - %m", orig_name, errno);
+			break;
+		}
+
+		pid = fork();
+
+		if (pid == -1) {
+			log_message(LOG_INFO, "fork() for perf failed");
+			break;
+		}
+
+		/* Child */
+		if (!pid) {
+			char buf[9];
+
+			snprintf(buf, sizeof buf, "%d", getppid());
+			execlp("perf", "perf", "record", "-p", buf, "-q", "-g", "--call-graph", "fp", NULL);
+			exit(0);
+		}
+
+		/* Parent */
+		char buf[sizeof(struct inotify_event) + NAME_MAX + 1];
+		struct inotify_event *ie = (struct inotify_event*)buf;
+		struct epoll_event ee = { .events = EPOLLIN, .data.fd = in };
+
+		if ((ep = epoll_create(1)) == -1) {
+			log_message(LOG_INFO, "perf epoll_create failed errno %d - %m", errno);
+			break;
+		}
+
+		if (epoll_ctl(ep, EPOLL_CTL_ADD, in, &ee) == -1) {
+			log_message(LOG_INFO, "perf epoll_ctl failed errno %d - %m", errno);
+			break;
+		}
+
+		do {
+			ret = epoll_wait(ep, &ee, 1, 1000);
+			if (ret == 0) {
+				log_message(LOG_INFO, "Timed out waiting for creation of %s", perf_name);
+				break;
+			}
+			else if (ret == -1) {
+				if (errno == EINTR)
+					continue;
+				log_message(LOG_INFO, "perf epoll returned errno %d - %m", errno);
+				break;
+			}
+
+			ret = read(in, buf, sizeof(buf));
+			if (ret == -1) {
+				if (errno == EINTR)
+					continue;
+				log_message(LOG_INFO, "perf inotify read returned errno %d %m", errno);
+				break;
+			}
+			if (ret < (int)sizeof(*ie)) {
+				log_message(LOG_INFO, "read returned %d", ret);
+				break;
+			}
+			if (!(ie->mask & IN_CREATE)) {
+				log_message(LOG_INFO, "mask is 0x%x", ie->mask);
+				continue;
+			}
+			if (!ie->len) {
+				log_message(LOG_INFO, "perf inotify read returned no len");
+				continue;
+			}
+
+			if (strcmp(ie->name, perf_name))
+				continue;
+
+			/* Rename the /perf.data file */
+			strcat(orig_name, perf_name);
+			new_name = make_file_name(orig_name, process,
+#if HAVE_DECL_CLONE_NEWNET
+							network_namespace,
+#else
+							NULL,
+#endif
+							instance_name);
+
+			if (rename(orig_name, new_name))
+				log_message(LOG_INFO, "Rename %s to %s failed - %m (%d)", orig_name, new_name, errno);
+
+			FREE(new_name);
+		} while (false);
+	} while (false);
+
+	if (ep != -1)
+		close(ep);
+	if (in != -1)
+		close(in);
+	if (orig_name)
+		FREE(orig_name);
 }
 #endif
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -54,6 +54,9 @@
 #if !defined _HAVE_LIBIPTC_ || defined _LIBIPTC_DYNAMIC_ || defined _WITH_STACKTRACE_
 #include "logger.h"
 #endif
+#if !defined _HAVE_LIBIPTC_ || defined _LIBIPTC_DYNAMIC_
+#include "process.h"
+#endif
 
 /* global vars */
 unsigned long debug = 0;
@@ -651,7 +654,7 @@ fork_exec(char **argv)
 	if (log_file_name)
 		flush_log_file();
 
-	pid = fork();
+	pid = local_fork();
 	if (pid < 0)
 		res = -1;
 	else if (pid == 0) {

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -144,7 +144,7 @@ static inline uint16_t csum_incremental_update16(const uint16_t old_csum, const 
 extern unsigned long debug;
 
 /* Prototypes defs */
-extern void dump_buffer(char *, size_t, FILE *);
+extern void dump_buffer(char *, size_t, FILE *, int);
 #ifdef _WITH_STACKTRACE_
 extern void write_stacktrace(const char *, const char *);
 #endif

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -47,6 +47,15 @@
 
 #define STR(x)  #x
 
+#ifdef _WITH_PERF_
+typedef enum {
+	PERF_NONE,
+	PERF_RUN,
+	PERF_ALL,
+	PERF_END,
+} perf_t;
+#endif
+
 /* inline stuff */
 static inline int __ip6_addr_equal(const struct in6_addr *a1,
 				   const struct in6_addr *a2)
@@ -140,13 +149,21 @@ static inline uint16_t csum_incremental_update16(const uint16_t old_csum, const 
 
 	return ~acc & 0xffff;
 }
+
 /* global vars exported */
 extern unsigned long debug;
+#ifdef _WITH_PERF_
+extern perf_t perf_run;
+#endif
 
 /* Prototypes defs */
 extern void dump_buffer(char *, size_t, FILE *, int);
 #ifdef _WITH_STACKTRACE_
 extern void write_stacktrace(const char *, const char *);
+#endif
+extern char *make_file_name(const char *, const char *, const char *, const char *);
+#ifdef _WITH_PERF_
+extern void run_perf(const char *, const char *, const char *);
 #endif
 extern uint16_t in_csum(const uint16_t *, size_t, uint32_t, uint32_t *);
 extern char *inet_ntop2(uint32_t);


### PR DESCRIPTION
The next-generation scheduler uses epoll rather than select, and more efficient queue structures (reb-black trees and list_head). This removes the limit of 1024 monitored file descriptors (i.e. about 500 VMAC interfaces or the VRRP configuration using over 500 interfaces).

This has been tested with 2000 VMAC interfaces, utilising in excess of 4000 open file descriptors.

Also fix segfault in HTTP_GET checker.