### PR TITLE
Add track_process for vrrp instances

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1515,6 +1515,7 @@ VRRP_AUTH_SUPPORT=No
 MACVLAN_SUPPORT=No
 ENABLE_JSON=No
 BFD_SUPPORT=No
+HAVE_CN_PROC=No
 if test "$enable_vrrp" != no; then
   VRRP_SUPPORT=Yes
   AC_DEFINE([_WITH_VRRP_], [ 1 ], [Define to 1 if have VRRP support])
@@ -1567,12 +1568,21 @@ if test "$enable_vrrp" != no; then
     AC_DEFINE([_WITH_BFD_], [ 1 ], [Define to 1 if have BFD support])
     add_config_opt([BFD])
   fi
+
+  dnl -- Check for process events connector - Linux v2.6.15
+  AC_CHECK_HEADERS([linux/cn_proc.h],
+    [
+       add_system_opt([CN_PROC])
+       HAVE_CN_PROC=Yes
+       AC_DEFINE([_WITH_CN_PROC_], [ 1 ], [Define to 1 if have linux/cn_proc.h])
+    ])
 fi
 AM_CONDITIONAL([WITH_VRRP], [test $VRRP_SUPPORT = Yes])
 AM_CONDITIONAL([VRRP_AUTH], [test $VRRP_AUTH_SUPPORT = Yes])
 AM_CONDITIONAL([VMAC], [test $MACVLAN_SUPPORT = Yes])
 AM_CONDITIONAL([WITH_JSON], [test $ENABLE_JSON = Yes])
 AM_CONDITIONAL([WITH_BFD], [test $BFD_SUPPORT = Yes])
+AM_CONDITIONAL([CN_PROC], [test $HAVE_CN_PROC = Yes])
 
 if test ${IPVS_SUPPORT} = No -a ${VRRP_SUPPORT} = No; then
   AC_MSG_ERROR([keepalived MUST be compiled with at least one of LVS or VRRP framework])

--- a/doc/keepalived.conf.SYNOPSIS
+++ b/doc/keepalived.conf.SYNOPSIS
@@ -517,10 +517,12 @@ global_defs {                                 # Block identification
     vrrp_netlink_cmd_rcv_bufs_force <BOOL>    #  very large configurations where a large number of interfaces exist, and
     vrrp_netlink_monitor_rcv_bufs BYTES       #  the initial read of the interfaces on the system causes a netlink buffer
     vrrp_netlink_monitor_rcv_bufs_force <BOOL> # overrun.
-    lvs_netlink_cmd_rcv_bufs BYTES            #  The vrrp netlink command and monitor socket and the checker command
-    lvs_netlink_cmd_rcv_bufs_force <BOOL>     #  and monitor socket buffer sizes can be independently set. 
+    lvs_netlink_cmd_rcv_bufs BYTES            #  The vrrp netlink command and monitor socket, the checker command and
+    lvs_netlink_cmd_rcv_bufs_force <BOOL>     #  monitor socket and process monitor buffer sizes can be independently set.
     lvs_netlink_monitor_rcv_bufs BYTES        #  The force flag means to use SO_RCVBUFFORCE, so that the buffer size can
     lvs_netlink_monitor_rcv_bufs_force <BOOL> #  exceed /proc/sys/net/core/rmem_max.
+    process_monitor_rcv_bufs BYTES            # For 1400 processes terminating simultaneously, 212992 (the default on my
+    process_monitor_rcv_bufs_force <BOOL>     #  system) is insufficient, whereas 500000 is sufficient.
 
                                               # When a socket is opened, the kernel configures the max rx buffer size for
                                               # the socket to /proc/sys/net/core/rmem_default. On some systems this can be
@@ -647,6 +649,7 @@ This block is divided in 5 sub-blocks:
 
     * VRRP scripts
     * VRRP track files
+    * VRRP track processes
     * VRRP track BFDs
     * VRRP synchronization group
     * VRRP gratuitous ARP/NA intervals
@@ -719,7 +722,77 @@ If a vrrp instance using a track_file is a member of a sync group, unless
 sync_group_tracking_weight is set on the group weight 0 must be set.
 Likewise, if the vrrp instance is the address owner, weight 0 must also be set.
 
-    2.3. BFD Configuration
+    2.3. VRRP track processes
+
+    The configuration block looks like:
+
+vrrp_track_process <STRING> {   # VRRP track file declaration
+    process <QUOTED_STRING>     # process to monitor
+    weight <-254..254>          # default weight (default is 1)
+    quorum NUM                  # minimum number of processes for success
+    delay SECS                  # time to delay after process quorum lost before
+                                #   consider process failed (in fractions of second)
+    full_command                # Normally process string is matched against the process name,
+                                #   as shown on the Name: line in /proc/PID/status.
+                                #   This option matches the full command line
+}
+
+To avoid having to frequently run a track_script to monitor the existance
+of processes (often haproxy or nginx), vrrp_track_process can monitor whether
+other processes are running.
+
+One difference from pgrep is track_process doesn't do a regular expression match of the
+command string, but does an exact match. 'pgrep ssh' will match an sshd process, this
+track_process will not (it is equivalent to pgrep "^ssh$").
+
+If full_command is used (equivalent to pgrep -f), /proc/PID/cmdline is used, but
+any updates to cmdline will not be detected (a process shouldn't normally change it,
+although it is possible with great care, for example systemd).
+
+Quorum is the number of matching processes that must be run for an OK status.
+
+Delay might be useful if it anticipated that a process may be reloaded (stopped and
+restarted), and it isn't desired to down and up a vrrp instance.
+
+A positive weight means that an OK status will add <weight> to the priority of all
+VRRP instances which monitor it. On the opposite, a negative weight will be subtracted
+from the initial priority in case of insufficient processes.
+
+If the vrrp instance or sync group is not the address owner and the result is between
+-253 and 253, the result will be added to the initial priority of the VRRP instance
+(a negative value will reduce the priority), although the effective priority will
+be limited to the range [1,254].
+
+If a vrrp instance using a track_process is a member of a sync group, unless
+sync_group_tracking_weight is set on the group weight 0 must be set.
+Likewise, if the vrrp instance is the address owner, weight 0 must also be set.
+
+Rational for not using pgrep/pidof/killall and the likes:
+
+Every time pgrep or its equivalent is run, it iterates though the /proc/[1-9][0-9]*
+directories, and opens the status and cmdline pseudo files in each directory.
+The cmdline pseudo file is mapped to the process's address space, and so if that
+part of the process is swapped out, it will have to be fetched from the swap space.
+pgrep etc also include zombie processes whereas keepalived does not, since they aren't
+running.
+
+This implementation only iterates though /proc/[1-9][0-9]*/ directories at start up, and
+it won't even read the cmdline pseudo files if 'full_command' is not specified for any of
+the vrrp_track_process entries. After startup, it uses the process_events
+kernel <-> userspace connector to receive notification of process changes. If full_command
+is specified for any track_process instance, the cmdline pseudo file will have to be
+read upon notification of the creation of the new process, but at that time it is very
+unlikely that it will have already been swapped out.
+
+On a busy system with a high number of process creations/terminations, using a
+track_script with pgrep/pidof/killall may be more efficient, although those processes
+are inefficient compared to the minimum that keepalived needs.
+
+Using pgrep etc on a system that is swapping can have a significant detrimental impact
+on the performance of the system, due to having to fetch swapped memory from the swap
+space, thereby causing additional swapping.
+
+    2.4. BFD Configuration
 
     This is an implementation of RFC5880 (Bidirectional forwarding detection),
     and this can be configured to work between 2 keepalived instances, but using
@@ -753,7 +826,7 @@ bfd_instance <STRING> {
     vrrp|checker                       # Only notify vrrp or checker process. Default is notify both.
 }
 
-    2.4. VRRP synchronization group
+    2.5. VRRP synchronization group
 
     The configuration block looks like :
 
@@ -783,6 +856,11 @@ vrrp_sync_group <STRING> {      # VRRP sync group declaration
     }
     track_file {                # Files state we monitor
       <STRING>			# weight defaults to value configured in the vrrp_track_file
+      <STRING> weight <INTEGER: -254..254>
+      ...
+    }
+    track_process {             # Processes we monitor
+      <STRING>			# weight defaults to value configured in the vrrp_track_process
       <STRING> weight <INTEGER: -254..254>
       ...
     }
@@ -846,7 +924,7 @@ Important: for a SYNC group to run reliably, it is vital that all instances in
     instance will have taken over the secondary IP address, and the proper master
     needs to be able to restore it.
 
-    2.5. VRRP gratuitous ARP/NA intervals
+    2.6. VRRP gratuitous ARP/NA intervals
 
     This section allows the setting of delays between sending gratuitous ARPs
     and unsolicited neighbour advertisements. This is intended for when an
@@ -875,7 +953,7 @@ garp_group {
     interfaces that aren't specified in a garp_group will inherit the global
     settings.
 
-    2.6. VRRP instance
+    2.7. VRRP instance
 
     The configuration block looks like :
 
@@ -916,6 +994,11 @@ vrrp_instance <STRING> {                      # VRRP instance declaration
     }
     track_file {                              # Files state we monitor
       <STRING>
+      <STRING>
+      <STRING> weight <INTEGER: -254..254>
+      ...
+    }
+    track_process {                           # Processes we monitor
       <STRING>
       <STRING> weight <INTEGER: -254..254>
       ...

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -484,14 +484,20 @@ and
     \fBvrrp_netlink_monitor_rcv_bufs \fRBYTES
     \fBvrrp_netlink_monitor_rcv_bufs_force \fR<BOOL>
 
-    # The vrrp netlink command and monitor socket and the checker command
-    # and monitor socket buffer sizes can be independently set.
+    # The vrrp netlink command and monitor socket the checker command and
+    # and monitor socket and process monitor buffer sizes can be independently set.
     # The force flag means to use SO_RCVBUFFORCE, so that the buffer size
     # can exceed /proc/sys/net/core/rmem_max.
     \fBlvs_netlink_cmd_rcv_bufs \fRBYTES
     \fBlvs_netlink_cmd_rcv_bufs_force \fR<BOOL>
     \fBlvs_netlink_monitor_rcv_bufs \fRBYTES
     \fBlvs_netlink_monitor_rcv_bufs_force \fR<BOOL>
+
+    # As a guide for process_monitor_rcv_bufs for 1400 processes terminating
+    # simultaneously, 212992 (the default on some systems) is insufficient, whereas
+    # 500000 is sufficient.
+    \fBprocess_monitor_rcv_bufs \fRBYTES
+    \fBprocess_monitor_rcv_bufs_force \fR<BOOL>
 
     # When a socket is opened, the kernel configures the max rx buffer size for
     # the socket to /proc/sys/net/core/rmem_default. On some systems this can be
@@ -620,6 +626,78 @@ To force a route/rule to be IPv6, add the keyword "inet6".
         ...
     }
 .fi
+.PP
+.SH VRRP track processes
+.PP
+.nf
+The configuration block looks like:
+
+\fBvrrp_track_process\fR <STRING> {   # VRRP track file declaration
+    \fBprocess\fR <QUOTED_STRING>     # process to monitor
+    \fBweight\fR <-254..254>          # default weight (default is 1)
+    \fBquorum\fR NUM                  # minimum number of processes for success
+    \fBdelay\fR SECS                  # time to delay after process quorum lost before
+                                #   consider process failed (in fractions of second)
+    \fBfull_command\fR                # Normally process string is matched against the process name,
+                                #   as shown on the Name: line in /proc/PID/status.
+                                #   This option matches the full command line
+}
+.fi
+.PP
+To avoid having to frequently run a track_script to monitor the existance
+of processes (often haproxy or nginx), vrrp_track_process can monitor whether
+other processes are running.
+.PP
+One difference from pgrep is track_process doesn't do a regular expression match of the
+command string, but does an exact match. 'pgrep ssh' will match an sshd process, this
+track_process will not (it is equivalent to pgrep "^ssh$").
+.PP
+If full_command is used (equivalent to pgrep -f), /proc/PID/cmdline is used, but
+any updates to cmdline will not be detected (a process shouldn't normally change it,
+although it is possible with great care, for example systemd).
+.PP
+Quorum is the number of matching processes that must be run for an OK status.
+.PP
+Delay might be useful if it anticipated that a process may be reloaded (stopped and
+restarted), and it isn't desired to down and up a vrrp instance.
+.PP
+A positive weight means that an OK status will add <weight> to the priority of all
+VRRP instances which monitor it. On the opposite, a negative weight will be subtracted
+from the initial priority in case of insufficient processes.
+.PP
+If the vrrp instance or sync group is not the address owner and the result is between
+-253 and 253, the result will be added to the initial priority of the VRRP instance
+(a negative value will reduce the priority), although the effective priority will
+be limited to the range [1,254].
+.PP
+If a vrrp instance using a track_process is a member of a sync group, unless
+sync_group_tracking_weight is set on the group weight 0 must be set.
+Likewise, if the vrrp instance is the address owner, weight 0 must also be set.
+.PP
+Rational for not using pgrep/pidof/killall and the likes:
+.PP
+Every time pgrep or its equivalent is run, it iterates though the /proc/[1-9][0-9]*
+directories, and opens the status and cmdline pseudo files in each directory.
+The cmdline pseudo file is mapped to the process's address space, and so if that
+part of the process is swapped out, it will have to be fetched from the swap space.
+pgrep etc also include zombie processes whereas keepalived does not, since they aren't
+running.
+.PP
+This implementation only iterates though /proc/[1-9][0-9]*/ directories at start up, and
+it won't even read the cmdline pseudo files if 'full_command' is not specified for any of
+the vrrp_track_process entries. After startup, it uses the process_events
+kernel <-> userspace connector to receive notification of process changes. If full_command
+is specified for any track_process instance, the cmdline pseudo file will have to be
+read upon notification of the creation of the new process, but at that time it is very
+unlikely that it will have already been swapped out.
+.PP
+On a busy system with a high number of process creations/terminations, using a
+track_script with pgrep/pidof/killall may be more efficient, although those processes
+are inefficient compared to the minimum that keepalived needs.
+.PP
+Using pgrep etc on a system that is swapping can have a significant detrimental impact
+on the performance of the system, due to having to fetch swapped memory from the swap
+space, thereby causing additional swapping.
 .PP
 .SH BFD CONFIGURATION
 .PP

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -49,6 +49,9 @@
 #include "scheduler.h"
 #include "process.h"
 #include "utils.h"
+#ifdef _WITH_CN_PROC_
+#include "track_process.h"
+#endif
 
 /* Global variables */
 int bfd_vrrp_event_pipe[2] = { -1, -1};
@@ -327,9 +330,12 @@ start_bfd_child(void)
 
 	prog_type = PROG_TYPE_BFD;
 
-	/* Close the read end of the event notification pipes */
+	/* Close the read end of the event notification pipes, and the track_process fd */
 #ifdef _WITH_VRRP_
 	close(bfd_vrrp_event_pipe[0]);
+#ifdef _WITH_CN_PROC_
+	close_track_processes();
+#endif
 #endif
 #ifdef _WITH_LVS_
 	close(bfd_checker_event_pipe[0]);

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -66,6 +66,9 @@
 #include "check_bfd.h"
 #endif
 #include "timer.h"
+#ifdef _WITH_CN_PROC_
+#include "track_process.h"
+#endif
 
 /* Global variables */
 bool using_ha_suspend;
@@ -513,13 +516,16 @@ start_check_child(void)
 	initialise_debug_options();
 
 #ifdef _WITH_BFD_
-	/* Close the write end of the BFD checker event notification pipe */
+	/* Close the write end of the BFD checker event notification pipe and the track_process fd */
 	close(bfd_checker_event_pipe[1]);
 
 #ifdef _WITH_VRRP_
 	close(bfd_vrrp_event_pipe[0]);
 	close(bfd_vrrp_event_pipe[1]);
 #endif
+#endif
+#ifdef _WITH_CN_PROC_
+	close_track_processes();
 #endif
 
 	if ((global_data->instance_name

--- a/keepalived/core/Makefile.am
+++ b/keepalived/core/Makefile.am
@@ -35,4 +35,9 @@ if LIBNL_DYNAMIC
   EXTRA_libcore_a_SOURCES += libnl_link.c
 endif
 
+if CN_PROC
+  libcore_a_LIBADD	+= track_process.o
+  EXTRA_libcore_a_SOURCES += track_process.c
+endif
+
 MAINTAINERCLEANFILES	= @MAINTAINERCLEANFILES@

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -574,6 +574,10 @@ dump_global_data(FILE *fp, data_t * data)
 	conf_write(fp, " vrrp_netlink_cmd_rcv_bufs_force = %u", global_data->vrrp_netlink_cmd_rcv_bufs_force);
 	conf_write(fp, " vrrp_netlink_monitor_rcv_bufs = %u", global_data->vrrp_netlink_monitor_rcv_bufs);
 	conf_write(fp, " vrrp_netlink_monitor_rcv_bufs_force = %u", global_data->vrrp_netlink_monitor_rcv_bufs_force);
+#ifdef _WITH_CN_PROC_
+	conf_write(fp, " process_monitor_rcv_bufs = %u", global_data->process_monitor_rcv_bufs);
+	conf_write(fp, " process_monitor_rcv_bufs_force = %u", global_data->process_monitor_rcv_bufs_force);
+#endif
 #endif
 #ifdef _WITH_LVS_
 	conf_write(fp, " lvs_netlink_cmd_rcv_bufs = %u", global_data->lvs_netlink_cmd_rcv_bufs);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -1298,6 +1298,41 @@ vrrp_netlink_cmd_rcv_bufs_force_handler(vector_t *strvec)
 
 	global_data->vrrp_netlink_cmd_rcv_bufs_force = res;
 }
+
+#ifdef _WITH_CN_PROC_
+static void
+process_monitor_rcv_bufs_handler(vector_t *strvec)
+{
+	unsigned val;
+
+	if (!strvec)
+		return;
+
+	val = get_netlink_rcv_bufs_size(strvec, "process_monitor");
+
+	if (val)
+		global_data->process_monitor_rcv_bufs = val;
+}
+
+static void
+process_monitor_rcv_bufs_force_handler(vector_t *strvec)
+{
+	int res = true;
+
+	if (!strvec)
+		return;
+
+	if (vector_size(strvec) >= 2) {
+		res = check_true_false(strvec_slot(strvec,1));
+		if (res < 0) {
+			report_config_error(CONFIG_GENERAL_ERROR, "Invalid value '%s' for global process_monitor_rcv_bufs_force specified", FMT_STR_VSLOT(strvec, 1));
+			return;
+		}
+	}
+
+	global_data->process_monitor_rcv_bufs_force = res;
+}
+#endif
 #endif
 
 #ifdef _WITH_LVS_
@@ -1612,6 +1647,10 @@ init_global_keywords(bool global_active)
 	install_keyword("vrrp_netlink_cmd_rcv_bufs_force", &vrrp_netlink_cmd_rcv_bufs_force_handler);
 	install_keyword("vrrp_netlink_monitor_rcv_bufs", &vrrp_netlink_monitor_rcv_bufs_handler);
 	install_keyword("vrrp_netlink_monitor_rcv_bufs_force", &vrrp_netlink_monitor_rcv_bufs_force_handler);
+#ifdef _WITH_CN_PROC_
+	install_keyword("process_monitor_rcv_bufs", &process_monitor_rcv_bufs_handler);
+	install_keyword("process_monitor_rcv_bufs_force", &process_monitor_rcv_bufs_force_handler);
+#endif
 #endif
 #ifdef _WITH_LVS_
 	install_keyword("lvs_netlink_cmd_rcv_bufs", &lvs_netlink_cmd_rcv_bufs_handler);

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -553,6 +553,11 @@ netlink_socket(nl_handle_t *nl, unsigned rcvbuf_size, bool force, int flags, int
 		return -1;
 #endif
 
+#if !HAVE_DECL_SOCK_CLOEXEC
+	if (set_sock_flags(nl->fd, F_SETFD, FD_CLOEXEC))
+		log_message(LOG_INFO, "Unable to set CLOEXEC on netlink socket - %s (%d)", strerror(errno), errno);
+#endif
+
 	memset(&snl, 0, sizeof (snl));
 	snl.nl_family = AF_NETLINK;
 

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -61,6 +61,9 @@
 #include "vrrp_daemon.h"
 #include "vrrp_parser.h"
 #include "vrrp_if.h"
+#ifdef _WITH_CN_PROC_
+#include "track_process.h"
+#endif
 #ifdef _WITH_JSON_
 #include "vrrp_json.h"
 #endif
@@ -1800,6 +1803,12 @@ keepalived_main(int argc, char **argv)
 			create_pid_dir();
 		}
 	}
+
+	/* If we want to monitor processes, we have to do it before calling
+	 * setns() */
+#ifdef _WITH_CN_PROC_
+	open_track_processes();
+#endif
 
 #if HAVE_DECL_CLONE_NEWNET
 	if (global_data->network_namespace) {

--- a/keepalived/core/track_process.c
+++ b/keepalived/core/track_process.c
@@ -1,0 +1,794 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        Process tracking framework.
+ *
+ * Author:      Alexandre Cassen, <acassen@linux-vs.org>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2018-2018 Alexandre Cassen, <acassen@gmail.com>
+ */
+
+/* For details on the proc connector, see:
+ *
+ * https://stackoverflow.com/questions/26852228/detect-new-process-creation-instantly-in-linux
+ * https://unix.stackexchange.com/questions/260162/how-to-track-newly-created-processes-in-linux
+ * http://netsplit.com/the-proc-connector-and-socket-filters
+ */
+
+#include "config.h"
+
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <linux/connector.h>
+#include <linux/cn_proc.h>
+#include <signal.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "track_process.h"
+#include "global_data.h"
+#include "list.h"
+#if !HAVE_DECL_SOCK_NONBLOCK
+#include "old_socket.h"
+#endif
+#include "rbtree.h"
+#include "vrrp_data.h"
+#include "bitops.h"
+
+static thread_t *read_thread;
+static thread_t *reload_thread;
+static rb_root_t process_tree = RB_ROOT;
+static int nl_sock = -1;
+unsigned num_cpus;
+static int64_t *cpu_seq;
+static bool need_reinitialise;
+
+static void
+set_rcv_buf(unsigned buf_size, bool force)
+{
+	if (setsockopt(nl_sock, SOL_SOCKET, force ? SO_RCVBUFFORCE : SO_RCVBUF, &buf_size, sizeof(buf_size)) < 0)
+		log_message(LOG_INFO, "Cannot set process monitor SO_RCVBUF%s option. errno=%d (%m)", force ? "FORCE" : "", errno);
+}
+
+static int
+pid_compare(const tracked_process_instance_t *tpi1, const tracked_process_instance_t *tpi2)
+{
+	return tpi1->pid - tpi2->pid;
+}
+
+static inline void
+add_process(pid_t pid, vrrp_tracked_process_t *tpr)
+{
+	tracked_process_instance_t tp = { .pid = pid };
+	tracked_process_instance_t *tpi;
+
+	if (!(tpi = rb_search(&process_tree, &tp, pid_tree, pid_compare))) {
+		PMALLOC(tpi);
+		tpi->pid = tp.pid;
+		tpi->processes = alloc_list(NULL, NULL);
+		RB_CLEAR_NODE(&tpi->pid_tree);
+		rb_insert_sort(&process_tree, tpi, pid_tree, pid_compare);
+	}
+
+	list_add(tpi->processes, tpr);
+	++tpr->num_cur_proc;
+}
+
+#ifdef UNUSED_CODE
+static int scandir_filter(const struct dirent *dirent)
+{
+	if (dirent->d_type != DT_DIR)
+		return false;
+
+	if (dirent->d_name[0] <= '0' || dirent->d_name[0] > '9')
+		return false;
+
+	return true;
+}
+
+static int
+scandir_sort(const struct dirent **a, const struct dirent **b)
+{
+	return 0;
+}
+
+static pid_t
+read_procs(const char *name)
+{
+	struct dirent **namelist;
+	struct dirent **ent_p;
+	struct dirent *ent;
+	int ret;
+
+	ret = scandir("/proc", &namelist, scandir_filter, scandir_sort);
+	log_message(LOG_INFO, "scandir returned %d\n", ret);
+
+	for (ent_p = namelist, ent = *namelist; ret--; ent = *++ent_p) {
+		log_message(LOG_INFO, "0x%p: %s\n", ent, ent->d_name);
+		free(ent);
+	}
+
+	free(namelist);
+}
+#endif
+
+static void
+read_procs(list processes)
+{
+	/* /proc/PID/status has line State: which can be Z for zombie process (but cmdline is empty then)
+	 * /proc/PID/stat has cmd name as 2nd field in (), and state as third field. For states see
+	 * man proc(5)
+	 * pgrep uses status and cmdline files. Without -f, pgrep looks at comm (in status/stat/comm). If
+	 * -f is specified, it reads cmdline.
+	 * To change comm for a process, use prctl(PR_SET_NAME). */
+	DIR *proc_dir = opendir("/proc");
+	struct dirent *ent;
+	char cmdline[22];	/* "/proc/xxxxxxx/cmdline" */
+	int fd;
+	char cmd_buf[vrrp_data->vrrp_max_process_name_len + 2];
+	char stat_buf[128];
+	char *p;
+	char *comm;
+	ssize_t len;
+	char *proc_name;
+	vrrp_tracked_process_t *tpr;
+	element e;
+
+	while ((ent = readdir(proc_dir))) {
+		if (ent->d_type != DT_DIR)
+			continue;
+		if (ent->d_name[0] <= '0' || ent->d_name[0] >= '9')
+			continue;
+
+		/* We want to avoid reading /proc/PID/cmdline, since it reads the process
+		 * address space, and if the process is swapped out, then it will have to be
+		 * swapped in to read it. */
+		if (vrrp_data->vrrp_use_process_cmdline) {
+			snprintf(cmdline, sizeof(cmdline), "/proc/%.7s/cmdline", ent->d_name);
+
+			if ((fd = open(cmdline, O_RDONLY)) == -1)
+				continue;
+
+			len = read(fd, cmd_buf, sizeof(cmd_buf) - 1);
+			close(fd);
+			cmd_buf[len] = '\0';
+		}
+
+		if (vrrp_data->vrrp_use_process_comm) {
+			snprintf(cmdline, sizeof(cmdline), "/proc/%.7s/stat", ent->d_name);
+
+			if ((fd = open(cmdline, O_RDONLY)) == -1)
+				continue;
+
+			len = read(fd, stat_buf, sizeof(stat_buf) - 1);
+			close(fd);
+			stat_buf[len] = '\0';
+			if (len && stat_buf[len-1] == '\n')
+				stat_buf[len - 1] = '\0';
+
+			/* Find the comm field, terminate it and check not a zombie process */
+			p = strchr(stat_buf + 2, '(');
+			if (!p)
+				continue;
+
+			comm = p + 1;
+			p = strchr(p, ')');
+			if (!p)
+				continue;
+			*p = '\0';
+			if (p[2] == 'Z')
+				continue;
+		}
+
+		LIST_FOREACH(processes, tpr, e) {
+			if (tpr->full_command)
+				proc_name = cmd_buf;
+			else
+				proc_name = comm;
+
+			if (!strcmp(proc_name, tpr->process_path)) {
+				/* We have got a match */
+				add_process(atoi(ent->d_name), tpr);
+			}
+		}
+	}
+
+	closedir(proc_dir);
+}
+
+static void
+check_process(pid_t pid, char *comm)
+{
+	char cmdline[22];	/* "/proc/xxxxxxx/cmdline" */
+	int fd;
+	char cmd_buf[vrrp_data->vrrp_max_process_name_len + 2];
+	char comm_buf[17];
+	ssize_t len;
+	char *proc_name;
+	vrrp_tracked_process_t *tpr;
+	element e;
+
+	/* We want to avoid reading /proc/PID/cmdline, since it reads the process
+	 * address space, and if the process is swapped out, then it will have to be
+	 * swapped in to read it. */
+	if (vrrp_data->vrrp_use_process_cmdline) {
+		snprintf(cmdline, sizeof(cmdline), "/proc/%d/cmdline", pid);
+
+		if ((fd = open(cmdline, O_RDONLY)) == -1)
+			return;
+
+		len = read(fd, cmd_buf, sizeof(cmd_buf) - 1);
+		close(fd);
+		cmd_buf[len] = '\0';
+	}
+
+	if (vrrp_data->vrrp_use_process_comm && !comm) {
+		snprintf(cmdline, sizeof(cmdline), "/proc/%d/comm", pid);
+
+		if ((fd = open(cmdline, O_RDONLY)) == -1)
+			return;
+
+		len = read(fd, comm_buf, sizeof(comm_buf) - 1);
+		close(fd);
+		comm_buf[len] = '\0';
+		if (len && comm_buf[len-1] == '\n')
+			comm_buf[len-1] = '\0';
+		comm = comm_buf;
+	}
+
+	LIST_FOREACH(vrrp_data->vrrp_track_processes, tpr, e) {
+		if (tpr->full_command)
+			proc_name = cmd_buf;
+		else
+			proc_name = comm;
+
+		if (!strcmp(proc_name, tpr->process_path)) {
+			/* We have got a match */
+			add_process(pid, tpr);
+
+			if (tpr->num_cur_proc == tpr->quorum) {
+				/* Cancel timer thread if any, otherwise update status */
+				if (tpr->timer_thread) {
+					thread_cancel(tpr->timer_thread);
+					tpr->timer_thread = NULL;
+				}
+				else
+					process_update_track_process_status(tpr, true);
+			}
+		}
+	}
+}
+
+static void
+check_process_fork(pid_t parent_pid, pid_t child_pid)
+{
+	tracked_process_instance_t tp = { .pid = parent_pid };
+	tracked_process_instance_t *tpi, *tpi_child;
+	vrrp_tracked_process_t *tpr;
+	element e;
+
+	/* If we aren't interested in the parent, we aren't interested in the child */
+	if (!(tpi = rb_search(&process_tree, &tp, pid_tree, pid_compare)))
+		return;
+
+	PMALLOC(tpi_child);
+	tpi_child->pid = child_pid;
+	tpi_child->processes = alloc_list(NULL, NULL);
+	RB_CLEAR_NODE(&tpi_child->pid_tree);
+	rb_insert_sort(&process_tree, tpi_child, pid_tree, pid_compare);
+
+	LIST_FOREACH(tpi->processes, tpr, e)
+	{
+		list_add(tpi_child->processes, tpr);
+		if (++tpr->num_cur_proc == tpr->quorum)
+			process_update_track_process_status(tpr, true);
+	}
+}
+
+static int
+process_lost_quorum_timer_thread(thread_t *thread)
+{
+	vrrp_tracked_process_t *tpr = thread->arg;
+
+	process_update_track_process_status(tpr, false);
+	tpr->timer_thread = NULL;
+
+	return 0;
+}
+
+static void
+check_process_termination(pid_t pid)
+{
+	tracked_process_instance_t tp = { .pid = pid };
+	tracked_process_instance_t *tpi;
+	vrrp_tracked_process_t *tpr;
+	element e;
+
+	tpi = rb_search(&process_tree, &tp, pid_tree, pid_compare);
+
+	if (!tpi)
+		return;
+
+	LIST_FOREACH(tpi->processes, tpr, e)
+	{
+		if (tpr->num_cur_proc-- == tpr->quorum) {
+			if (tpr->delay)
+				tpr->timer_thread = thread_add_timer(master, process_lost_quorum_timer_thread, tpr, tpr->delay);
+			else
+				process_update_track_process_status(tpr, false);
+		}
+	}
+
+	free_list(&tpi->processes);
+	rb_erase(&tpi->pid_tree, &process_tree);
+	FREE(tpi);
+}
+
+static void
+check_process_comm_change(pid_t pid, char *comm)
+{
+	tracked_process_instance_t tp = { .pid = pid };
+	tracked_process_instance_t *tpi;
+	vrrp_tracked_process_t *tpr;
+	element e, next;
+
+	tpi = rb_search(&process_tree, &tp, pid_tree, pid_compare);
+
+	if (tpi) {
+		LIST_FOREACH_NEXT(tpi->processes, tpr, e, next)
+		{
+			if (tpr->full_command)
+				continue;
+
+			list_remove(tpi->processes, e);
+			if (tpr->num_cur_proc-- == tpr->quorum) {
+				if (tpr->delay)
+					tpr->timer_thread = thread_add_timer(master, process_lost_quorum_timer_thread, tpr, tpr->delay);
+				else
+					process_update_track_process_status(tpr, false);
+			}
+		}
+
+		if (LIST_ISEMPTY(tpi->processes)) {
+			free_list(&tpi->processes);
+			rb_erase(&tpi->pid_tree, &process_tree);
+			FREE(tpi);
+		}
+	}
+
+	check_process(pid, comm);
+}
+
+/*
+ * connect to netlink
+ * returns netlink socket, or -1 on error
+ */
+static int
+nl_connect(void)
+{
+	int rc;
+	int nl_sock;
+	struct sockaddr_nl sa_nl;
+
+	nl_sock = socket(PF_NETLINK, SOCK_DGRAM | SOCK_CLOEXEC | SOCK_NONBLOCK, NETLINK_CONNECTOR);
+	if (nl_sock == -1) {
+		log_message(LOG_INFO, "Failed to open process monitoring socket - errno %d - %m", errno);
+		return -1;
+	}
+
+#if !HAVE_DECL_SOCK_NONBLOCK
+        if (set_sock_flags(nl_sock, F_SETFL, O_NONBLOCK))
+                log_message(LOG_INFO, "Unable to set NONBLOCK on netlink process socket - %s (%d)", strerror(errno), errno);
+#endif
+
+#if !HAVE_DECL_SOCK_CLOEXEC
+        if (set_sock_flags(nl_sock, F_SETFD, FD_CLOEXEC))
+                log_message(LOG_INFO, "Unable to set CLOEXEC on netlink process socket - %s (%d)", strerror(errno), errno);
+#endif
+
+	sa_nl.nl_family = AF_NETLINK;
+	sa_nl.nl_groups = CN_IDX_PROC;
+	sa_nl.nl_pid = getpid();
+
+	rc = bind(nl_sock, (struct sockaddr *)&sa_nl, sizeof(sa_nl));
+	if (rc == -1) {
+		log_message(LOG_INFO, "Failed to bind to process monitoring socket - errno %d - %m", errno);
+		close(nl_sock);
+		return -1;
+	}
+
+	return nl_sock;
+}
+
+/*
+ * subscribe on proc events (process notifications)
+ */
+static int set_proc_ev_listen(int nl_sock, bool enable)
+{
+	int rc;
+	struct __attribute__ ((aligned(NLMSG_ALIGNTO))) {
+		struct nlmsghdr nl_hdr;
+		struct __attribute__ ((__packed__)) {
+			struct cn_msg cn_msg;
+			enum proc_cn_mcast_op cn_mcast;
+		};
+	} nlcn_msg;
+
+	memset(&nlcn_msg, 0, sizeof(nlcn_msg));
+	nlcn_msg.nl_hdr.nlmsg_len = sizeof(nlcn_msg);
+	nlcn_msg.nl_hdr.nlmsg_pid = getpid();
+	nlcn_msg.nl_hdr.nlmsg_type = NLMSG_DONE;
+
+	nlcn_msg.cn_msg.id.idx = CN_IDX_PROC;
+	nlcn_msg.cn_msg.id.val = CN_VAL_PROC;
+	nlcn_msg.cn_msg.len = sizeof(enum proc_cn_mcast_op);
+
+	nlcn_msg.cn_mcast = enable ? PROC_CN_MCAST_LISTEN : PROC_CN_MCAST_IGNORE;
+
+	rc = send(nl_sock, &nlcn_msg, sizeof(nlcn_msg), 0);
+	if (rc == -1) {
+		log_message(LOG_INFO, "Failed to set/clear process event listen - errno %d - %m", errno);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+process_lost_messages_timer_thread(__attribute__((unused)) thread_t *thread)
+{
+	reload_thread = NULL;
+	unsigned buf_size;
+	socklen_t buf_size_len = sizeof(buf_size);
+	unsigned i;
+	vrrp_tracked_process_t *tpr;
+	element e;
+	tracked_process_instance_t *tpi, *next;
+
+	need_reinitialise = false;
+
+	if (getsockopt(nl_sock, SOL_SOCKET, SO_RCVBUF, &buf_size, &buf_size_len) < 0) {
+		log_message(LOG_INFO, "Cannot get process monitor SO_RCVBUF option. errno=%d (%m)", errno);
+		return 0;
+	}
+
+	buf_size *= 2;
+	set_rcv_buf(buf_size, global_data->process_monitor_rcv_bufs_force);
+
+	log_message(LOG_INFO, "Setting global_def process_monitor_rcv_bufs to %u - recommend updating configuration file", buf_size);
+
+	/* Reset the sequence numbers */
+	for (i = 0; i < num_cpus; i++)
+		cpu_seq[i] = -1;
+
+	/* Remove the existing process tree */
+	rb_for_each_entry_safe(tpi, next, &process_tree, pid_tree) {
+		free_list(&tpi->processes);
+		rb_erase(&tpi->pid_tree, &process_tree);
+		FREE(tpi);
+	}
+
+	/* Save process counters, and clear any down timers */
+	LIST_FOREACH(vrrp_data->vrrp_track_processes, tpr, e) {
+		tpr->sav_num_cur_proc = tpr->num_cur_proc;
+		tpr->num_cur_proc = 0;
+		if (tpr->timer_thread) {
+			thread_cancel(tpr->timer_thread);
+			tpr->timer_thread = NULL;
+		}
+	}
+
+	/* Re read processes */
+	read_procs(vrrp_data->vrrp_track_processes);
+
+	/* See if anything changed */
+	LIST_FOREACH(vrrp_data->vrrp_track_processes, tpr, e) {
+		if (tpr->sav_num_cur_proc != tpr->num_cur_proc) {
+			if ((tpr->sav_num_cur_proc < tpr->quorum) == (tpr->num_cur_proc < tpr->quorum)) {
+				if (__test_bit(LOG_DETAIL_BIT, &debug))
+					log_message(LOG_INFO, "Process %s, number of current processes changed from %u to %u", tpr->pname, tpr->sav_num_cur_proc, tpr->num_cur_proc);
+				continue;
+			}
+			if (tpr->num_cur_proc >= tpr->quorum) {
+				if (__test_bit(LOG_DETAIL_BIT, &debug))
+					log_message(LOG_INFO, "Process %s, number of current processes changed from %u to %u, quorum up", tpr->pname, tpr->sav_num_cur_proc, tpr->num_cur_proc);
+				process_update_track_process_status(tpr, true);
+			} else {
+				if (__test_bit(LOG_DETAIL_BIT, &debug))
+					log_message(LOG_INFO, "Process %s, number of current processes changed from %u to %u, quorum down", tpr->pname, tpr->sav_num_cur_proc, tpr->num_cur_proc);
+				if (tpr->delay)
+					tpr->timer_thread = thread_add_timer(master, process_lost_quorum_timer_thread, tpr, tpr->delay);
+				else
+					process_update_track_process_status(tpr, false);
+			}
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * handle a single process event
+ */
+static volatile bool need_exit = false;
+static int handle_proc_ev(int nl_sock)
+{
+	struct nlmsghdr *nlmsghdr;
+	ssize_t len;
+	char __attribute__ ((aligned(NLMSG_ALIGNTO)))buf[4096];
+	struct cn_msg *cn_msg;
+	struct proc_event *proc_ev;
+
+	while (!need_exit) {
+		len = recv(nl_sock, &buf, sizeof(buf), 0);
+		if (len == 0)
+			return 0;
+		else if (len == -1) {
+			if (errno == EINTR)
+				continue;
+			if (errno == EAGAIN)
+				return 0;
+
+			if (errno == ENOBUFS) {
+				/* We have missed some messages. Allow time for
+				 * things to settle down, and reinitialise. */
+				if (reload_thread)
+					thread_cancel(reload_thread);
+				reload_thread = thread_add_timer(master, process_lost_messages_timer_thread, NULL, TIMER_HZ);
+				need_reinitialise = true;
+			}
+			else
+				log_message(LOG_INFO, "process monitor netlink recv error %d - %m", errno);
+
+			return -1;
+		}
+		for (nlmsghdr = (struct nlmsghdr *)buf;
+                        NLMSG_OK (nlmsghdr, len);
+                        nlmsghdr = NLMSG_NEXT (nlmsghdr, len)) {
+
+			if (nlmsghdr->nlmsg_type == NLMSG_ERROR ||
+			    nlmsghdr->nlmsg_type == NLMSG_NOOP)
+				continue;
+
+			cn_msg = NLMSG_DATA(nlmsghdr);
+			if ((cn_msg->id.idx != CN_IDX_PROC) ||
+                            (cn_msg->id.val != CN_VAL_PROC))
+                                continue;
+
+			proc_ev = (struct proc_event *)cn_msg->data;
+			if ((!need_reinitialise || __test_bit(LOG_DETAIL_BIT, &debug)) &&
+			    cpu_seq[proc_ev->cpu] != -1 &&
+			    !(cpu_seq[proc_ev->cpu] + 1 == cn_msg->seq ||
+			      (cn_msg->seq == 0 && cpu_seq[proc_ev->cpu] == UINT32_MAX)))
+				log_message(LOG_INFO, "Missed %ld messages on CPU %d", cn_msg->seq - cpu_seq[proc_ev->cpu] - 1, proc_ev->cpu);
+
+			cpu_seq[proc_ev->cpu] = cn_msg->seq;
+
+			switch (proc_ev->what)
+			{
+			case PROC_EVENT_NONE:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "set mcast listen ok");
+#endif
+				break;
+			case PROC_EVENT_FORK:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				/* See if we have parent pid, in which case this is a new process */
+				log_message(LOG_INFO, "fork: parent tid=%d pid=%d -> child tid=%d pid=%d",
+						proc_ev->event_data.fork.parent_pid,
+						proc_ev->event_data.fork.parent_tgid,
+						proc_ev->event_data.fork.child_pid,
+						proc_ev->event_data.fork.child_tgid);
+#endif
+				check_process_fork(proc_ev->event_data.fork.parent_pid, proc_ev->event_data.fork.child_pid);
+				break;
+			case PROC_EVENT_EXEC:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "exec: tid=%d pid=%d",
+						proc_ev->event_data.exec.process_pid,
+						proc_ev->event_data.exec.process_tgid);
+#endif
+				// We may be losing a process. Check if have pid, and check new cmdline */
+				check_process(proc_ev->event_data.exec.process_pid, NULL);
+				break;
+			case PROC_EVENT_UID:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "uid change: tid=%d pid=%d from %d to %d",
+						proc_ev->event_data.id.process_pid,
+						proc_ev->event_data.id.process_tgid,
+						proc_ev->event_data.id.r.ruid,
+						proc_ev->event_data.id.e.euid);
+#endif
+				break;
+			case PROC_EVENT_GID:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "gid change: tid=%d pid=%d from %d to %d",
+						proc_ev->event_data.id.process_pid,
+						proc_ev->event_data.id.process_tgid,
+						proc_ev->event_data.id.r.rgid,
+						proc_ev->event_data.id.e.egid);
+#endif
+				break;
+			case PROC_EVENT_SID:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "sid change: tid=%d pid=%d",
+						proc_ev->event_data.sid.process_pid,
+						proc_ev->event_data.sid.process_tgid);
+#endif
+				break;
+			case PROC_EVENT_PTRACE:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "ptrace change: tid=%d pid=%d tracer tid=%d, pid=%d",
+						proc_ev->event_data.ptrace.process_pid,
+						proc_ev->event_data.ptrace.process_tgid,
+						proc_ev->event_data.ptrace.tracer_tgid,
+						proc_ev->event_data.ptrace.tracer_pid);
+#endif
+				break;
+			case PROC_EVENT_COMM:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "comm: tid=%d pid=%d comm %s",
+						proc_ev->event_data.comm.process_pid,
+						proc_ev->event_data.comm.process_tgid,
+						proc_ev->event_data.comm.comm);
+#endif
+				check_process_comm_change(proc_ev->event_data.comm.process_pid, proc_ev->event_data.comm.comm);
+				break;
+			case PROC_EVENT_COREDUMP:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "coredump: tid=%d pid=%d",
+						proc_ev->event_data.coredump.process_pid,
+						proc_ev->event_data.coredump.process_tgid);
+#endif
+				break;
+			case PROC_EVENT_EXIT:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "exit: tid=%d pid=%d exit_code=%u, signal=%u,",
+						proc_ev->event_data.exit.process_pid,
+						proc_ev->event_data.exit.process_tgid,
+						proc_ev->event_data.exit.exit_code,
+						proc_ev->event_data.exit.exit_signal);
+#endif
+				check_process_termination(proc_ev->event_data.exit.process_pid);
+				break;
+			default:
+#ifdef LOG_ALL_PROCESS_EVENTS
+				log_message(LOG_INFO, "unhandled proc event %d", proc_ev->what);
+#endif
+				break;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int
+read_process_update(thread_t *thread)
+{
+	int rc = EXIT_SUCCESS;
+
+	rc = handle_proc_ev(thread->u.fd);
+
+	read_thread = thread_add_read(thread->master, read_process_update, NULL, thread->u.fd, TIMER_NEVER);
+
+	return rc;
+}
+
+bool
+open_track_processes(void)
+{
+	nl_sock = nl_connect();
+	if (nl_sock == -1)
+		return true ;
+
+	return false;
+}
+
+bool
+close_track_processes(void)
+{
+	if (nl_sock == -1)
+		return true;
+
+	close(nl_sock);
+
+	nl_sock = -1;
+
+	return false;
+}
+
+bool
+init_track_processes(list processes)
+{
+	int rc = EXIT_SUCCESS;
+	unsigned i;
+
+	if (global_data->process_monitor_rcv_bufs)
+		set_rcv_buf(global_data->process_monitor_rcv_bufs, global_data->process_monitor_rcv_bufs_force);
+
+	rc = set_proc_ev_listen(nl_sock, true);
+	if (rc == -1) {
+		close(nl_sock);
+		nl_sock = -1;
+		return EXIT_FAILURE;
+	}
+
+	if (!cpu_seq) {
+		num_cpus = sysconf(_SC_NPROCESSORS_CONF);
+		cpu_seq = MALLOC(num_cpus * sizeof(*cpu_seq));
+		for (i = 0; i < num_cpus; i++)
+			cpu_seq[i] = -1;
+	}
+
+	read_procs(processes);
+
+	read_thread = thread_add_read(master, read_process_update, NULL, nl_sock, TIMER_NEVER);
+
+	return rc;
+}
+
+void
+end_process_monitor(void)
+{
+	vrrp_tracked_process_t *tpr;
+	element e;
+	tracked_process_instance_t *tpi, *next;
+
+	set_proc_ev_listen(nl_sock, false);
+
+	if (read_thread) {
+		thread_cancel(read_thread);
+		read_thread = NULL;
+	}
+
+	close(nl_sock);
+	nl_sock = -1;
+
+	FREE(cpu_seq);
+
+	/* Cancel any timer threads */
+	LIST_FOREACH(vrrp_data->vrrp_track_processes, tpr, e) {
+		if (tpr->timer_thread) {
+			thread_cancel(tpr->timer_thread);
+			tpr->timer_thread = NULL;
+		}
+	}
+
+	rb_for_each_entry_safe(tpi, next, &process_tree, pid_tree) {
+		free_list(&tpi->processes);
+		rb_erase(&tpi->pid_tree, &process_tree);
+		FREE(tpi);
+	}
+}
+
+#ifdef THREAD_DUMP
+void
+register_process_monitor_addresses(void)
+{
+	register_thread_address("process_lost_quorum", process_lost_quorum_timer_thread);
+	register_thread_address("process_lost_messages", process_lost_messages_timer_thread);
+	register_thread_address("monitor_processes", read_process_update);
+}
+#endif

--- a/keepalived/core/track_process.c
+++ b/keepalived/core/track_process.c
@@ -54,6 +54,7 @@
 #endif
 #include "rbtree.h"
 #include "vrrp_data.h"
+#include "utils.h"
 #include "bitops.h"
 
 static thread_t *read_thread;

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -209,6 +209,10 @@ typedef struct _data {
 	bool				vrrp_netlink_cmd_rcv_bufs_force;
 	unsigned			vrrp_netlink_monitor_rcv_bufs;
 	bool				vrrp_netlink_monitor_rcv_bufs_force;
+#ifdef _WITH_CN_PROC_
+	unsigned			process_monitor_rcv_bufs;
+	bool				process_monitor_rcv_bufs_force;
+#endif
 #endif
 #ifdef _WITH_LVS_
 	unsigned			lvs_netlink_cmd_rcv_bufs;

--- a/keepalived/include/track_process.h
+++ b/keepalived/include/track_process.h
@@ -1,0 +1,43 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        track_process.c include file.
+ *
+ * Author:      Alexandre Cassen, <acassen@linux-vs.org>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2018-2018 Alexandre Cassen, <acassen@gmail.com>
+ */
+
+#ifndef _VRRP_TRACK_PROCESS_H
+#define _VRRP_TRACK_PROCESS_H
+
+/* global includes */
+
+/* local includes */
+#include "track_process.h"
+#include "list.h"
+#include "vrrp.h"
+
+
+/* prototypes */
+extern bool open_track_processes(void);
+extern bool close_track_processes(void);
+extern bool init_track_processes(list);
+extern void end_process_monitor(void);
+#ifdef THREAD_DUMP
+extern void register_process_monitor_addresses(void);
+#endif
+
+#endif

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -116,6 +116,9 @@ typedef struct _vrrp_sgroup {
 	list			track_ifp;		/* Interface state we monitor */
 	list			track_script;		/* Script state we monitor */
 	list			track_file;		/* Files whose value we monitor (list of tracked_file_t) */
+#ifdef _WITH_CN_PROC_
+	list			track_process;		/* Processes we monitor (list of tracked_process_t) */
+#endif
 #ifdef _WITH_BFD_
 	list			track_bfd;		/* List of tracked_bfd_t */
 #endif
@@ -199,6 +202,9 @@ typedef struct _vrrp_t {
 	list			track_ifp;		/* Interface state we monitor */
 	list			track_script;		/* Script state we monitor */
 	list			track_file;		/* list of tracked_file_t - Files whose value we monitor */
+#ifdef _WITH_CN_PROC_
+	list			track_process;		/* list of tracked_process_t - Processes we monitor */
+#endif
 #ifdef _WITH_BFD_
 	list			track_bfd;		/* List of tracked_bfd_t */
 #endif

--- a/keepalived/include/vrrp_data.h
+++ b/keepalived/include/vrrp_data.h
@@ -26,6 +26,7 @@
 /* system includes */
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 /* local includes */
 #include "list.h"
@@ -44,6 +45,12 @@ typedef struct _vrrp_data {
 	list			vrrp_socket_pool;
 	list			vrrp_script;		/* vrrp_script_t */
 	list			vrrp_track_files;	/* vrrp_tracked_file_t */
+#ifdef _WITH_CN_PROC_
+	list			vrrp_track_processes;	/* vrrp_tracked_process_t */
+	size_t			vrrp_max_process_name_len;
+	bool			vrrp_use_process_cmdline;
+	bool			vrrp_use_process_comm;
+#endif
 #ifdef _WITH_BFD_
 	list			vrrp_track_bfds;	/* vrrp_tracked_bfd_t */
 #endif
@@ -68,12 +75,19 @@ extern void alloc_vrrp_script(char *);
 extern void alloc_vrrp_track_script(vector_t *);
 extern void alloc_vrrp_file(char *);
 extern void alloc_vrrp_track_file(vector_t *);
+#ifdef _WITH_CN_PROC_
+extern void alloc_vrrp_process(char *);
+extern void alloc_vrrp_track_process(vector_t *);
+#endif
 #ifdef _WITH_BFD_
 extern void alloc_vrrp_track_bfd(vector_t *);
 #endif
 extern void alloc_vrrp_group_track_if(vector_t *);
 extern void alloc_vrrp_group_track_script(vector_t *);
 extern void alloc_vrrp_group_track_file(vector_t *);
+#ifdef _WITH_CN_PROC_
+extern void alloc_vrrp_group_track_process(vector_t *);
+#endif
 #ifdef _WITH_BFD_
 extern void alloc_vrrp_group_track_bfd(vector_t *);
 #endif

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -80,6 +80,9 @@
 #ifdef _WITH_FIREWALL_
 #include "vrrp_firewall.h"
 #endif
+#ifdef _WITH_CN_PROC_
+#include "track_process.h"
+#endif
 
 /* Global variables */
 bool non_existent_interface_specified;
@@ -338,6 +341,11 @@ vrrp_terminate_phase1(bool schedule_next_thread)
 #ifdef _WITH_PERF_
 	if (perf_run == PERF_END)
 		run_perf("vrrp", global_data->network_namespace, global_data->instance_name);
+#endif
+
+#ifdef _WITH_CN_PROC_
+	/* Stop monitoring process terminations */
+	end_process_monitor();
 #endif
 
 	/* Terminate all script processes */
@@ -861,6 +869,9 @@ register_vrrp_thread_addresses(void)
 #endif
 	register_vrrp_fifo_addresses();
 	register_vrrp_inotify_addresses();
+#ifdef _WITH_CN_PROC_
+	register_process_monitor_addresses();
+#endif
 
 #ifndef _DEBUG_
 	register_thread_address("print_vrrp_data", print_vrrp_data);

--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -702,10 +702,7 @@ clear_address_list(list delete_addr,
 	netlink_iplist(delete_addr, IPADDRESS_DEL, false);
 #ifdef _WITH_FIREWALL_
 	if (remove_from_firewall)
-{
-log_message(LOG_INFO, "In clear_address_list");
 		firewall_remove_rule_to_iplist(delete_addr, false);
-}
 #endif
 }
 

--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -1458,7 +1458,7 @@ alloc_route(list rt_list, vector_t *strvec, bool allow_track_group)
 		else if (!strcmp(str, "metric") ||
 			 !strcmp(str, "priority") ||
 			 !strcmp(str, "preference")) {
-			if (get_u32(&new->metric, strvec_slot(strvec, ++i), UINT32_MAX, "Invalid MTU %s specified for route"))
+			if (get_u32(&new->metric, strvec_slot(strvec, ++i), UINT32_MAX, "Invalid metric %s specified for route"))
 				goto err;
 			new->mask |= IPROUTE_BIT_METRIC;
 		}


### PR DESCRIPTION
The track_process feature acts like having a track_script calling pidof/pgrep/pkill/killall, but is more efficient, more responsive and add extra features.