### PR TITLE
Also skip route not configured with down interface

### DIFF
--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -1051,7 +1051,9 @@ interface_down(interface_t *ifp)
 			/* Any route that has an oif will be tracking the interface,
 			 * so we only need to check for routes that dont specify an
 			 * oif */
-			if (!route->oif && route->configured_ifindex != ifp->ifindex)
+			/* Don't track route if it's not configured with this down
+			 * interface. */
+			if (!route->oif || route->configured_ifindex != ifp->ifindex)
 				continue;
 
 			route->set = false;


### PR DESCRIPTION
Otherwise, if keepalived has virtual_routes configured, we create
a virtual interface and bring it up and down, current code will bring
VRRP state to FAULT and never return.

```
 # ip tun add test mode ipip remote 10.0.0.1 local 10.0.0.2
 # ip link set test up
 # ip link set test down
```