### PR TITLE
Make it possible to specify decimal value for delay_loop, connect_timeout, delay_before_retry.

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1467,7 +1467,7 @@ The syntax for virtual_server is :
 \fBvirtual_server fwmark \fR<INTEGER> |
 \fBvirtual_server group \fR<STRING> {
     # delay timer for checker polling
-    \fBdelay_loop \fR<INTEGER>
+    \fBdelay_loop \fR<DECIMAL>
 
     # LVS scheduler
     \fBlvs_sched \fRrr|wrr|lc|wlc|lblc|sh|mh|dh|fo|ovf|lblcr|sed|nq
@@ -1561,7 +1561,7 @@ The syntax for virtual_server is :
     \fBretry \fR<INTEGER>
 
     # delay before retry
-    \fBdelay_before_retry \fR<INTEGER>
+    \fBdelay_before_retry \fR<DECIMAL>
 
     # Optional random delay to start the initial check
     # for maximum N seconds.
@@ -1571,7 +1571,7 @@ The syntax for virtual_server is :
     \fBwarmup \fR<INTEGER>
 
     # delay timer for checker polling
-    \fBdelay_loop \fR<INTEGER>
+    \fBdelay_loop \fR<DECIMAL>
 
     # Set weight to 0 when healthchecker detects failure
     \fBinhibit_on_failure\fR
@@ -1607,9 +1607,9 @@ The syntax for virtual_server is :
 
         \fBalpha \fR<BOOL>                    # see above
         \fBretry \fR<INTEGER>                 # see above
-        \fBdelay_before_retry \fR<INTEGER>    # see above
+        \fBdelay_before_retry \fR<DECIMAL>    # see above
         \fBwarmup \fR<INTEGER>                # see above
-        \fBdelay_loop \fR<INTEGER>            # see above
+        \fBdelay_loop  \fR<DECIMAL>           # see above
         \fBinhibit_on_failure \fR<BOOL>       # see above
         \fBlog_all_failures \fR<BOOL>         # log all failures when checker up
 
@@ -1643,7 +1643,7 @@ The syntax for virtual_server is :
 
             # Optional connection timeout in seconds.
             # The default is 5 seconds
-            \fBconnect_timeout \fR<INTEGER>
+            \fBconnect_timeout \fR<DECIMAL>
 
             # Optional fwmark to mark all outgoing
             # checker packets with
@@ -1651,9 +1651,9 @@ The syntax for virtual_server is :
 
             \fBalpha \fR<BOOL>                    # see above
             \fBretry \fR<INTEGER>                 # see above
-            \fBdelay_before_retry \fR<INTEGER>    # see above
+            \fBdelay_before_retry \fR<DECIMAL>    # see above
             \fBwarmup \fR<INTEGER>                # see above
-            \fBdelay_loop \fR<INTEGER>            # see above
+            \fBdelay_loop \fR<DECIMAL>            # see above
             \fBinhibit_on_failure \fR<BOOL>       # see above
         }
 

--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -299,13 +299,13 @@ static void
 co_timeout_handler(vector_t *strvec)
 {
 	conn_opts_t *co = CHECKER_GET_CO();
-	unsigned long timer;
+	double timer;
 
-	if (!read_timer(strvec, 1, &timer, 1, UINT_MAX / TIMER_HZ, true)) {
+	if (!read_double_strvec(strvec, 1, &timer, 1.0 / TIMER_HZ, UINT_MAX / TIMER_HZ, true)) {
 		report_config_error(CONFIG_GENERAL_ERROR, "connect_timeout %s invalid - ignoring", FMT_STR_VSLOT(strvec, 1));
 		return;
 	}
-	co->connection_to = timer;
+	co->connection_to = timer * TIMER_HZ;
 }
 
 #ifdef _WITH_SO_MARK_
@@ -342,9 +342,9 @@ static void
 delay_before_retry_handler(vector_t *strvec)
 {
 	checker_t *checker = CHECKER_GET_CURRENT();
-	unsigned delay;
+	double delay;
 
-	if (!read_unsigned_strvec(strvec, 1, &delay, 0, UINT_MAX / TIMER_HZ, true)) {
+	if (!read_double_strvec(strvec, 1, &delay, 0 / TIMER_HZ, UINT_MAX / TIMER_HZ, true)) {
 		report_config_error(CONFIG_GENERAL_ERROR, "Invalid delay_before_retry connection value '%s'", FMT_STR_VSLOT(strvec, 1));
 		return;
 	}
@@ -370,11 +370,11 @@ warmup_handler(vector_t *strvec)
 static void
 delay_handler(vector_t *strvec)
 {
-	unsigned long delay_loop;
+	double delay_loop;
 	checker_t *checker = CHECKER_GET_CURRENT();
 
-	if (read_timer(strvec, 1, &delay_loop, 1, 0, true))
-		checker->delay_loop = delay_loop;
+	if (read_double_strvec(strvec, 1, &delay_loop, 1.0 / TIMER_HZ, UINT_MAX / TIMER_HZ, true))
+		checker->delay_loop = delay_loop * TIMER_HZ;
 	else
 		report_config_error(CONFIG_GENERAL_ERROR, "delay_loop '%s' is invalid - ignoring", FMT_STR_VSLOT(strvec, 1));
 }

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -220,10 +220,10 @@ static void
 vs_delay_handler(vector_t *strvec)
 {
 	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
-	unsigned long delay;
+	double delay;
 
-	if (read_timer(strvec, 1, &delay, 1, 0, true))
-		vs->delay_loop = delay;
+	if (read_double_strvec(strvec, 1, &delay, 1.0 / TIMER_HZ, UINT_MAX / TIMER_HZ, true))
+		vs->delay_loop = delay * TIMER_HZ;
 	else
 		report_config_error(CONFIG_GENERAL_ERROR, "virtual server delay loop '%s' invalid - ignoring", FMT_STR_VSLOT(strvec, 1));
 }


### PR DESCRIPTION
To shorten the real server monitoring interval, I have make it possible to sepcify decimal value for following items.
- delay_loop
- connect_timeout
- delay_before_retry

```
virtual_server 192.168.1.200 80 {
  delay_loop 0.5 

    real_server 192.168.1.11 80 {
    ...
    TCP_CHECK {
      connect_timeout 0.4
      delay_before_retry 0,8
    ...
```