### PR TITLE
Remove variable timer of unsigned long cast in read_timer().

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -1914,7 +1914,7 @@ read_timer(vector_t *strvec, size_t index, unsigned long *res, unsigned long min
 	fmax_time = (double)((max_time) ? max_time : TIMER_MAXIMUM) / TIMER_HZ;
 
 	ret = read_double_strvec(strvec, index, &timer, fmin_time, fmax_time, ignore_error);
-	*res = timer * TIMER_HZ > TIMER_MAXIMUM ? TIMER_MAXIMUM : (unsigned long)timer * TIMER_HZ;
+	*res = timer * TIMER_HZ > TIMER_MAXIMUM ? TIMER_MAXIMUM : timer * TIMER_HZ;
 
 	return ret;
 }


### PR DESCRIPTION
```
(unsigned long)timer * TIMER_HZ;
```
A long type var timer is cast to `unsigned long`, it's scale falls.

For example var timer is `0.7`.
By the C Lang rules, Cast priority is higher than calculation, so var timer become `0` and multiply TIMER_HZ.