### PR TITLE
In uninstalling keepalived which installed by rpm package with upstart system, it occurs problems.

### DIFF
--- a/keepalived.spec.in
+++ b/keepalived.spec.in
@@ -123,6 +123,7 @@ if [ $1 -eq 0 ]; then
 @INIT_SYSV_TRUE@	/sbin/chkconfig --del keepalived
 @INIT_SYSTEMD_TRUE@	/bin/systemctl disable keepalived.service >/dev/null 2>&1 || :
 @INIT_SYSTEMD_TRUE@	/bin/systemctl stop keepalived.service >/dev/null 2>&1 || :
+@INIT_UPSTART_TRUE@	/sbin/stop keepalived >/dev/null 2>&1 || :
 :
 fi
 

--- a/keepalived.spec.in
+++ b/keepalived.spec.in
@@ -113,6 +113,7 @@ if [ $1 -eq 1 ]; then
         # Enable (but don't start) the units by default
 @INIT_SYSV_TRUE@	/sbin/chkconfig --add keepalived
 @INIT_SYSTEMD_TRUE@	/bin/systemctl enable keepalived.service >/dev/null 2>&1 || :
+:
 fi
 
 %preun
@@ -122,6 +123,7 @@ if [ $1 -eq 0 ]; then
 @INIT_SYSV_TRUE@	/sbin/chkconfig --del keepalived
 @INIT_SYSTEMD_TRUE@	/bin/systemctl disable keepalived.service >/dev/null 2>&1 || :
 @INIT_SYSTEMD_TRUE@	/bin/systemctl stop keepalived.service >/dev/null 2>&1 || :
+:
 fi
 
 %postun
@@ -131,6 +133,7 @@ if [ $1 -ge 1 ]; then
 	# and restart the daemon
 @INIT_SYSTEMD_TRUE@	/bin/systemctl daemon-reload >/dev/null 2>&1 || :
 @INIT_SYSTEMD_TRUE@	/bin/systemctl try-restart keepalived.service >/dev/null 2>&1 || :
+:
 fi
 
 %files


### PR DESCRIPTION
When uninstalling keepalived, it occurs two problems.
```
sudo yum remove keepalived / sudo rpm -e keepalived
```

### 1. sysntax error.
  - it raises following syntax error.
  ```
  >> line 7: syntax error near unexpected token `fi'
  ```
  - resolved: e5e9a79

### 2. Not stopping process.
  - After uninstall keepalived, the process continue to run.
  - resolved: 641b861