### PR TITLE
Fix reutrn value of notify_script_compare misusing issue.

### DIFF
--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -89,7 +89,7 @@ misc_check_compare(void *a, void *b)
 	misc_checker_t *old = CHECKER_DATA(a);
 	misc_checker_t *new = CHECKER_DATA(b);
 
-	return !notify_script_compare(&old->script, &new->script);
+	return notify_script_compare(&old->script, &new->script);
 }
 
 static void

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -202,7 +202,7 @@ typedef struct _check_data {
 #define VS_SCRIPT_ISEQ(XS,YS) \
 	(!(XS) == !(YS) && \
 	 (!(XS) || \
-	  (!notify_script_compare((XS), (YS)) && \
+	  (notify_script_compare((XS), (YS)) && \
 	   (XS)->uid == (YS)->uid && \
 	   (XS)->gid == (YS)->gid)))
 


### PR DESCRIPTION
False means not equal and true means equal.