### PR TITLE
Fix parse error when semicolon in the end of Scripts.

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -60,7 +60,7 @@
 
 #define BOB "{"
 #define EOB "}"
-#define WHITE_SPACE_STR " \t\f\n\r\v"
+#define WHITE_SPACE_STR " \t\f\n\r\v;"
 
 typedef struct _defs {
 	char *name;


### PR DESCRIPTION
Fix parse error when semicolon in the end of Scripts.
Such as config following script in virtual_server,
    quorum_up "/usr/sbin/ip addr add 192.168.122.15/32 dev lo;" 
which will lead to the failure of adding the ip address.
So we should consider ";" as part of WHITE_SPACE_STR.