### PR TITLE
fix keepalived deadlock on signal_handler

### DIFF
--- a/lib/signals.c
+++ b/lib/signals.c
@@ -181,10 +181,8 @@ static void
 signal_handler(int sig)
 {
 	if (write(signal_pipe[1], &sig, sizeof(int)) != sizeof(int)) {
-		DBG("signal_pipe write error %s", strerror(errno));
 		assert(0);
-
-		log_message(LOG_INFO, "BUG - write to signal_pipe[1] error %s - please report", strerror(errno));
+		fprintf(stderr, "BUG - write to signal_pipe[1] error %s - please report\n", strerror(errno));
 	}
 }
 #endif


### PR DESCRIPTION
It's unsafe to use syslog in signal_handler,it may cause deadlock:
#0  0x00007f7d1242248c in __lll_lock_wait_private () from /lib64/libc.so.6
#1  0x00007f7d1239e3cd in _L_lock_15626 () from /lib64/libc.so.6
#2  0x00007f7d1239b4d3 in malloc () from /lib64/libc.so.6
#3  0x00007f7d1238da5a in open_memstream () from /lib64/libc.so.6
#4  0x00007f7d1240e32a in __vsyslog_chk () from /lib64/libc.so.6
#5  0x00007f7d1240e922 in __syslog_chk () from /lib64/libc.so.6
#6  0x000055691ddd60bf in syslog (__fmt=0x55691dddeb6f "%s", __pri=6) at /usr/include/bits/syslog.h:31
#7  vlog_message (facility=6, format=<optimized out>, args=args@entry=0x7ffe4c1b8900) at logger.c:50
#8  0x000055691ddd6184 in log_message (facility=facility@entry=6, 
    format=format@entry=0x55691dde5d50 "BUG - write to signal_pipe[1] error %s - please report") at logger.c:59
#9  0x000055691ddd5805 in signal_handler (sig=1) at signals.c:100
#10 <signal handler called>
#11 0x00007f7d1242248a in __lll_lock_wait_private () from /lib64/libc.so.6
#12 0x00007f7d1239e3cd in _L_lock_15626 () from /lib64/libc.so.6
#13 0x00007f7d1239b4d3 in malloc () from /lib64/libc.so.6
#14 0x00007f7d1238da5a in open_memstream () from /lib64/libc.so.6
#15 0x00007f7d1240e32a in __vsyslog_chk () from /lib64/libc.so.6
#16 0x00007f7d1240e922 in __syslog_chk () from /lib64/libc.so.6
#17 0x000055691ddd60bf in syslog (__fmt=0x55691dddeb6f "%s", __pri=6) at /usr/include/bits/syslog.h:31
#18 vlog_message (facility=6, format=<optimized out>, args=args@entry=0x7ffe4c1b9380) at logger.c:50
#19 0x000055691ddd6184 in log_message (facility=facility@entry=6, 
    format=format@entry=0x55691dde5d50 "BUG - write to signal_pipe[1] error %s - please report") at logger.c:59
#20 0x000055691ddd5805 in signal_handler (sig=17) at signals.c:100
#21 <signal handler called>
#22 0x00007f7d12398de4 in _int_malloc () from /lib64/libc.so.6
#23 0x00007f7d1239bf04 in calloc () from /lib64/libc.so.6
#24 0x00007f7d13e5f409 in __nlmsg_alloc () from /lib64/libnl-3.so.200
#25 0x00007f7d13e5f846 in nlmsg_convert () from /lib64/libnl-3.so.200
#26 0x00007f7d13e61daf in nl_recvmsgs_report () from /lib64/libnl-3.so.200
#27 0x00007f7d13e624a9 in nl_recvmsgs () from /lib64/libnl-3.so.200
#28 0x00007f7d13e62511 in nl_wait_for_ack () from /lib64/libnl-3.so.200
#29 0x00007f7d14073ad0 in genl_ctrl_probe_by_name () from /lib64/libnl-genl-3.so.200
#30 0x00007f7d14073ceb in genl_ctrl_resolve () from /lib64/libnl-genl-3.so.200
#31 0x000055691dda0b55 in ipvs_nl_send_message (msg=msg@entry=0x556924f077a0, 
    func=func@entry=0x55691dda0b00 <ipvs_nl_noop_cb>, arg=arg@entry=0x0) at libipvs.c:302
#32 0x000055691dda515f in ipvs_add_laddr (svc=0x55692fc2ac10, laddr=0x5569359d34e0) at libipvs.c:930
#33 0x000055691dd9d273 in ipvs_talk (cmd=cmd@entry=1168, daemonrule=daemonrule@entry=0x0, 
    ignore_error=ignore_error@entry=false) at ipvswrapper.c:255
#34 0x000055691dd9d614 in ipvs_laddr_group_cmd (cmd=cmd@entry=1168, laddr_group=laddr_group@entry=0x556932f1b4e0)
    at ipvswrapper.c:626
#35 0x000055691dd9f24a in ipvs_laddr_cmd (vs=0x55692fc2ac10, cmd=1168) at ipvswrapper.c:804
#36 ipvs_cmd (cmd=cmd@entry=1168, vs=vs@entry=0x556931f77e70, rs=rs@entry=0x0) at ipvswrapper.c:874
#37 0x000055691dd9b610 in init_service_laddr (vs=0x556931f77e70) at ipwrapper.c:672
#38 init_service_vs (vs=0x556931f77e70) at ipwrapper.c:762
#39 0x000055691dd9baa1 in init_services () at ipwrapper.c:815
#40 0x000055691dd8dc45 in start_check () at check_daemon.c:277
---Type <return> to continue, or q <return> to quit---
#41 0x000055691dd8dfe5 in reload_check_thread (thread=<optimized out>) at check_daemon.c:399
#42 0x000055691ddd3bde in thread_call (thread=0x7ffe4c1ba010) at scheduler.c:963
#43 launch_scheduler () at scheduler.c:986
#44 0x000055691dd8e1af in start_check_child () at check_daemon.c:522
#45 0x000055691dd89340 in start_keepalived () at main.c:337
#46 keepalived_main (argc=2, argv=<optimized out>) at main.c:1064
#47 0x00007f7d12338455 in __libc_start_main () from /lib64/libc.so.6
#48 0x000055691dd879fe in _start ()

I wonder if we can use fprintf instead of log_message ? fprintf is safe in signal handler.
-------------------------------------------------

Signed-off-by: Lin Miaohe <linmiaohe@huawei.com>
--