### PR TITLE
fix OPENSSL_init_crypto init option

### DIFF
--- a/genhash/ssl.c
+++ b/genhash/ssl.c
@@ -45,7 +45,7 @@ init_ssl(void)
 {
 	/* Library initialization */
 #if HAVE_OPENSSL_INIT_CRYPTO
-	if (!OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, NULL))
+	if (!OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
 		fprintf(stderr, "OPENSSL_init_crypto failed\n");
 #else
 	SSL_library_init();

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -69,7 +69,7 @@ build_ssl_ctx(void)
 
 	/* Library initialization */
 #if HAVE_OPENSSL_INIT_CRYPTO
-	if (!OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, NULL))
+	if (!OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
 		log_message(LOG_INFO, "OPENSSL_init_crypto failed");
 #else
 	SSL_library_init();


### PR DESCRIPTION
we should automatic loading of the libcrypto error strings in OPENSSL_init_crypto init  .