### PR TITLE
global_parser.c: fix build with kernel < 4.1

### DIFF
--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -60,6 +60,11 @@
 
 #define LVS_MAX_TIMEOUT		(86400*31)	/* 31 days */
 
+/* For kernels < 4.1 */
+#ifndef NFT_TABLE_MAXNAMELEN
+#define NFT_TABLE_MAXNAMELEN 32
+#endif
+
 /* data handlers */
 /* Global def handlers */
 #ifdef _WITH_LINKBEAT_


### PR DESCRIPTION
NFT_TABLE_MAXNAMELEN has been added only in kernel 4.1 with
https://github.com/torvalds/linux/commit/1cae565e8b746f484f1ff1b71d2a1c89d7cf0668

So define it to 32 if it is not defined

Fixes:
 - http://autobuild.buildroot.org/results/a33433abeb122cfb15f7f21ab777e84040bdcb8b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>