### PR TITLE
Add option to flush lvs on shutdown

### DIFF
--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201902140001Z"
+     LAST-UPDATED "201903250001Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201903250001Z"
+     DESCRIPTION "add lvs_flush_onstop"
      REVISION "201902140001Z"
      DESCRIPTION "add checker connection timeout"
      REVISION "201902140000Z"
@@ -388,6 +390,14 @@ dynamicInterfaces OBJECT-TYPE
     DESCRIPTION
         "True if dynamic interfaces is enabled."
     ::= { global 10 }
+
+lvsFlushOnStop OBJECT-TYPE
+    SYNTAX INTEGER { enabled(1), disabled(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Indicate whether LVS config is flushed at shutdown."
+    ::= { global 11 }
 
 -- ----------------------------------------------------------------------
 -- VRRP part
@@ -4159,6 +4169,7 @@ globalGroup OBJECT-GROUP
     trapEnable,
     linkBeat,
     lvsFlush,
+    lvsFlushOnStop,
     ipvs64BitStats,
     netNamespace,
     dbus,

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -224,6 +224,9 @@ and
     # flush any existing LVS configuration at startup
     \fBlvs_flush\fR
 
+    # flush remaining LVS configuration at shutdown
+    \fBlvs_flush_onstop\fR
+
     # delay for second set of gratuitous ARPs after transition to MASTER.
     # in seconds, 0 for no second set.
     # (default: 5)

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -191,8 +191,12 @@ checker_terminate_phase1(bool schedule_next_thread)
 		script_killall(master, SIGTERM, true);
 
 	/* Send shutdown messages */
-	if (!__test_bit(DONT_RELEASE_IPVS_BIT, &debug))
+	if (global_data->lvs_flush_onstop) {
+		log_message(LOG_INFO, "Flushing lvs on shutdown in oneshot");
+		ipvs_flush_cmd();
+	} else if (!__test_bit(DONT_RELEASE_IPVS_BIT, &debug)) {
 		clear_services();
+	}
 
 	if (schedule_next_thread) {
 		/* If there are no child processes, we can terminate immediately,

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -438,6 +438,7 @@ dump_global_data(FILE *fp, data_t * data)
 	}
 #endif
 	conf_write(fp, " LVS flush = %s", data->lvs_flush ? "true" : "false");
+	conf_write(fp, " LVS flush on stop = %s", data->lvs_flush_onstop ? "true" : "false");
 #endif
 	if (data->notify_fifo.name) {
 		conf_write(fp, " Global notify fifo = %s", data->notify_fifo.name);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -442,6 +442,12 @@ lvs_flush_handler(__attribute__((unused)) vector_t *strvec)
 {
 	global_data->lvs_flush = true;
 }
+
+static void
+lvs_flush_onstop_handler(__attribute__((unused)) vector_t *strvec)
+{
+	global_data->lvs_flush_onstop = true;
+}
 #endif
 #ifdef _HAVE_SCHED_RT_
 static int
@@ -1609,6 +1615,7 @@ init_global_keywords(bool global_active)
 #ifdef _WITH_LVS_
 	install_keyword("lvs_timeouts", &lvs_timeouts);
 	install_keyword("lvs_flush", &lvs_flush_handler);
+	install_keyword("lvs_flush_onstop", &lvs_flush_onstop_handler);
 #ifdef _WITH_VRRP_
 	install_keyword("lvs_sync_daemon", &lvs_syncd_handler);
 #endif

--- a/keepalived/core/snmp.c
+++ b/keepalived/core/snmp.c
@@ -115,6 +115,7 @@ enum snmp_global_magic {
 	SNMP_TRAPS,
 	SNMP_LINKBEAT,
 	SNMP_LVSFLUSH,
+	SNMP_LVSFLUSH_ONSTOP,
 	SNMP_IPVS_64BIT_STATS,
 	SNMP_NET_NAMESPACE,
 	SNMP_DBUS,
@@ -183,6 +184,9 @@ RELAX_CAST_QUAL_END
 #ifdef _WITH_LVS_
 	case SNMP_LVSFLUSH:
 		long_ret = global_data->lvs_flush?1:2;
+		return (u_char *)&long_ret;
+	case SNMP_LVSFLUSH_ONSTOP:
+		long_ret = global_data->lvs_flush_onstop?1:2;
 		return (u_char *)&long_ret;
 #endif
 	case SNMP_IPVS_64BIT_STATS:
@@ -286,6 +290,8 @@ static struct variable8 global_vars[] = {
 	{SNMP_LINKBEAT, ASN_INTEGER, RONLY, snmp_scalar, 1, {5}},
 	/* lvsFlush */
 	{SNMP_LVSFLUSH, ASN_INTEGER, RONLY, snmp_scalar, 1, {6}},
+	/* lvsFlushOnStop */
+	{SNMP_LVSFLUSH_ONSTOP, ASN_INTEGER, RONLY, snmp_scalar, 1, {6}},
 #ifdef _WITH_LVS_64BIT_STATS_
 	/* LVS 64-bit stats */
 	{SNMP_IPVS_64BIT_STATS, ASN_INTEGER, RONLY, snmp_scalar, 1, {7}},

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -112,6 +112,7 @@ typedef struct _data {
 	struct lvs_syncd_config		lvs_syncd;
 #endif
 	bool				lvs_flush;		/* flush any residual LVS config at startup */
+	bool				lvs_flush_onstop;	/* flush any LVS config at shutdown */
 #endif
 #ifdef _WITH_VRRP_
 	struct sockaddr_in		vrrp_mcast_group4;


### PR DESCRIPTION
Currently all known virtual servers and their real servers are removed one at a
time at shutdown. With large configurations on a busy system, this can take some
time.

Add an option just like the existing 'lvs_flush' which operates on shutdown.
Typical environments with a single keepalived instance can take advantage of
this option to achieve a faster shutdown or restart cycle.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>