### PR TITLE
fix add new rs into exist vs with alpha online

### DIFF
--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -934,7 +934,7 @@ bool validate_check_config(void)
 
 		/* In Alpha mode also mark any checker that hasn't run as failed.
 		 * Reloading is handled in migrate_checkers() */
-		if (!reload) {
+		if (!checker->has_run) {
 			if (checker->alpha) {
 				set_checker_state(checker, false);
 				UNSET_ALIVE(checker->rs);


### PR DESCRIPTION
When we config a virtual server and a real server with alpha [real server is unreachable], and then we add a new real server into the virtual server and reload it, the new added  real server will be online for a while.