### PR TITLE
Make new real servers at reload start down if have alpha mode checkers

### DIFF
--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -113,7 +113,6 @@ dump_checker_opts(FILE *fp, void *data)
 	conf_write(fp, "   Has run = %d", checker->has_run);
 	conf_write(fp, "   Retries left before fail = %d", checker->retry_it);
 	conf_write(fp, "   Delay before retry = %f", (double)checker->default_delay_before_retry / TIMER_HZ);
-	conf_write(fp, "   Log all failures = %d", checker->log_all_failures);
 }
 
 /* Queue a checker into the checkers_queue */

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -310,8 +310,10 @@ start_check(list old_checkers_queue, data_t *prev_global_data)
 		stop_check(KEEPALIVED_EXIT_FATAL);
 
 	/* Processing differential configuration parsing */
-	if (reload)
+	if (reload) {
 		clear_diff_services(old_checkers_queue);
+		check_new_rs_state();
+	}
 
 	/* We can send SMTP messages from here so set the time */
 	set_time_now();

--- a/keepalived/include/ipwrapper.h
+++ b/keepalived/include/ipwrapper.h
@@ -49,6 +49,7 @@ extern bool init_services(void);
 extern void clear_services(void);
 extern void set_quorum_states(void);
 extern void clear_diff_services(list);
+extern void check_new_rs_state(void);
 extern void link_vsg_to_vs(void);
 
 #endif


### PR DESCRIPTION
This commit enhances pull request #1180 by ensuring that new alpha mode checkers for an existing real server don't cause the real server to be brought down at reload until the checkers have run.