### PR TITLE
add udp health check

### DIFF
--- a/keepalived/check/Makefile.am
+++ b/keepalived/check/Makefile.am
@@ -16,7 +16,7 @@ libcheck_a_SOURCES = \
 	check_daemon.c check_data.c check_parser.c \
 	check_api.c check_tcp.c check_http.c check_ssl.c \
 	check_smtp.c check_misc.c check_dns.c check_print.c \
-	ipwrapper.c ipvswrapper.c libipvs.c
+	ipwrapper.c ipvswrapper.c libipvs.c check_udp.c check_ping.c
 
 AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 

--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -48,6 +48,7 @@
 #include "bfd_event.h"
 #include "bfd_daemon.h"
 #endif
+#include "check_udp.h"
 
 /* Global vars */
 list checkers_queue;
@@ -677,6 +678,7 @@ install_checkers_keyword(void)
 	install_misc_check_keyword();
 	install_smtp_check_keyword();
 	install_tcp_check_keyword();
+	install_udp_check_keyword();
 	install_http_check_keyword();
 	install_ssl_check_keyword();
 	install_dns_check_keyword();

--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -155,6 +155,11 @@ queue_checker(void (*free_func) (void *), void (*dump_func) (FILE *, void *)
 
 	/* queue the checker */
 	list_add(checkers_queue, checker);
+	if(compare) {
+		if(rs->samecheckers == NULL)
+			rs->samecheckers = alloc_list(NULL, NULL);
+		list_add(rs->samecheckers, checker);
+	}
 
 	return checker;
 }

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -476,6 +476,8 @@ free_rs(void *data)
 	free_list(&rs->tracked_bfds);
 #endif
 	FREE_PTR(rs->virtualhost);
+	if (rs->samecheckers) 
+		free(&rs->samecheckers);
 	FREE(rs);
 }
 

--- a/keepalived/check/check_ping.c
+++ b/keepalived/check/check_ping.c
@@ -1,0 +1,130 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        ICMP checker.
+ *
+ * Author:      Jie Liu, <liujie165@huawei.com>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
+ */
+#include "config.h"
+#include "check_ping.h"
+#include "logger.h"
+#include "layer4.h"
+#include <error.h>
+#include <stdio.h>
+
+enum connect_result ping_it(int fd, conn_opts_t* co)
+{
+	struct icmphdr icmp_hdr;
+	struct sockaddr_storage *dest = &co->dst;
+	int size = 0;
+	int seq = 1;
+	socklen_t addrlen;
+	char send_buf[ICMP_BUFSIZE];
+
+	memset(&icmp_hdr, 0, sizeof icmp_hdr);
+	icmp_hdr.type = ICMP_ECHO;
+	icmp_hdr.un.echo.id = fd;//arbitrary id
+	icmp_hdr.un.echo.sequence = seq++;
+	addrlen = sizeof(*dest);
+	memcpy(send_buf, &icmp_hdr, sizeof(icmp_hdr));
+	size = sendto(fd, send_buf, sizeof(send_buf), 0, (struct sockaddr*)dest, addrlen);
+
+	if(size < 0)
+	{
+		log_message(LOG_INFO, "send icmp packet fail!");
+		return connect_error;
+	}
+	return connect_success;
+}
+
+enum connect_result recv_it(int fd)
+{
+	char recv_buf[ICMP_BUFSIZE];
+	int size = 0;
+	int ret = connect_error;
+	struct icmphdr rcv_hdr;
+
+	memset(recv_buf, 0, sizeof(recv_buf));
+	size = recv(fd, recv_buf, sizeof(recv_buf), 0);
+
+	if(size < 0) {
+		log_message(LOG_INFO, "recv icmp packet error!");
+		return ret;
+	} else if ((unsigned int)size < sizeof(rcv_hdr)) {
+		log_message(LOG_INFO, "Error, got short ICMP packet, %d bytes", size);
+		return ret;
+	}
+	memcpy(&rcv_hdr, recv_buf, sizeof(rcv_hdr));
+	if (rcv_hdr.type == ICMP_ECHOREPLY)
+		ret = connect_success;
+	else {
+		log_message(LOG_INFO, "Got ICMP packet with type 0x%x ?!?", rcv_hdr.type);
+	}
+	return ret;
+}
+
+enum connect_result ping6_it(int fd, conn_opts_t* co)
+{
+	struct icmp6_hdr* send_hdr;
+	struct sockaddr_storage *dest = &co->dst;
+	struct sockaddr_in6* dest_in6 = (struct sockaddr_in6*)dest;
+	int size = 0;
+	int seq = 1;
+	char send_buf[ICMP_BUFSIZE];
+	send_hdr = (struct icmp6_hdr*)&send_buf;
+
+	memset(send_hdr, 0, sizeof(struct icmp6_hdr));
+	send_hdr->icmp6_type = ICMP6_ECHO_REQUEST;
+	send_hdr->icmp6_id = fd;
+	send_hdr->icmp6_seq = seq;
+
+	size = sendto(fd, send_buf, ICMP_BUFSIZE, 0,dest_in6, sizeof(*dest_in6));
+	if(size < 0)
+	{
+		log_message(LOG_INFO, "send icmpv6 packet fail!");
+		return connect_error;
+	}
+	return connect_success;
+}
+
+enum connect_result recv6_it(int fd)
+{
+	char recv_buf[ICMP_BUFSIZE];
+	int size = 0;
+	int ret = connect_error;
+	struct icmp6_hdr* rcv_hdr;
+
+	size = recv(fd, recv_buf, sizeof(recv_buf), 0);
+
+	if (size < 0) {
+		log_message(LOG_INFO, "recv icmpv6 packet error!");
+		return ret;
+	} else if ((unsigned int)size < sizeof(rcv_hdr)) {
+		log_message(LOG_INFO, "Error, got short ICMPV6 packet, %d bytes", size);
+		return ret;
+	}
+	rcv_hdr = (struct icmp6_hdr*)&recv_buf;
+
+	if (rcv_hdr->icmp6_type == ICMP6_ECHO_REPLY)
+		ret = connect_success;
+	else
+		log_message(LOG_INFO, "Got ICMP packet with type 0x%x ?!?", rcv_hdr->icmp6_type);
+
+	return ret;
+}
+
+

--- a/keepalived/check/check_udp.c
+++ b/keepalived/check/check_udp.c
@@ -1,0 +1,388 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        UDP checker.
+ *
+ * Author:      Jie Liu, <liujie165@huawei.com>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
+ */
+
+#include "config.h"
+
+#include <unistd.h>
+#include <stdio.h>
+
+#include "check_udp.h"
+#include "check_api.h"
+#include "memory.h"
+#include "ipwrapper.h"
+#include "layer4.h"
+#include "logger.h"
+#include "smtp.h"
+#include "utils.h"
+#include "parser.h"
+#include "check_ping.h"
+#if !HAVE_DECL_SOCK_CLOEXEC
+#include "old_socket.h"
+#endif
+#ifdef THREAD_DUMP
+#include "scheduler.h"
+#endif
+
+static int udp_connect_thread(thread_t *);
+static int icmp_connect_thread(thread_t * thread);
+static int choose_mode_thread(thread_t * thread);
+
+/* Configuration stream handling */
+static void
+free_udp_check(void *data)
+{
+	FREE(CHECKER_CO(data));
+	FREE(CHECKER_DATA(data));
+	FREE(data);
+}
+
+static void
+dump_udp_check(FILE *fp, void *data)
+{
+	checker_t *checker = data;
+	conf_write(fp, "   Keepalive method = TCP_CHECK");
+	dump_checker_opts(fp, checker);
+}
+
+static bool
+udp_check_compare(void *a, void *b)
+{
+	return compare_conn_opts(CHECKER_CO(a), CHECKER_CO(b));
+}
+
+static void
+udp_check_handler(__attribute__((unused)) vector_t *strvec)
+{
+	udp_check_t *udp_check;
+	udp_check = MALLOC(sizeof (udp_check_t));
+        udp_check->ping_check = 1;
+
+	/* queue new checker */
+	queue_checker(free_udp_check, dump_udp_check, choose_mode_thread,
+		      udp_check_compare, udp_check, CHECKER_NEW_CO());
+}
+
+static void
+udp_ping_check_off_handler(__attribute__((unused)) vector_t *strvec)
+{
+	udp_check_t *udp_check = CHECKER_GET();
+	udp_check->ping_check = 0;
+}
+
+static void
+udp_check_end_handler(void)
+{
+	if (!check_conn_opts(CHECKER_GET_CO())) {
+		dequeue_new_checker();
+	}
+}
+
+void
+install_udp_check_keyword(void)
+{
+	install_keyword("UDP_CHECK", &udp_check_handler);
+	install_sublevel();
+	install_keyword("ping_check_off", &udp_ping_check_off_handler);
+	install_checker_common_keywords(true);
+	install_sublevel_end_handler(udp_check_end_handler);
+	install_sublevel_end();
+}
+
+static void
+udp_epilog(thread_t * thread, bool is_success)
+{
+	checker_t *checker;
+	udp_check_t *udp_check;
+	unsigned long delay;
+	bool checker_was_up;
+	bool rs_was_alive;
+
+	checker = THREAD_ARG(thread);
+	udp_check = CHECKER_ARG(checker);
+
+	if (is_success || checker->retry_it >= checker->retry) {
+		delay = checker->delay_loop;
+		checker->retry_it = 0;
+
+		if (is_success && (!checker->is_up || !checker->has_run)) {
+			log_message(LOG_INFO, "UDP connection to %s success."
+					, FMT_CHK(checker));
+			checker_was_up = checker->is_up;
+			rs_was_alive = checker->rs->alive;
+			update_svr_checker_state(UP, checker);
+			if (checker->rs->smtp_alert && !checker_was_up &&
+			    (rs_was_alive != checker->rs->alive || !global_data->no_checker_emails))
+				smtp_alert(SMTP_MSG_RS, checker, NULL,
+					   "=> UDP CHECK succeed on service <=");
+		} else if (!is_success && 
+			   (checker->is_up || !checker->has_run)) {
+			if (checker->retry && checker->has_run)
+				log_message(LOG_INFO
+				    , "UDP_CHECK on service %s failed after %d retries."
+				    , FMT_CHK(checker)
+				    , checker->retry);
+			else
+				log_message(LOG_INFO
+				    , "UDP_CHECK on service %s failed."
+				    , FMT_CHK(checker));
+			checker_was_up = checker->is_up;
+			rs_was_alive = checker->rs->alive;
+			update_svr_checker_state(DOWN, checker);
+			if (checker->rs->smtp_alert && checker_was_up &&
+			    (rs_was_alive != checker->rs->alive || !global_data->no_checker_emails))
+				smtp_alert(SMTP_MSG_RS, checker, NULL,
+					   "=> TCP CHECK failed on service <=");
+		}
+		if(udp_check->ping_check)
+			thread_add_timer(thread->master, icmp_connect_thread, checker, delay);
+		else
+			thread_add_timer(thread->master, udp_connect_thread, checker, delay);
+	} else {
+		delay = checker->delay_before_retry;
+		++checker->retry_it;
+		thread_add_timer(thread->master, udp_connect_thread, checker, delay);
+	}
+
+	checker->has_run = true;
+}
+
+static int
+udp_check_thread(thread_t * thread)
+{
+	checker_t *checker = THREAD_ARG(thread);
+	int status;
+
+	status = udp_socket_state(thread->u.f.fd, thread);
+
+	close(thread->u.f.fd);
+
+	switch(status) {
+	case connect_success:
+		udp_epilog(thread, true);
+		break;
+	default:
+		if (checker->is_up &&
+		    (global_data->checker_log_all_failures || checker->log_all_failures))
+			log_message(LOG_INFO, "UDP connection to %s failed."
+					, FMT_CHK(checker));
+		udp_epilog(thread, false);
+	}
+
+	return 0;
+}
+
+static int
+udp_connect_thread(thread_t * thread)
+{
+	checker_t *checker = THREAD_ARG(thread);
+	conn_opts_t *co = checker->co;
+	int fd;
+	int status;
+
+	/*
+	 * Register a new checker thread & return
+	 * if checker is disabled
+	 */
+	if (!checker->enabled) {
+		thread_add_timer(thread->master, udp_connect_thread, checker,
+				 checker->delay_loop);
+		return 0;
+	}
+
+	if ((fd = socket(co->dst.ss_family, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
+		log_message(LOG_INFO, "UDP connect fail to create socket. Rescheduling.");
+		thread_add_timer(thread->master, udp_connect_thread, checker,
+				checker->delay_loop);
+
+		return 0;
+	}
+
+	status = udp_bind_connect(fd, co);
+
+	/* handle udp connection status & register check worker thread */
+	if(udp_connection_state(fd, status, thread, udp_check_thread,
+			co->connection_to)) {
+		close(fd);
+		log_message(LOG_INFO, "TCP socket bind failed. Maybe port used up. Rescheduling.");
+		thread_add_timer(thread->master, udp_connect_thread, checker,
+					checker->delay_loop);
+	}
+
+	return 0;
+}
+
+static void
+icmp_epilog(thread_t * thread, bool is_success)
+{
+	checker_t *checker;
+	unsigned long delay;
+	bool checker_was_up;
+	bool rs_was_alive;
+
+	checker = THREAD_ARG(thread);
+
+	if (is_success || checker->retry_it >= checker->retry) {
+		delay = checker->delay_loop;
+		checker->retry_it = 0;
+
+		if (!is_success && 
+			   (checker->is_up || !checker->has_run)) {
+			if (checker->retry && checker->has_run)
+				log_message(LOG_INFO
+				    , "ICMP CHECK on service %s of %s failed after %d retries."
+				    , FMT_CHK(checker), FMT_VS(checker->vs)
+				    , checker->retry);
+			else
+				log_message(LOG_INFO
+				    , "ICMP CHECK on service %s failed."
+				    , FMT_CHK(checker));
+			checker_was_up = checker->is_up;
+			rs_was_alive = checker->rs->alive;
+			update_svr_checker_state(DOWN, checker);
+			if (checker->rs->smtp_alert && checker_was_up &&
+			    (rs_was_alive != checker->rs->alive || !global_data->no_checker_emails))
+				smtp_alert(SMTP_MSG_RS, checker, NULL,
+					   "=> ICMP CHECK failed on service <=");
+		}
+	} else {
+		delay = checker->delay_before_retry;
+		++checker->retry_it;
+	}
+	if(is_success)
+		thread_add_timer(thread->master, udp_connect_thread, checker, 0);
+	else
+		thread_add_timer(thread->master, icmp_connect_thread, checker, delay);
+}
+
+static int
+icmp_check_thread(thread_t * thread)
+{
+	checker_t *checker = THREAD_ARG(thread);
+	int status;
+
+	if (thread->type == THREAD_READ_TIMEOUT) {
+		if (checker->is_up)
+			log_message(LOG_INFO, "ICMP connection to address %s Timeout.", FMT_CHK(checker));
+		status = connect_error;
+	} else {
+		status = checker->co->dst.ss_family == AF_INET ?
+			recv_it(thread->u.f.fd):recv6_it(thread->u.f.fd);
+	}
+	/*
+	 * If status = connect_success, then we start udp check with the record of icmp failed times.
+	 * Otherwise we will do the icmp connect again until it reaches the unhealthy threshold.
+	 * we handle fd uniform.
+	 */
+	close(thread->u.f.fd);
+	switch(status) {
+	case connect_success:
+		icmp_epilog(thread, 1);
+		break;
+	case connect_error:
+		if (checker->is_up)
+			log_message(LOG_INFO, "ICMP connection to %s of %s failed."
+				,FMT_CHK(checker), FMT_VS(checker->vs));
+		icmp_epilog(thread, 0);
+		break;
+	default:
+		break;
+	}
+	return 0;
+}
+
+int
+icmp_connect_thread(thread_t * thread)
+{
+	checker_t *checker = THREAD_ARG(thread);
+	conn_opts_t *co = checker->co;
+	int fd;
+	int status;
+	struct protoent* protocol = NULL;
+	int size = SOCK_RECV_BUFF;
+
+	if (!checker->enabled) {
+		thread_add_timer(thread->master, icmp_connect_thread, checker,
+				checker->delay_loop);
+		return 0;
+	}
+
+	protocol = co->dst.ss_family == AF_INET ? getprotobyname("icmp"):getprotobyname("ipv6-icmp");
+
+	if (!protocol) {
+		log_message(LOG_INFO, "%s connect fail to getprotobyname. Rescheduling.",
+			(co->dst.ss_family == AF_INET)?"ICMP":"ICMPv6");
+		thread_add_timer(thread->master, icmp_connect_thread, checker,
+				checker->delay_loop);
+		return 0;
+	}
+
+	if ((fd = socket(co->dst.ss_family, SOCK_DGRAM, protocol->p_proto)) == -1) {
+		log_message(LOG_INFO, "%s connect fail to create socket. Rescheduling.",
+			(co->dst.ss_family == AF_INET)?"ICMP":"ICMPv6");
+		thread_add_timer(thread->master, icmp_connect_thread, checker,
+				checker->delay_loop);
+		return 0;
+	}
+
+	setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
+	/*
+	 * OK if setsockopt fails
+	 * Prevent users from pinging broadcast or multicast addresses
+	 */
+	if (co->dst.ss_family == AF_INET)
+		status = ping_it(fd, co);
+	else
+		status = ping6_it(fd, co);
+
+	/* handle icmp send status & register check worker thread */
+	if(icmp_send_state(fd, status, thread, icmp_check_thread,
+		co->connection_to)) {
+		close(fd);
+		log_message(LOG_INFO, "ICMP socket send failed. Rescheduling.");
+		thread_add_timer(thread->master, icmp_connect_thread, checker,
+			checker->delay_loop);
+	}
+	return 0;
+}
+
+int
+choose_mode_thread(thread_t * thread){
+	checker_t *checker = THREAD_ARG(thread);
+	udp_check_t *udp_check = CHECKER_ARG(checker);
+	if(udp_check->ping_check)
+		thread_add_timer(thread->master, icmp_connect_thread, checker, 0);
+	else
+		thread_add_timer(thread->master, udp_connect_thread, checker, 0);
+	return 0;
+}
+
+
+#ifdef THREAD_DUMP
+void
+register_check_udp_addresses(void)
+{
+	register_thread_address("icmp_check_thread", icmp_check_thread);
+	register_thread_address("icmp_connect_thread", icmp_connect_thread);
+	register_thread_address("udp_check_thread", udp_check_thread);
+	register_thread_address("udp_connect_thread", udp_connect_thread);
+}
+#endif

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -736,16 +736,10 @@ migrate_checkers(virtual_server_t *vs, real_server_t *old_rs, real_server_t *new
 	checker_t dummy_checker;
 	bool a_checker_has_run = false;
 
-	l = alloc_list(NULL, NULL);
-	LIST_FOREACH(old_checkers_queue, old_c, e) {
-		if (old_c->rs == old_rs)
-			list_add(l, old_c);
-	}
+	l = old_rs->samecheckers;
 
 	if (!LIST_ISEMPTY(l)) {
-		LIST_FOREACH(checkers_queue, new_c, e) {
-			if (new_c->rs != new_rs || !new_c->compare)
-				continue;
+		LIST_FOREACH(new_rs->samecheckers, new_c, e) {
 			LIST_FOREACH(l, old_c, e1) {
 				if (old_c->compare == new_c->compare && new_c->compare(old_c, new_c)) {
 					/* Update status if different */
@@ -765,7 +759,7 @@ migrate_checkers(virtual_server_t *vs, real_server_t *old_rs, real_server_t *new
 
 	/* Find out how many checkers are really failed */
 	new_rs->num_failed_checkers = 0;
-	LIST_FOREACH(checkers_queue, new_c, e) {
+	LIST_FOREACH(new_rs->samecheckers, new_c, e) {
 		if (new_c->rs != new_rs)
 			continue;
 		if (new_c->has_run && !new_c->is_up)
@@ -777,7 +771,7 @@ migrate_checkers(virtual_server_t *vs, real_server_t *old_rs, real_server_t *new
 	/* If a checker has failed, set new alpha checkers to be down until
 	 * they have run. */
 	if (new_rs->num_failed_checkers || (!new_rs->alive && !a_checker_has_run)) {
-		LIST_FOREACH(checkers_queue, new_c, e) {
+		LIST_FOREACH(new_rs->samecheckers, new_c, e) {
 			if (new_c->rs != new_rs)
 				continue;
 			if (!new_c->has_run) {

--- a/keepalived/core/layer4.c
+++ b/keepalived/core/layer4.c
@@ -25,10 +25,12 @@
 
 #include <errno.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include "layer4.h"
 #include "logger.h"
 #include "scheduler.h"
+#include "check_api.h"
 
 #ifndef _WITH_LVS_
 static
@@ -177,5 +179,118 @@ socket_connection_state(int fd, enum connect_result status, thread_t * thread,
 	}
 
 	return true;
+}
+#endif
+
+#ifdef _WITH_LVS_
+enum connect_result
+udp_bind_connect(int fd, conn_opts_t *co)
+{
+	socklen_t addrlen;
+	int ret;
+	int val;
+	struct sockaddr_storage *addr = &co->dst;
+	struct sockaddr_storage *bind_addr = &co->bindto;
+	char buff[UDP_BUFSIZE] = "";
+
+	/* Make socket non-block. */
+	val = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, val | O_NONBLOCK);
+#ifdef _WITH_SO_MARK_
+	if (co->fwmark) {
+		if (setsockopt (fd, SOL_SOCKET, SO_MARK, &co->fwmark, sizeof (co->fwmark)) < 0) {
+			log_message(LOG_ERR, "Error setting fwmark %d to socket: %s", co->fwmark, strerror(errno));
+			return connect_error;
+		}
+	}
+#endif
+
+	/* Bind socket */
+	if (((struct sockaddr *) bind_addr)->sa_family != AF_UNSPEC) {
+		addrlen = sizeof(*bind_addr);
+		if (bind(fd, (struct sockaddr *) bind_addr, addrlen) != 0) {
+			log_message(LOG_INFO, "bind failed. errno: %d, error: %s", errno, strerror(errno));
+			return connect_error;
+		}
+	}
+
+	/* Set remote IP and connect */
+	addrlen = sizeof(*addr);
+	ret = connect(fd, (struct sockaddr *) addr, addrlen);
+
+	if(ret < 0) {
+		log_message(LOG_INFO, "connect failed. ret: %d, errno: %d, error: %s", ret, errno, strerror(errno));
+		return connect_error;
+	}
+
+	/* Send udp packets and receive icmp packets */
+	ret = send(fd, buff, strlen(buff), 0);
+
+	if ((unsigned int)ret == strlen(buff)) {
+		fcntl(fd, F_SETFL, val);
+		return connect_success;
+	}
+
+	/* restore previous fd args */
+	fcntl(fd, F_SETFL, val);
+	return connect_error;
+}
+
+enum connect_result
+udp_socket_state(int fd, thread_t * thread)
+{
+	int ret = 0;
+	char recv_buf[UDP_BUFSIZE];
+
+	/* Handle Read timeout, we consider it success */
+	if (thread->type == THREAD_READ_TIMEOUT) {
+	/* Once the real server ignore me, return connect_success */
+		return connect_success;
+	}
+
+	ret = recv(fd, recv_buf, sizeof(recv_buf)-1, 0);
+
+	/* Ret less than 0 means the port is unreachable.
+	 * Otherwise, we consider it success. 
+	 */
+
+	if (ret < 0) 
+		return connect_error;
+				
+	return connect_success;
+}
+
+int
+udp_connection_state(int fd, enum connect_result status, thread_t * thread,
+					int (*func) (thread_t *), long timeout)
+{
+	checker_t *checker;
+
+	checker = THREAD_ARG(thread);
+
+	switch (status) {
+	case connect_success:
+		thread_add_read(thread->master, func, checker, fd, timeout, true);
+		return 0;
+	default:
+		return 1;
+	}
+}
+
+int
+icmp_send_state(int fd, enum connect_result status, thread_t * thread,
+					int (*func) (thread_t *), long timeout)
+{
+	checker_t *checker;
+
+	checker = THREAD_ARG(thread);
+
+	switch (status) {
+	case connect_success:
+		thread_add_read(thread->master, func, checker, fd, timeout, true);
+		return 0;
+	default:
+		return 1;
+	}
 }
 #endif

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -100,6 +100,7 @@ typedef struct _real_server {
 #ifdef _WITH_BFD_
 	list				tracked_bfds;	/* list of bfd_checker_t */
 #endif
+	list                            samecheckers;	/* recored the checkers with same real server */
 } real_server_t;
 
 /* Virtual Server group definition */

--- a/keepalived/include/check_ping.h
+++ b/keepalived/include/check_ping.h
@@ -1,0 +1,51 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        check_udp.c include file.
+ *
+ * Author:      Jie Liu, <liujie165@huawei.com>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
+ */
+
+#ifndef _CHECK_PING_H
+#define _CHECK_PING_H
+
+/* system includes */
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip_icmp.h>
+#include <netinet/icmp6.h>
+#include <unistd.h>
+#include <signal.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <string.h>
+#include <netdb.h>
+#include <pthread.h>
+#include "check_api.h"
+
+#define SOCK_RECV_BUFF 128*1024 //128k
+#define ICMP_BUFSIZE 128
+
+/* function prototypes */
+extern enum connect_result ping_it(int, conn_opts_t* );
+extern enum connect_result recv_it(int);
+extern enum connect_result ping6_it(int, conn_opts_t* );
+extern enum connect_result recv6_it(int);
+
+
+#endif

--- a/keepalived/include/check_udp.h
+++ b/keepalived/include/check_udp.h
@@ -1,0 +1,41 @@
+/*
+ * Soft:        Keepalived is a failover program for the LVS project
+ *              <www.linuxvirtualserver.org>. It monitor & manipulate
+ *              a loadbalanced server pool using multi-layer checks.
+ *
+ * Part:        check_udp.c include file.
+ *
+ * Author:      Jie Liu, <liujie165@huawei.com>
+ *
+ *              This program is distributed in the hope that it will be useful,
+ *              but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *              See the GNU General Public License for more details.
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Copyright (C) 2001-2012 Alexandre Cassen, <acassen@gmail.com>
+ */
+
+#ifndef _CHECK_UDP_H
+#define _CHECK_UDP_H
+
+/* system includes */
+#include <unistd.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+
+/* local includes */
+#include "scheduler.h"
+
+typedef struct _udp_check {
+	unsigned	ping_check;
+} udp_check_t;
+
+/* Prototypes defs */
+extern void install_udp_check_keyword(void);
+
+#endif

--- a/keepalived/include/layer4.h
+++ b/keepalived/include/layer4.h
@@ -31,6 +31,8 @@
 /* local includes */
 #include "scheduler.h"
 
+#define UDP_BUFSIZE 512
+
 enum connect_result {
 	connect_error,
 	connect_in_progress,
@@ -97,6 +99,19 @@ tcp_connection_state(int fd, enum connect_result status, thread_t * thread,
 {
 	return socket_connection_state(fd, status, thread, func, timeout);
 }
-#endif
 
+extern enum connect_result
+udp_bind_connect(int, conn_opts_t *);
+
+extern enum connect_result
+udp_socket_state(int, thread_t *);
+
+extern int
+udp_connection_state(int, enum connect_result, thread_t *,
+	int (*func) (thread_t *), long);
+
+extern int
+icmp_send_state(int, enum connect_result, thread_t *,
+	int (*func) (thread_t *), long);
+#endif
 #endif


### PR DESCRIPTION
Hi, I have developed a UDP_CHECK to replace the way of using MISC_CHECK and scripts, which will greatly improve performance.
Meanwhile, we should do something to let it work properly. 
1. We must config the ping_group_range.
	`echo 0 0 > /proc/sys/net/ipv4/ping_group_range`
2. If we config a real server in several virtual server, the icmp_ratelimit should be canceled.
	`echo 0 > /proc/sys/net/ipv4/icmp_ratelimit`
	
PS: Due to some special reasons, someone may think ping is not safe enough, so I add a switch to let user choose whether to use ping or not.
Of course, if we do not use ping, then when the real server unexpectedly shutdown, we will consider it healthy :(

At last is an simple example config:
```
real_server 33.33.110.103 5001 {
    weight 2
    UDP_CHECK {
		connect_port 5001
		connect_timeout 15
		retry 3
		delay_before_retry 3
		#ping_check_off
	}
}
```