### PR TITLE
Propagate libm to KA_LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -778,7 +778,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([[
   ]])],
   AC_MSG_RESULT([no]),
   AC_MSG_RESULT([yes])
-    add_to_var([KA_LDFLAGS], [-lm])
+    add_to_var([KA_LIBS], [-lm])
   )
 CFLAGS=$SAV_CFLAGS
 LDFLAGS=$SAV_LDFLAGS


### PR DESCRIPTION
This fixes FTBFS on Ubuntu 14.04:

make[2]: Entering directory `/home/thresh/keepalived/keepalived'
gcc -DHAVE_CONFIG_H -I. -I../lib    -I./include -I ../lib  -g -D_GNU_SOURCE -Wall -Wextra -Wunused -Wstrict-prototypes -Wbad-function-cast -Wcast-qual -Wdisabled-optimization -Wfloat-equal -Winit-self -Winline -Wjump-misses-init -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Woverlength-strings -Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector -Wstrict-overflow=4 -Wstrict-prototypes -Wsuggest-attribute=const -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-attribute=pure -Wtrampolines -Wundef -Wuninitialized -Wunsuffixed-float-constants -Wunused-macros -Wvariadic-macros -fPIE -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 -grecord-gcc-switches -O2  -g -O2 -D_GNU_SOURCE -MT main.o -MD -MP -MF .deps/main.Tpo -c -o main.o main.c
mv -f .deps/main.Tpo .deps/main.Po
gcc -g -D_GNU_SOURCE -Wall -Wextra -Wunused -Wstrict-prototypes -Wbad-function-cast -Wcast-qual -Wdisabled-optimization -Wfloat-equal -Winit-self -Winline -Wjump-misses-init -Wlogical-op -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Woverlength-strings -Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector -Wstrict-overflow=4 -Wstrict-prototypes -Wsuggest-attribute=const -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-attribute=pure -Wtrampolines -Wundef -Wuninitialized -Wunsuffixed-float-constants -Wunused-macros -Wvariadic-macros -fPIE -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 -grecord-gcc-switches -O2  -g -O2 -D_GNU_SOURCE -pie -lm   -o keepalived main.o core/libcore.a check/libcheck.a vrrp/libvrrp.a  core/libcore.a ../lib/liblib.a -lcrypto  -lssl
vrrp/libvrrp.a(vrrp_ip_rule_route_parser.o): In function `get_time_rtt':
/home/thresh/keepalived/keepalived/vrrp/vrrp_ip_rule_route_parser.c:150: undefined reference to `__fpclassify'
../lib/liblib.a(parser.o): In function `read_double_func':
/home/thresh/keepalived/lib/parser.c:294: undefined reference to `__fpclassify'
collect2: error: ld returned 1 exit status
make[2]: *** [keepalived] Error 1
make[2]: Leaving directory `/home/thresh/keepalived/keepalived'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/thresh/keepalived/keepalived'
make: *** [all-recursive] Error 1