### PR TITLE
keepalived.conf may set to zero to the real server's weight

### DIFF
--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -545,8 +545,8 @@ rs_weight_handler(vector_t *strvec)
 	real_server_t *rs = LIST_TAIL_DATA(vs->rs);
 	unsigned weight;
 
-	if (!read_unsigned_strvec(strvec, 1, &weight, 1, 65535, true)) {
-		report_config_error(CONFIG_GENERAL_ERROR, "Real server weight %s is outside range 1-65535", FMT_STR_VSLOT(strvec, 1));
+	if (!read_unsigned_strvec(strvec, 1, &weight, 0, 65535, true)) {
+		report_config_error(CONFIG_GENERAL_ERROR, "Real server weight %s is outside range 0-65535", FMT_STR_VSLOT(strvec, 1));
 		return;
 	}
 	rs->weight = weight;


### PR DESCRIPTION
Hi, All.

In the current keepalived version, keepalived.conf does not allow the zero-weight real server.
This patch enables it.

I think that it is effective in the following situations.

1. when restart to keepalived, zero-weight real server connection is maintained

   If we will set to zero-weight real server by ipvsadm, we will set to the zero-weight real server keepalived.conf, and restart to keepalived, we will keep the zero-weight real server.
   Thereby, the active and in-active connections allocated to real server can be maintained.

2. zero-weight real server can be done from the keepalived starting

   When I want to add zero-weight real server, I should set to one-weight real server at keepalived.conf, and I set manually the real server weight to zero by ipvsadm.
   In this situation, there is a problem that some connections reach the real server before weight changes to zero.
   But if keepalived.conf will allow to set to zero for the real server, this problem is solved.

For your reference, setting to zero-weight real server by keepalived.conf was accepted before keepalived 2.0.0, but it became unusable by a119136ad46fba2e763741e81712cd047f3fe986 .
