### PR TITLE
correct syntax error when _HAVE_VRRP_VMAC_ && no HAVE_IFLA_LINK_NETNSID

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2750,9 +2750,9 @@ vrrp_complete_instance(vrrp_t * vrrp)
 				    ifp->hw_addr[sizeof(ll_addr) - 1] == vrrp->vrid &&
 				    (ifp->base_ifp == vrrp->configured_ifp->base_ifp
 #ifdef HAVE_IFLA_LINK_NETNSID
-				     || (ifp == ifp->base_ifp && vrrp->configured_ifp->base_netns_id == ifp->base_netns_id))
+				     || (ifp == ifp->base_ifp && vrrp->configured_ifp->base_netns_id == ifp->base_netns_id)
 #endif
-															   )
+															   ))
 				{
 					log_message(LOG_INFO, "(%s) Found matching interface %s", vrrp->iname, ifp->ifname);
 					if (vrrp->vmac_ifname[0] &&


### PR DESCRIPTION
compilation error occurs on the kernel with MAC VLAN support and IFLA_LINK_NETNSID not support.

```
vrrp.c: In function 'vrrp_complete_instance':
vrrp.c:2756:5: error: expected ')' before '{' token
     {
     ^
vrrp.c:2772:4: error: expected expression before '}' token
    }
    ^
```

This PR corrects the above error.