### PR TITLE
genhash: ask the server to disable keep-alive

### DIFF
--- a/genhash/include/http.h
+++ b/genhash/include/http.h
@@ -41,10 +41,12 @@
 /* GET processing command */
 #define REQUEST_TEMPLATE "GET %s HTTP/1.0\r\n" \
 			 "User-Agent: KeepAlive GenHash Client\r\n" \
+			 "Connection: close\r\n" \
 			 "Host: %s%s\r\n\r\n"
 
 #define REQUEST_TEMPLATE_IPV6 "GET %s HTTP/1.0\r\n" \
 			 "User-Agent: KeepAlive GenHash Client\r\n" \
+			 "Connection: close\r\n" \
 			 "Host: [%s]%s\r\n\r\n"
 
 /* Output delimiters */


### PR DESCRIPTION
genhash speaks only HTTP/1.0 which strictly speaking doesn't support
keep-alive; but some servers which do not support version 1.0 may
interpret the absence of a "Connection" header as "enable keep-alive",
as required by version 1.1 of the protocol.  This breaks genhash,
which waits until the server closes the connection.

To fix this, this patch adds "Connection:close" which explicitly
disables keep-alive.