### PR TITLE
Fix systemd notice caused by PIDFile referencing /var/run

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2255,6 +2255,8 @@ GNU_STD_PATHS=No
 if test "${enable_gnu_std_paths}" = "yes"; then
   AC_DEFINE([GNU_STD_PATHS], [ 1 ], [set to enforce GNU standard paths, for .pid files etc])
   PID_DIR=$localstatedir
+elif test $INIT_TYPE = systemd; then
+  PID_DIR=/
 else
   PID_DIR=/var
 fi

--- a/keepalived/keepalived.service.in
+++ b/keepalived/keepalived.service.in
@@ -5,7 +5,7 @@ Wants=network-online.target @SNMP_SERVICE@
 
 [Service]
 Type=forking
-PIDFile=@PID_DIR@/run/keepalived.pid
+PIDFile=/run/keepalived.pid
 KillMode=process
 EnvironmentFile=-@sysconfdir@/sysconfig/keepalived
 ExecStart=@sbindir@/keepalived $KEEPALIVED_OPTIONS


### PR DESCRIPTION
exact message: "PIDFile= references a path below legacy directory /var/run/"

please review this carefully, I removed the variable from `keepalived.service.in` as all systemd machines will output this error when PIDFile doesn't start with /run - so it's pretty much a fixed requirement.

Notice introduced in https://github.com/systemd/systemd/issues/10657