### PR TITLE
Fix sending SMTP alerts

### DIFF
--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -64,7 +64,9 @@
 #define TASK_COMM_LEN	16
 #endif
 
+#ifdef _WITH_LVS_
 #define LVS_MAX_TIMEOUT		(86400*31)	/* 31 days */
+#endif
 
 /* data handlers */
 /* Global def handlers */

--- a/keepalived/core/smtp.c
+++ b/keepalived/core/smtp.c
@@ -73,18 +73,19 @@ struct {
 	int (*send) (thread_ref_t);
 	int (*read) (thread_ref_t, int);
 } SMTP_FSM[SMTP_MAX_FSM_STATE] = {
-/*      Stream Write Handlers    |   Stream Read handlers   *
- *-------------------------------+--------------------------*/
-	{connection_error,		NULL},			/* connect_error */
-	{connection_in_progress,	NULL},			/* connect_in_progress */
-	{connection_timeout,		NULL},			/* connect_timeout */
-	{connection_success,		connection_code},	/* connect_success */
-	{helo_cmd,			helo_code},		/* HELO */
-	{mail_cmd,			mail_code},		/* MAIL */
-	{rcpt_cmd,			rcpt_code},		/* RCPT */
-	{data_cmd,			data_code},		/* DATA */
-	{body_cmd,			body_code},		/* BODY */
-	{quit_cmd,			quit_code}		/* QUIT */
+/*       Code			  Stream Write Handlers		Stream Read handlers *
+ *------------------------------+----------------------------------------------------*/
+	[connect_error]		= {connection_error,		NULL},
+	[connect_in_progress]	= {connection_in_progress,	NULL},
+	[connect_timeout]	= {connection_timeout,		NULL},
+	[connect_fail]		= {connection_error,		NULL},
+	[connect_success]	= {connection_success,		connection_code},
+	[HELO]			= {helo_cmd,			helo_code},
+	[MAIL]			= {mail_cmd,			mail_code},
+	[RCPT]			= {rcpt_cmd,			rcpt_code},
+	[DATA]			= {data_cmd,			data_code},
+	[BODY]			= {body_cmd,			body_code},
+	[QUIT]			= {quit_cmd,			quit_code}
 };
 
 static void

--- a/keepalived/include/layer4.h
+++ b/keepalived/include/layer4.h
@@ -36,7 +36,8 @@ enum connect_result {
 	connect_in_progress,
 	connect_timeout,
 	connect_fail,
-	connect_success
+	connect_success,
+	connect_result_next
 };
 
 /* connection options structure definition */

--- a/keepalived/include/smtp.h
+++ b/keepalived/include/smtp.h
@@ -29,6 +29,7 @@
 
 /* local includes */
 #include "global_data.h"
+#include "layer4.h"
 #ifdef _WITH_LVS_
 #include "check_data.h"
 #include "check_api.h"

--- a/keepalived/include/smtp.h
+++ b/keepalived/include/smtp.h
@@ -41,17 +41,20 @@
 #define SMTP_PORT_STR		"25"
 #define SMTP_BUFFER_LENGTH	512U
 #define SMTP_BUFFER_MAX		1024U
-#define SMTP_MAX_FSM_STATE	10
 
-/* SMTP command stage */
-#define HELO	4
-#define MAIL	5
-#define RCPT	6
-#define DATA	7
-#define BODY	8
-#define QUIT	9
-#define END	10
-#define ERROR	11
+/* SMTP command stage. This values are used along with the enum connect_result
+ * values in the SMTP FSM, and so need to follow them. */
+enum smtp_cmd_state {
+	HELO = connect_result_next,
+	MAIL,
+	RCPT,
+	DATA,
+	BODY,
+	QUIT,
+	END,
+	ERROR
+};
+#define SMTP_MAX_FSM_STATE	END
 
 /* SMTP mesage type format */
 typedef enum {

--- a/keepalived/include/vrrp_data.h
+++ b/keepalived/include/vrrp_data.h
@@ -36,7 +36,7 @@
 typedef struct _vrrp_data {
 	list			static_track_groups;
 	list			static_addresses;
-#if _HAVE_FIB_ROUTING_
+#ifdef _HAVE_FIB_ROUTING_
 	list			static_routes;
 	list			static_rules;
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2973,6 +2973,7 @@ vrrp_complete_instance(vrrp_t * vrrp)
 #ifdef _WITH_FIREWALL_
 	if (vrrp->base_priority != VRRP_PRIO_OWNER && !vrrp->accept) {
 		bool have_firewall = false;
+		char *str;
 
 #ifdef _WITH_IPTABLES_
 		if (global_data->vrrp_iptables_inchain[0])
@@ -2988,8 +2989,9 @@ vrrp_complete_instance(vrrp_t * vrrp)
 			strcpy(global_data->vrrp_iptables_inchain, DEFAULT_IPTABLES_CHAIN_IN);
 			strcpy(global_data->vrrp_iptables_outchain, DEFAULT_IPTABLES_CHAIN_OUT);
 #else
-			global_data->vrrp_nf_table_name = MALLOC(strlen(DEFAULT_NFTABLES_TABLE) + 1);
-			strcpy(global_data->vrrp_nf_table_name, DEFAULT_NFTABLES_TABLE);
+			str = MALLOC(strlen(DEFAULT_NFTABLES_TABLE) + 1);
+			strcpy(str, DEFAULT_NFTABLES_TABLE);
+			global_data->vrrp_nf_table_name = str;
 #endif
 		}
 
@@ -3279,7 +3281,7 @@ sync_group_tracking_init(void)
 	}
 }
 
-#if _HAVE_FIB_ROUTING_
+#ifdef _HAVE_FIB_ROUTING_
 static void
 process_static_entries(void)
 {

--- a/keepalived/vrrp/vrrp_static_track.c
+++ b/keepalived/vrrp/vrrp_static_track.c
@@ -30,7 +30,7 @@
 #include "vrrp_static_track.h"
 #include "vrrp_ipaddress.h"
 #include "vrrp_track.h"
-#if _HAVE_FIB_ROUTING_
+#ifdef _HAVE_FIB_ROUTING_
 #include "vrrp_iproute.h"
 #include "vrrp_iprule.h"
 #endif
@@ -112,7 +112,7 @@ static_track_group_init(void)
 	static_track_group_t *tg;
 	vrrp_t *vrrp;
 	ip_address_t *addr;
-#if _HAVE_FIB_ROUTING_
+#ifdef _HAVE_FIB_ROUTING_
 	ip_route_t *route;
 	ip_rule_t *rule;
 #endif
@@ -146,7 +146,7 @@ static_track_group_init(void)
 			add_vrrp_to_interface(vrrp, addr->ifp, 0, false, TRACK_SADDR);
 	}
 
-#if _HAVE_FIB_ROUTING_
+#ifdef _HAVE_FIB_ROUTING_
 	/* Add the tracking vrrps to track the interface of each tracked address */
 	LIST_FOREACH(vrrp_data->static_routes, route, e) {
 		if (!route->track_group)
@@ -182,7 +182,7 @@ void
 static_track_reinstate_config(interface_t *ifp)
 {
 	ip_address_t *addr;
-#if _HAVE_FIB_ROUTING_
+#ifdef _HAVE_FIB_ROUTING_
 	ip_route_t *route;
 /*	ip_rule_t *rule; */
 #endif
@@ -196,7 +196,7 @@ static_track_reinstate_config(interface_t *ifp)
 		reinstate_static_address(addr);
 	}
 
-#if _HAVE_FIB_ROUTING_
+#ifdef _HAVE_FIB_ROUTING_
 	/* Add the tracking vrrps to track the interface of each tracked address */
 	LIST_FOREACH(vrrp_data->static_routes, route, e) {
 		if (route->dont_track)


### PR DESCRIPTION
Issue #1275 identified that SMTP alerts were not working. The SMTP alerts
were broken by commit 5860cf3 - "Make checker fail if ENETUNREACH returned
by connect()", since the SMTP state machine was not updated to handle the
addition value in enum connect_result.

This commit adds code to handle the additional enum, but also makes the
code less sensitive to such changes, and more likely to produce compiler
warnings/errors if appropriate updates are not done in the future.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>