### PR TITLE
handle pidfile_write correctly

### DIFF
--- a/keepalived/core/pidfile.c
+++ b/keepalived/core/pidfile.c
@@ -69,7 +69,12 @@ pidfile_write(const char *pid_file, int pid)
 		       pid_file);
 		return 0;
 	}
-	fprintf(pidfile, "%d\n", pid);
+	if (fprintf(pidfile, "%d\n", pid) < 0) {
+		log_message(LOG_INFO, "pidfile_write : Cannot write %s pidfile",
+		       pid_file);
+		fclose(pidfile);
+		return 0;
+	}
 	fclose(pidfile);
 	return 1;
 }


### PR DESCRIPTION
fprintf will fail under certain circumstances,
such as the disk is full.

Signed-off-by: Jie Liu <liujie165@huawei.com>