### PR TITLE
Fix for JSON characters escaping (issue #1299)

### DIFF
--- a/lib/json_writer.c
+++ b/lib/json_writer.c
@@ -85,8 +85,8 @@ static void jsonw_puts(const json_writer_t *self, const char *str)
 		case '"':
 			fputs("\\\"", self->out);
 			break;
-		case '\'':
-			fputs("\\\'", self->out);
+		case '/':
+			fputs("\\/", self->out);
 			break;
 		default:
 			putc(*str, self->out);


### PR DESCRIPTION
Changes, according to https://github.com/acassen/keepalived/issues/1299.