### PR TITLE
Fix segfault when we do not config vsg

### DIFF
--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -767,6 +767,9 @@ update_alive_counts(virtual_server_t *old, virtual_server_t *new)
 	list *old_l, *new_l;
 	element e;
 
+	if (!old->vsg || !new->vsg)
+	 	return ;
+
 	list old_ll[] = {
 		old->vsg->addr_range,
 		old->vsg->vfwmark,


### PR DESCRIPTION
When we do not config vsg, during reloading,
the old and new vsg is NULL, so we can not
use old(new)->vsg->addr_range or
old(new)->vsg->vfwmark directly.

Signed-off-by: Jie Liu <liujie165@huawei.com>