### PR TITLE
check_dns: fix blank DNS name problem

### DIFF
--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -509,8 +509,14 @@ dns_type_handler(const vector_t *strvec)
 static void
 dns_name_handler(const vector_t *strvec)
 {
+	char *dns_name = NULL;
 	dns_check_t *dns_check = CHECKER_GET();
-	dns_check->name = set_value(strvec);
+
+	dns_name = set_value(strvec);
+	if (!dns_name)
+		report_config_error(CONFIG_GENERAL_ERROR, "Blank DNS name - defaulting to \".\"");
+	else
+		dns_check->name = dns_name;
 }
 
 static void


### PR DESCRIPTION
In dns_name_handler func, set_value(strvec) will return NULL when
DNS name is blank in configure file. It will cause
reference-null-pointer problem in dns_make_query func.

Here, we will report config error and set DNS name to DNS_DEFAULT_NAME
when DNS name is NULL.

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>
Signed-off-by: Jie Liu <liujie165@huawei.com>
Reported-by: Ailing Duan <duanailing1@huawei.com>