### PR TITLE
Fix potential segfault when keywords without value

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -2003,9 +2003,6 @@ read_value_block(const vector_t *strvec)
 const char * __attribute__((malloc))
 set_value(const vector_t *strvec)
 {
-	if (vector_size(strvec) < 2)
-		return NULL;
-
 	return STRDUP(vector_slot(strvec, 1));
 }
 


### PR DESCRIPTION
As the pull request
https://github.com/acassen/keepalived/pull/1307#issue-287524770
says: when we meet the situation of like those who call
set_value, but the value is missing. Although we return the NULL
pointer, but it will still meet segfault. We can easily to reproduce
just like the config without a path:

 HTTP_GET {
 	url {
		path
		status_code 200
	}
}

So I consider it necessary to ensure all keywords using set_value
should have a value.

Signed-off-by: Jie Liu <liujie165@huawei.com>