### PR TITLE
Fix checking for VMAC/IPVLAN no longer used after reload

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3877,9 +3877,12 @@ clear_diff_vrrp(void)
 			 */
 			if (vrrp->ifp->is_ours &&
 			    ((__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags) &&
-			      !__test_bit(VRRP_VMAC_BIT, &vrrp->vmac_flags)) ||
-			     (__test_bit(VRRP_IPVLAN_BIT, &vrrp->vmac_flags) &&
-			      !__test_bit(VRRP_IPVLAN_BIT, &vrrp->vmac_flags)))) {
+			      !__test_bit(VRRP_VMAC_BIT, &new_vrrp->vmac_flags))
+#ifdef _HAVE_VRRP_IPVLAN_
+			     || (__test_bit(VRRP_IPVLAN_BIT, &vrrp->vmac_flags) &&
+				 !__test_bit(VRRP_IPVLAN_BIT, &new_vrrp->vmac_flags))
+#endif
+										     )) {
 				netlink_link_del_vmac(vrrp);
 			}
 #endif


### PR DESCRIPTION
This incorporates the patch in pull request 1310, and also fixes the code.