### PR TITLE
Various fixes/performance improvements for HTTP_GET checker

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1783,6 +1783,16 @@ The syntax for virtual_server is :
             # of a "Connection: close" line, which is included in
             # version 1.1 by default.
             \fBhttp_protocol \fR<PROTOCOL>
+            # When alpha mode is set, or when recovering from a failure,
+            # each URL is checked, with a delay of <delay_loop> between
+            # each check. if there were 20 URLs, and the <delay_loop> were
+            # 3 seconds, it would take 1 minute before the RS would come up
+            # following startup, or recovery from a failure. Setting
+            # fast_recovery removes the delay, both at start up and after
+            # recovery from a failure, meaning that the RS will come up
+            # once all the URLs have been checked, with no delay between
+            # checking each URL.
+            \fBfast_recovery \fR[<BOOL>]
             # An url to test
             # can have multiple entries here
             \fBurl \fR{

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -984,8 +984,11 @@ epilog(thread_ref_t thread, register_checker_t method)
 	}
 
 	/* register next timer thread */
-	if (method == REGISTER_CHECKER_NEW)
+	if (method == REGISTER_CHECKER_NEW) {
 		delay = checker->delay_loop;
+		if (!checker->has_run)
+			checker->retry_it = checker->retry;
+	}
 	else
 		delay = checker->delay_before_retry;
 

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -995,6 +995,8 @@ epilog(thread_ref_t thread, register_checker_t method)
 		if (!checker->has_run)
 			checker->retry_it = checker->retry;
 	}
+	else if (http_get_check->failed_url)
+		delay = checker->delay_before_retry > checker->delay_loop ? checker->delay_before_retry : checker->delay_loop;
 	else
 		delay = checker->delay_before_retry;
 

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -1005,8 +1005,14 @@ epilog(thread_ref_t thread, register_checker_t method)
 		thread_close_fd(thread);
 	}
 
-	/* Register next checker thread */
-	thread_add_timer(thread->master, http_connect_thread, checker, delay);
+	/* Register next checker thread.
+	 * If the checker is not up, but we are not aware of any failure,
+	 * don't delay the checks. */
+	if (!checker->has_run)
+		thread_add_event(thread->master, http_connect_thread, checker, 0);
+	else
+		thread_add_timer(thread->master, http_connect_thread, checker, delay);
+
 	return 0;
 }
 

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -1010,7 +1010,8 @@ epilog(thread_ref_t thread, register_checker_t method)
 	/* Register next checker thread.
 	 * If the checker is not up, but we are not aware of any failure,
 	 * don't delay the checks. */
-	if (!checker->has_run)
+	if (!checker->has_run ||
+	    (!checker->is_up && !http_get_check->failed_url))
 		thread_add_event(thread->master, http_connect_thread, checker, 0);
 	else
 		thread_add_timer(thread->master, http_connect_thread, checker, delay);

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -205,7 +205,7 @@ ssl_connect(thread_ref_t thread, int new_req)
 	http_checker_t *http_get_check = CHECKER_ARG(checker);
 	request_t *req = http_get_check->req;
 #ifdef _HAVE_SSL_SET_TLSEXT_HOST_NAME_
-	url_t *url = list_element(http_get_check->url, http_get_check->url_it);
+	url_t *url = ELEMENT_DATA(http_get_check->url_it);
 	const char* vhost = NULL;
 #endif
 	int ret = 0;
@@ -280,7 +280,7 @@ ssl_read_thread(thread_ref_t thread)
 	checker_t *checker = THREAD_ARG(thread);
 	http_checker_t *http_get_check = CHECKER_ARG(checker);
 	request_t *req = http_get_check->req;
-	url_t *url = list_element(http_get_check->url, http_get_check->url_it);
+	url_t *url = ELEMENT_DATA(http_get_check->url_it);
 	unsigned timeout = checker->co->connection_to;
 	unsigned char digest[MD5_DIGEST_LENGTH];
 	int r = 0;

--- a/keepalived/check/check_ssl.c
+++ b/keepalived/check/check_ssl.c
@@ -317,13 +317,11 @@ ssl_read_thread(thread_ref_t thread)
 
 		r = (req->error == SSL_ERROR_ZERO_RETURN) ? SSL_shutdown(req->ssl) : 0;
 
-		if (r && !req->extracted) {
+		if (r && !req->extracted)
 			return timeout_epilog(thread, "SSL read error from");
-		}
 
 		/* Handle response stream */
 		http_handle_response(thread, digest, !req->extracted);
-
 	}
 
 	return 0;

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -113,6 +113,7 @@ typedef struct _url {
 typedef struct _http_checker {
 	unsigned			proto;
 	element				url_it;		/* current url checked list element */
+	url_t				*failed_url;	/* the url that is currently failing, if any */
 	request_t			*req;		/* GET buffer and SSL args */
 	list				url;
 	http_protocol_t			http_protocol;

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -121,6 +121,7 @@ typedef struct _http_checker {
 #ifdef _HAVE_SSL_SET_TLSEXT_HOST_NAME_
 	bool				enable_sni;
 #endif
+	bool				fast_recovery;
 } http_checker_t;
 
 /* global defs */

--- a/keepalived/include/check_http.h
+++ b/keepalived/include/check_http.h
@@ -112,7 +112,7 @@ typedef struct _url {
 
 typedef struct _http_checker {
 	unsigned			proto;
-	unsigned			url_it;		/* current url checked index */
+	element				url_it;		/* current url checked list element */
 	request_t			*req;		/* GET buffer and SSL args */
 	list				url;
 	http_protocol_t			http_protocol;


### PR DESCRIPTION
Pull request #1306 identified that second and subsequent URLs in an HTTP_GET checker were not being executed after the first check. Unfortunately the patch provided didn't handle retry_it quite properly.

A number of enhancements were possible to enable faster startup and recovery, and also to ensure that all URLs are checked continuously.