### PR TITLE
DNS_CHECK: correct error info in dns_type_handler func

### DIFF
--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -501,7 +501,9 @@ dns_type_handler(const vector_t *strvec)
 
 	dns_type = dns_type_lookup(strvec_slot(strvec, 1));
 	if (!dns_type)
-		report_config_error(CONFIG_GENERAL_ERROR, "Unknown DNS check type %s - defaulting to SOA", vector_size(strvec) < 2 ? "[blank]" : strvec_slot(strvec, 1));
+		report_config_error(CONFIG_GENERAL_ERROR, "Unknown DNS check type %s - setting to %s",
+				    vector_size(strvec) < 2 ? "[blank]" : strvec_slot(strvec, 1),
+				    dns_type_name(dns_check->type));
 	else
 		dns_check->type = dns_type;
 }


### PR DESCRIPTION
Sometimes, users set two type values by mistake in keepalived.conf,
and the first is right and the second one is not in DNS_TYPE[].
Then the dns_check->type is set successfully when parsing first type value
, which may be different from the default SOA. As for the second one,
the dns_type_handler func will print error info "Defaulting to SOA",
actually, currently the dns_check->type may be not equal to SOA.

Here, we will print the dns_type_name(dns_check->type) instead of "SOA".

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>