### PR TITLE
Add VRRP tracking reverse option, and SNMP updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -419,6 +419,9 @@ AS_IF([test .$enable_regex != .yes],
     AS_IF([test .$enable_regex_timers = .yes], [AC_MSG_ERROR([enable-regex-timers requires enable-regex])])
     AS_IF([test .$enable_regex_debug = .yes], [AC_MSG_ERROR([enable-regex-debug requires enable-regex])])
   )
+AS_IF([test .$enable_track_process = .no],
+    AS_IF([test .$enable_track_process_debug = .yes], [AC_MSG_ERROR([enable-track-process-debug incompatible with disable-track-process])])
+  )
 
 dnl -- Check for diagnostic pragmas in functions - GCC 4.6.0
 AC_MSG_CHECKING([diagnostic pragmas in functions])

--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201906300002Z"
+     LAST-UPDATED "201906300003Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201906300003Z"
+     DESCRIPTION "add vrrp process tracker"
      REVISION "201906300002Z"
      DESCRIPTION "add vrrp bfd tracker"
      REVISION "201906300001Z"
@@ -752,6 +754,64 @@ vrrpSyncTrackedBfdWgtRev OBJECT-TYPE
     DESCRIPTION
         "Weight reversed for the tracked BFD."
     ::= { vrrpSyncTrackedBfdEntry 4 }
+
+vrrpSyncTrackedProcessTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF VrrpSyncTrackedProcessEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Table of tracked processes for each sync group."
+    ::= { vrrp 22 }
+
+vrrpSyncTrackedProcessEntry OBJECT-TYPE
+    SYNTAX VrrpSyncTrackedProcessEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Information describing a tracked process"
+    INDEX { vrrpSyncGroupIndex, vrrpSyncTrackedProcessIndex }
+    ::= { vrrpSyncTrackedProcessTable 1 }
+
+VrrpSyncTrackedProcessEntry ::= SEQUENCE {
+    vrrpSyncTrackedProcessIndex Integer32,
+    vrrpSyncTrackedProcessName DisplayString,
+    vrrpSyncTrackedProcessWeight Integer32,
+    vrrpSyncTrackedProcessWgtRev INTEGER
+}
+
+vrrpSyncTrackedProcessIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Index of the tracked process in the set of tracked processes for
+         the given VRRP instance. This index has no relation with the
+         index of vrrpSyncProcessTable."
+    ::= { vrrpSyncTrackedProcessEntry 1 }
+
+vrrpSyncTrackedProcessName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Name of the tracked process."
+    ::= { vrrpSyncTrackedProcessEntry 2 }
+
+vrrpSyncTrackedProcessWeight OBJECT-TYPE
+    SYNTAX Integer32 (-254..254)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight of the tracked process."
+    ::= { vrrpSyncTrackedProcessEntry 3 }
+
+vrrpSyncTrackedProcessWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reversed for the tracked process."
+    ::= { vrrpSyncTrackedProcessEntry 4 }
 
 vrrpSyncGroupMemberTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpSyncGroupMemberEntry
@@ -2797,6 +2857,215 @@ vrrpBfdWgtRev OBJECT-TYPE
         "Default weight reverse for the tracked BFD."
     ::= { vrrpBfdEntry 5 }
 
+-- VRRP track process
+-- see vrrp_track.h
+
+vrrpTrackedProcessTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF VrrpTrackedProcessEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Table of tracked processes for each VRRP instance."
+    ::= { vrrp 20 }
+
+vrrpTrackedProcessEntry OBJECT-TYPE
+    SYNTAX VrrpTrackedProcessEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Information describing a tracked process"
+    INDEX { vrrpInstanceIndex, vrrpTrackedProcessIndex }
+    ::= { vrrpTrackedProcessTable 1 }
+
+VrrpTrackedProcessEntry ::= SEQUENCE {
+    vrrpTrackedProcessIndex Integer32,
+    vrrpTrackedProcessName DisplayString,
+    vrrpTrackedProcessWeight Integer32,
+    vrrpTrackedProcessWgtRev Integer32
+}
+
+vrrpTrackedProcessIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Index of the tracked process in the set of tracked processes for
+         the given VRRP instance. This index has no relation with the
+         index of vrrpProcessTable."
+    ::= { vrrpTrackedProcessEntry 1 }
+
+vrrpTrackedProcessName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Name of the tracked process."
+    ::= { vrrpTrackedProcessEntry 2 }
+
+vrrpTrackedProcessWeight OBJECT-TYPE
+    SYNTAX Integer32 (-254..254)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight of the tracked process."
+    ::= { vrrpTrackedProcessEntry 3 }
+
+vrrpTrackedProcessWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reverse for the tracked process."
+    ::= { vrrpTrackedProcessEntry 4 }
+
+vrrpProcessTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF VrrpProcessEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Table of VRRP processes"
+    ::= { vrrp 21 }
+
+vrrpProcessEntry OBJECT-TYPE
+    SYNTAX VrrpProcessEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Information describing a VRRP process"
+    INDEX { vrrpProcessIndex }
+    ::= { vrrpProcessTable 1 }
+
+VrrpProcessEntry ::= SEQUENCE {
+    vrrpProcessIndex Integer32,
+    vrrpProcessName DisplayString,
+    vrrpProcessPath DisplayString,
+    vrrpProcessParams DisplayString,
+    vrrpProcessParamMatch INTEGER,
+    vrrpProcessWeight Integer32,
+    vrrpProcessWgtRev INTEGER,
+    vrrpProcessQuorum Unsigned32,
+    vrrpProcessQuorumMax Integer32,
+    vrrpProcessForkDelay Unsigned32,
+    vrrpProcessTerminateDelay Unsigned32,
+    vrrpProcessFullCommand INTEGER,
+    vrrpProcessCurProc Integer32,
+    vrrpProcessResult INTEGER
+}
+
+vrrpProcessIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Process index."
+    ::= { vrrpProcessEntry 1 }
+
+vrrpProcessName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Symbolic name of the process."
+    ::= { vrrpProcessEntry 2 }
+
+vrrpProcessPath OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Path of the process."
+    ::= { vrrpProcessEntry 3 }
+
+vrrpProcessParams OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Parameters to check of the process."
+    ::= { vrrpProcessEntry 4 }
+
+vrrpProcessParamMatch OBJECT-TYPE
+    SYNTAX INTEGER { none(0), exact(1), partial(2), initial(3) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Match type of the parameters."
+    ::= { vrrpProcessEntry 5 }
+
+vrrpProcessWeight OBJECT-TYPE
+    SYNTAX Integer32 (-254..254)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Default weight of the tracked process."
+    ::= { vrrpProcessEntry 6 }
+
+vrrpProcessWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Default weight reverse for the tracked process."
+    ::= { vrrpProcessEntry 7 }
+
+vrrpProcessQuorum OBJECT-TYPE
+    SYNTAX Unsigned32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Quorum of number of patching processes required."
+    ::= { vrrpProcessEntry 8 }
+
+vrrpProcessQuorumMax OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Maximum number of matching processes required."
+    ::= { vrrpProcessEntry 9 }
+
+vrrpProcessForkDelay OBJECT-TYPE
+    SYNTAX Unsigned32
+    UNITS "microseconds"
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Delay before consider new process running."
+    ::= { vrrpProcessEntry 10 }
+
+vrrpProcessTerminateDelay OBJECT-TYPE
+    SYNTAX Unsigned32
+    UNITS "microseconds"
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Delay before consider process terminated."
+    ::= { vrrpProcessEntry 11 }
+
+vrrpProcessFullCommand OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "True if full path named used rather than comm string."
+    ::= { vrrpProcessEntry 12 }
+
+vrrpProcessCurProc OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Number of matching processes currently running."
+    ::= { vrrpProcessEntry 13 }
+
+vrrpProcessResult OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Current status of the process."
+    ::= { vrrpProcessEntry 14 }
+
 -- Traps
 
 vrrpTrap OBJECT IDENTIFIER ::= { vrrp 10 }
@@ -4384,7 +4653,8 @@ vrrpCompliances MODULE-COMPLIANCE
     vrrpInstanceGroup,
     vrrpTrapsGroup,
     vrrpFileGroup,
-    vrrpBfdGroup
+    vrrpBfdGroup,
+    vrrpProcessGroup
     }
     ::= { compliances 2 }
 
@@ -4469,7 +4739,10 @@ vrrpSyncGroup OBJECT-GROUP
     vrrpSyncTrackedFileWgtRev,
     vrrpSyncTrackedBfdName,
     vrrpSyncTrackedBfdWeight,
-    vrrpSyncTrackedBfdWgtRev
+    vrrpSyncTrackedBfdWgtRev,
+    vrrpSyncTrackedProcessName,
+    vrrpSyncTrackedProcessWeight,
+    vrrpSyncTrackedProcessWgtRev
     }
     STATUS current
     DESCRIPTION
@@ -4518,6 +4791,9 @@ vrrpInstanceGroup OBJECT-GROUP
     vrrpTrackedBfdName,
     vrrpTrackedBfdWeight,
     vrrpTrackedBfdWgtRev,
+    vrrpTrackedProcessName,
+    vrrpTrackedProcessWeight,
+    vrrpTrackedProcessWgtRev,
     vrrpAddressType,
     vrrpAddressValue,
     vrrpAddressBroadcast,
@@ -4710,6 +4986,27 @@ vrrpBfdGroup OBJECT-GROUP
     DESCRIPTION
         "Conformance group for VRRP track BFDs."
     ::= { vrrpGroups 8 }
+
+vrrpProcessGroup OBJECT-GROUP
+    OBJECTS {
+    vrrpProcessName,
+    vrrpProcessPath,
+    vrrpProcessParams,
+    vrrpProcessParamMatch,
+    vrrpProcessWeight,
+    vrrpProcessWgtRev,
+    vrrpProcessQuorum,
+    vrrpProcessQuorumMax,
+    vrrpProcessForkDelay,
+    vrrpProcessTerminateDelay,
+    vrrpProcessFullCommand,
+    vrrpProcessCurProc,
+    vrrpProcessResult
+    }
+    STATUS current
+    DESCRIPTION
+        "Conformance group for VRRP track processes."
+    ::= { vrrpGroups 9 }
 
 checkGroups OBJECT IDENTIFIER ::= { groups 3 }
 

--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201906300001Z"
+     LAST-UPDATED "201906300002Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201906300002Z"
+     DESCRIPTION "add vrrp bfd tracker"
      REVISION "201906300001Z"
      DESCRIPTION "add reverse for vrrp trackers"
      REVISION "201904010001Z"
@@ -692,6 +694,64 @@ vrrpSyncTrackedFileWgtRev OBJECT-TYPE
     DESCRIPTION
         "Weight reversed for the tracked file."
     ::= { vrrpSyncTrackedFileEntry 4 }
+
+vrrpSyncTrackedBfdTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF VrrpSyncTrackedBfdEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Table of tracked BFDs for each sync group."
+    ::= { vrrp 19 }
+
+vrrpSyncTrackedBfdEntry OBJECT-TYPE
+    SYNTAX VrrpSyncTrackedBfdEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Information describing a tracked BFD"
+    INDEX { vrrpSyncGroupIndex, vrrpSyncTrackedBfdIndex }
+    ::= { vrrpSyncTrackedBfdTable 1 }
+
+VrrpSyncTrackedBfdEntry ::= SEQUENCE {
+    vrrpSyncTrackedBfdIndex Integer32,
+    vrrpSyncTrackedBfdName DisplayString,
+    vrrpSyncTrackedBfdWeight Integer32,
+    vrrpSyncTrackedBfdWgtRev Integer32
+}
+
+vrrpSyncTrackedBfdIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Index of the tracked BFD in the set of tracked BFDs for
+         the given VRRP instance. This index has no relation with the
+         index of vrrpSyncBfdTable."
+    ::= { vrrpSyncTrackedBfdEntry 1 }
+
+vrrpSyncTrackedBfdName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Name of the tracked BFD."
+    ::= { vrrpSyncTrackedBfdEntry 2 }
+
+vrrpSyncTrackedBfdWeight OBJECT-TYPE
+    SYNTAX Integer32 (-254..254)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight of the tracked BFD."
+    ::= { vrrpSyncTrackedBfdEntry 3 }
+
+vrrpSyncTrackedBfdWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reversed for the tracked BFD."
+    ::= { vrrpSyncTrackedBfdEntry 4 }
 
 vrrpSyncGroupMemberTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpSyncGroupMemberEntry
@@ -2611,6 +2671,132 @@ vrrpFileWgtRev OBJECT-TYPE
         "Default weight reverse for the tracked file."
     ::= { vrrpFileEntry 6 }
 
+-- VRRP track BFD
+-- see vrrp_track.h
+
+vrrpTrackedBfdTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF VrrpTrackedBfdEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Table of tracked BFDs for each VRRP instance."
+    ::= { vrrp 17 }
+
+vrrpTrackedBfdEntry OBJECT-TYPE
+    SYNTAX VrrpTrackedBfdEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Information describing a tracked BFD"
+    INDEX { vrrpInstanceIndex, vrrpTrackedBfdIndex }
+    ::= { vrrpTrackedBfdTable 1 }
+
+VrrpTrackedBfdEntry ::= SEQUENCE {
+    vrrpTrackedBfdIndex Integer32,
+    vrrpTrackedBfdName DisplayString,
+    vrrpTrackedBfdWeight Integer32,
+    vrrpTrackedBfdWgtRev Integer32
+}
+
+vrrpTrackedBfdIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Index of the tracked BFD in the set of tracked BFDs for
+         the given VRRP instance. This index has no relation with the
+         index of vrrpBfdTable."
+    ::= { vrrpTrackedBfdEntry 1 }
+
+vrrpTrackedBfdName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Name of the tracked BFD."
+    ::= { vrrpTrackedBfdEntry 2 }
+
+vrrpTrackedBfdWeight OBJECT-TYPE
+    SYNTAX Integer32 (-254..254)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight of the tracked BFD."
+    ::= { vrrpTrackedBfdEntry 3 }
+
+vrrpTrackedBfdWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reverse for the tracked BFD."
+    ::= { vrrpTrackedBfdEntry 4 }
+
+vrrpBfdTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF VrrpBfdEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Table of VRRP BFDs"
+    ::= { vrrp 18 }
+
+vrrpBfdEntry OBJECT-TYPE
+    SYNTAX VrrpBfdEntry
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Information describing a VRRP BFD"
+    INDEX { vrrpBfdIndex }
+    ::= { vrrpBfdTable 1 }
+
+VrrpBfdEntry ::= SEQUENCE {
+    vrrpBfdIndex Integer32,
+    vrrpBfdName DisplayString,
+    vrrpBfdResult INTEGER,
+    vrrpBfdWeight Integer32,
+    vrrpBfdWgtRev Integer32
+}
+
+vrrpBfdIndex OBJECT-TYPE
+    SYNTAX Integer32 (1..2147483647)
+    MAX-ACCESS not-accessible
+    STATUS current
+    DESCRIPTION
+        "Bfd index."
+    ::= { vrrpBfdEntry 1 }
+
+vrrpBfdName OBJECT-TYPE
+    SYNTAX DisplayString
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Symbolic name of the BFD."
+    ::= { vrrpBfdEntry 2 }
+
+vrrpBfdResult OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Current status of the BFD."
+    ::= { vrrpBfdEntry 3 }
+
+vrrpBfdWeight OBJECT-TYPE
+    SYNTAX Integer32 (-254..254)
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Default weight of the tracked BFD."
+    ::= { vrrpBfdEntry 4 }
+
+vrrpBfdWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Default weight reverse for the tracked BFD."
+    ::= { vrrpBfdEntry 5 }
+
 -- Traps
 
 vrrpTrap OBJECT IDENTIFIER ::= { vrrp 10 }
@@ -4197,7 +4383,8 @@ vrrpCompliances MODULE-COMPLIANCE
     vrrpSyncGroup,
     vrrpInstanceGroup,
     vrrpTrapsGroup,
-    vrrpFileGroup
+    vrrpFileGroup,
+    vrrpBfdGroup
     }
     ::= { compliances 2 }
 
@@ -4279,7 +4466,10 @@ vrrpSyncGroup OBJECT-GROUP
     vrrpSyncTrackedScriptWgtRev,
     vrrpSyncTrackedFileName,
     vrrpSyncTrackedFileWeight,
-    vrrpSyncTrackedFileWgtRev
+    vrrpSyncTrackedFileWgtRev,
+    vrrpSyncTrackedBfdName,
+    vrrpSyncTrackedBfdWeight,
+    vrrpSyncTrackedBfdWgtRev
     }
     STATUS current
     DESCRIPTION
@@ -4325,6 +4515,9 @@ vrrpInstanceGroup OBJECT-GROUP
     vrrpTrackedFileName,
     vrrpTrackedFileWeight,
     vrrpTrackedFileWgtRev,
+    vrrpTrackedBfdName,
+    vrrpTrackedBfdWeight,
+    vrrpTrackedBfdWgtRev,
     vrrpAddressType,
     vrrpAddressValue,
     vrrpAddressBroadcast,
@@ -4505,6 +4698,18 @@ vrrpFileGroup OBJECT-GROUP
     DESCRIPTION
         "Conformance group for VRRP track files."
     ::= { vrrpGroups 7 }
+
+vrrpBfdGroup OBJECT-GROUP
+    OBJECTS {
+    vrrpBfdName,
+    vrrpBfdResult,
+    vrrpBfdWeight,
+    vrrpBfdWgtRev
+    }
+    STATUS current
+    DESCRIPTION
+        "Conformance group for VRRP track BFDs."
+    ::= { vrrpGroups 8 }
 
 checkGroups OBJECT IDENTIFIER ::= { groups 3 }
 

--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -22,12 +22,14 @@ IMPORTS
         FROM SNMPv2-TC;
 
 keepalived MODULE-IDENTITY
-     LAST-UPDATED "201904010001Z"
+     LAST-UPDATED "201906300001Z"
      ORGANIZATION "Keepalived"
      CONTACT-INFO "http://www.keepalived.org"
      DESCRIPTION
         "This MIB describes objects used by keepalived, both
          for VRRP and health checker."
+     REVISION "201906300001Z"
+     DESCRIPTION "add reverse for vrrp trackers"
      REVISION "201904010001Z"
      DESCRIPTION "add lvs_flush_onstop for each virtual server"
      REVISION "201903250001Z"
@@ -547,7 +549,8 @@ vrrpSyncTrackedInterfaceEntry OBJECT-TYPE
 
 VrrpSyncTrackedInterfaceEntry ::= SEQUENCE {
     vrrpSyncTrackedInterfaceName DisplayString,
-    vrrpSyncTrackedInterfaceWeight Integer32
+    vrrpSyncTrackedInterfaceWeight Integer32,
+    vrrpSyncTrackedInterfaceWgtRev Integer32
 }
 
 vrrpSyncTrackedInterfaceName OBJECT-TYPE
@@ -565,6 +568,14 @@ vrrpSyncTrackedInterfaceWeight OBJECT-TYPE
     DESCRIPTION
         "Weight of the tracked interface."
     ::= { vrrpSyncTrackedInterfaceEntry 2 }
+
+vrrpSyncTrackedInterfaceWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reversed for the tracked interface."
+    ::= { vrrpSyncTrackedInterfaceEntry 3 }
 
 vrrpSyncTrackedScriptTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpSyncTrackedScriptEntry
@@ -586,7 +597,8 @@ vrrpSyncTrackedScriptEntry OBJECT-TYPE
 VrrpSyncTrackedScriptEntry ::= SEQUENCE {
     vrrpSyncTrackedScriptIndex Integer32,
     vrrpSyncTrackedScriptName DisplayString,
-    vrrpSyncTrackedScriptWeight Integer32
+    vrrpSyncTrackedScriptWeight Integer32,
+    vrrpSyncTrackedScriptWgtRev Integer32
 }
 
 vrrpSyncTrackedScriptIndex OBJECT-TYPE
@@ -615,6 +627,14 @@ vrrpSyncTrackedScriptWeight OBJECT-TYPE
         "Weight of the tracked interface."
     ::= { vrrpSyncTrackedScriptEntry 3 }
 
+vrrpSyncTrackedScriptWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reversed for the tracked interface."
+    ::= { vrrpSyncTrackedScriptEntry 4 }
+
 vrrpSyncTrackedFileTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpSyncTrackedFileEntry
     MAX-ACCESS not-accessible
@@ -635,7 +655,8 @@ vrrpSyncTrackedFileEntry OBJECT-TYPE
 VrrpSyncTrackedFileEntry ::= SEQUENCE {
     vrrpSyncTrackedFileIndex Integer32,
     vrrpSyncTrackedFileName DisplayString,
-    vrrpSyncTrackedFileWeight Integer32
+    vrrpSyncTrackedFileWeight Integer32,
+    vrrpSyncTrackedFileWgtRev Integer32
 }
 
 vrrpSyncTrackedFileIndex OBJECT-TYPE
@@ -663,6 +684,14 @@ vrrpSyncTrackedFileWeight OBJECT-TYPE
     DESCRIPTION
         "Weight of the tracked file."
     ::= { vrrpSyncTrackedFileEntry 3 }
+
+vrrpSyncTrackedFileWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reversed for the tracked file."
+    ::= { vrrpSyncTrackedFileEntry 4 }
 
 vrrpSyncGroupMemberTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpSyncGroupMemberEntry
@@ -1043,7 +1072,8 @@ vrrpTrackedInterfaceEntry OBJECT-TYPE
 
 VrrpTrackedInterfaceEntry ::= SEQUENCE {
     vrrpTrackedInterfaceName DisplayString,
-    vrrpTrackedInterfaceWeight Integer32
+    vrrpTrackedInterfaceWeight Integer32,
+    vrrpTrackedInterfaceWgtRev Integer32
 }
 
 vrrpTrackedInterfaceName OBJECT-TYPE
@@ -1061,6 +1091,14 @@ vrrpTrackedInterfaceWeight OBJECT-TYPE
     DESCRIPTION
         "Weight of the tracked interface."
     ::= { vrrpTrackedInterfaceEntry 2 }
+
+vrrpTrackedInterfaceWgtRev OBJECT-TYPE
+    SYNTAX Integer32
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reverse for the tracked interface."
+    ::= { vrrpTrackedInterfaceEntry 3 }
 
 vrrpTrackedScriptTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpTrackedScriptEntry
@@ -1082,7 +1120,8 @@ vrrpTrackedScriptEntry OBJECT-TYPE
 VrrpTrackedScriptEntry ::= SEQUENCE {
     vrrpTrackedScriptIndex Integer32,
     vrrpTrackedScriptName DisplayString,
-    vrrpTrackedScriptWeight Integer32
+    vrrpTrackedScriptWeight Integer32,
+    vrrpTrackedScriptWgtRev Integer32
 }
 
 vrrpTrackedScriptIndex OBJECT-TYPE
@@ -1110,6 +1149,14 @@ vrrpTrackedScriptWeight OBJECT-TYPE
     DESCRIPTION
         "Weight of the tracked interface."
     ::= { vrrpTrackedScriptEntry 3 }
+
+vrrpTrackedScriptWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reverse for the tracked interface."
+    ::= { vrrpTrackedScriptEntry 4 }
 
 -- IP addresses
 -- see vrrp_ipaddress.h
@@ -2347,7 +2394,8 @@ VrrpScriptEntry ::= SEQUENCE {
     vrrpScriptWeight Integer32,
     vrrpScriptResult INTEGER,
     vrrpScriptRise Unsigned32,
-    vrrpScriptFall Unsigned32
+    vrrpScriptFall Unsigned32,
+    vrrpScriptWgtRev Integer32
 }
 
 vrrpScriptIndex OBJECT-TYPE
@@ -2420,6 +2468,14 @@ vrrpScriptFall OBJECT-TYPE
         "How many times the script should fail before KO."
     ::= { vrrpScriptEntry 8 }
 
+vrrpScriptWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reverse for the script if successful."
+    ::= { vrrpScriptEntry 9 }
+
 -- VRRP files
 -- see vrrp_track.h
 
@@ -2443,7 +2499,8 @@ vrrpTrackedFileEntry OBJECT-TYPE
 VrrpTrackedFileEntry ::= SEQUENCE {
     vrrpTrackedFileIndex Integer32,
     vrrpTrackedFileName DisplayString,
-    vrrpTrackedFileWeight Integer32
+    vrrpTrackedFileWeight Integer32,
+    vrrpTrackedFileWgtRev Integer32
 }
 
 vrrpTrackedFileIndex OBJECT-TYPE
@@ -2472,6 +2529,14 @@ vrrpTrackedFileWeight OBJECT-TYPE
         "Weight of the tracked file."
     ::= { vrrpTrackedFileEntry 3 }
 
+vrrpTrackedFileWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Weight reverse for the tracked file."
+    ::= { vrrpTrackedFileEntry 4 }
+
 vrrpFileTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpFileEntry
     MAX-ACCESS not-accessible
@@ -2494,7 +2559,8 @@ VrrpFileEntry ::= SEQUENCE {
     vrrpFileName DisplayString,
     vrrpFilePath DisplayString,
     vrrpFileResult INTEGER,
-    vrrpFileWeight Integer32
+    vrrpFileWeight Integer32,
+    vrrpFileWgtRev Integer32
 }
 
 vrrpFileIndex OBJECT-TYPE
@@ -2536,6 +2602,14 @@ vrrpFileWeight OBJECT-TYPE
     DESCRIPTION
         "Default weight of the tracked file."
     ::= { vrrpFileEntry 5 }
+
+vrrpFileWgtRev OBJECT-TYPE
+    SYNTAX INTEGER { true(1), false(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Default weight reverse for the tracked file."
+    ::= { vrrpFileEntry 6 }
 
 -- Traps
 
@@ -4199,10 +4273,13 @@ vrrpSyncGroup OBJECT-GROUP
     vrrpSyncGroupMemberName,
     vrrpSyncTrackedInterfaceName,
     vrrpSyncTrackedInterfaceWeight,
+    vrrpSyncTrackedInterfaceWgtRev,
     vrrpSyncTrackedScriptName,
     vrrpSyncTrackedScriptWeight,
+    vrrpSyncTrackedScriptWgtRev,
     vrrpSyncTrackedFileName,
-    vrrpSyncTrackedFileWeight
+    vrrpSyncTrackedFileWeight,
+    vrrpSyncTrackedFileWgtRev
     }
     STATUS current
     DESCRIPTION
@@ -4241,10 +4318,13 @@ vrrpInstanceGroup OBJECT-GROUP
     vrrpInstanceScriptMstrRxLowerPri,
     vrrpTrackedInterfaceName,
     vrrpTrackedInterfaceWeight,
+    vrrpTrackedInterfaceWgtRev,
     vrrpTrackedScriptName,
     vrrpTrackedScriptWeight,
+    vrrpTrackedScriptWgtRev,
     vrrpTrackedFileName,
     vrrpTrackedFileWeight,
+    vrrpTrackedFileWgtRev,
     vrrpAddressType,
     vrrpAddressValue,
     vrrpAddressBroadcast,
@@ -4373,7 +4453,8 @@ vrrpScriptGroup OBJECT-GROUP
     vrrpScriptWeight,
     vrrpScriptResult,
     vrrpScriptRise,
-    vrrpScriptFall
+    vrrpScriptFall,
+    vrrpScriptWgtRev
     }
     STATUS current
     DESCRIPTION
@@ -4417,7 +4498,8 @@ vrrpFileGroup OBJECT-GROUP
     vrrpFileName,
     vrrpFilePath,
     vrrpFileResult,
-    vrrpFileWeight
+    vrrpFileWeight,
+    vrrpFileWgtRev
     }
     STATUS current
     DESCRIPTION

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -745,6 +745,8 @@ The configuration block looks like:
         param_match {initial|partial}
 
         # default weight (default is 1). For description of reverse, see track_process.
+        # 'weight 0 reverse' will cause the vrrp instance to be down when the
+        # quorum is up, and vice versa.
         \fBweight\fR <-254..254> [reverse]
 
         # minimum number of processes for success
@@ -895,7 +897,8 @@ The syntax for bfd instance is :
     # Normally, positive weights are added to the vrrp instance priority when
     # the bfd instance is up, negative weights reduce the priority when it is down.
     # However, if reverse is specified, the priority is decreased when up and
-    # increased when down.
+    # increased when down. 'weight 0 reverse' will cause the vrrp instance to be down
+    # when the bfd instance is up, and vice versa.
     \fBweight\fR <-253:253> [reverse]
 }
 .fi
@@ -942,6 +945,8 @@ The syntax for the vrrp script is:
 
     # adjust priority by this weight, (default: 0)
     # For description of reverse, see track_script.
+    # 'weight 0 reverse' will cause the vrrp instance to be down when the
+    # script is up, and vice versa.
     \fBweight \fR<INTEGER:-253..253> [reverse]
 
     # required number of successes for OK transition
@@ -969,7 +974,7 @@ or sync group monitors it.
 
 A value will be read as a number in text from the file.  If the weight
 configured against the track_file is 0, a non-zero value in the file will
-be treated as a failure status, and a zero value will be treaded as
+be treated as a failure status, and a zero value will be treated as
 an OK status, otherwise the value will be  multiplied by the weight configured
 in the track_file statement. If the result is less than -253 any VRRP
 instance or sync group monitoring the script will transition to the fault state
@@ -1038,6 +1043,8 @@ The syntax for vrrp_sync_group is :
     # Synchronization group tracking interface, script, file & bfd will
     # update the status/priority of all VRRP instances which are members
     # of the sync group.
+    # 'weight 0 reverse' will cause the vrrp instance to be down when the
+    # interface is up, and vice versa.
     \fBtrack_interface \fR{
         eth0
         eth1

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1049,9 +1049,18 @@ The syntax for vrrp_sync_group is :
     }
 
     # Files whose state we monitor, value is added to effective priority.
-    # <STRING> is the name of a vrrp_status_file
+    # <STRING> is the name of a vrrp_track_file
     # weight defaults to weight configured in vrrp_track_file
     \fBtrack_file \fR{
+        <STRING>
+        <STRING> weight <-254..254>
+        ...
+    }
+
+    # Process to monitor, weight is added to effective priority.
+    # <STRING> is the name of a vrrp_track_process
+    # weight defaults to weight configured in vrrp_track_process
+    \fBtrack_process \fR{
         <STRING>
         <STRING> weight <-254..254>
         ...
@@ -1256,6 +1265,16 @@ The syntax for vrrp_instance is :
     # <STRING> is the name of a vrrp_track_file
     \fBtrack_file \fR{
         <STRING>
+        <STRING>
+        <STRING> weight <-254..254>
+        ...
+    }
+
+    # Positive weights are added/subtracted when the process is running,
+    # negative weights are subtracted/added when the not running.
+    # <STRING> is the name of a vrrp_track_process
+    # weight defaults to weight configured in vrrp_track_process
+    \fBtrack_process \fR{
         <STRING>
         <STRING> weight <-254..254>
         ...

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -744,8 +744,8 @@ The configuration block looks like:
         #   any parameters, but specify param_match.
         param_match {initial|partial}
 
-        # default weight (default is 1)
-        \fBweight\fR <-254..254>
+        # default weight (default is 1). For description of reverse, see track_process.
+        \fBweight\fR <-254..254> [reverse]
 
         # minimum number of processes for success
         \fBquorum\fR NUM
@@ -1063,10 +1063,11 @@ The syntax for vrrp_sync_group is :
 
     # Process to monitor, weight is added to effective priority.
     # <STRING> is the name of a vrrp_track_process
-    # weight defaults to weight configured in vrrp_track_process
+    # weight defaults to weight configured in vrrp_track_process.
+    # See vrrp_instance track_process for description of weight.
     \fBtrack_process \fR{
         <STRING>
-        <STRING> weight <-254..254>
+        <STRING> weight <-254..254> [reverse|noreverse]
         ...
     }
 
@@ -1278,11 +1279,12 @@ The syntax for vrrp_instance is :
 
     # Positive weights are added/subtracted when the process is running,
     # negative weights are subtracted/added when the not running.
+    # If reverse is specified, the addition/subtraction is reversed.
     # <STRING> is the name of a vrrp_track_process
     # weight defaults to weight configured in vrrp_track_process
     \fBtrack_process \fR{
         <STRING>
-        <STRING> weight <-254..254>
+        <STRING> weight <-254..254> [reverse|noreverse]
         ...
     }
 

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -941,7 +941,8 @@ The syntax for the vrrp script is:
     \fBtimeout \fR<INTEGER>
 
     # adjust priority by this weight, (default: 0)
-    \fBweight \fR<INTEGER:-253..253>
+    # For description of reverse, see track_script.
+    \fBweight \fR<INTEGER:-253..253> [reverse]
 
     # required number of successes for OK transition
     \fBrise \fR<INTEGER>
@@ -1047,9 +1048,10 @@ The syntax for vrrp_sync_group is :
     # add a tracking script to the sync group (<SCRIPT_NAME> is the name
     # of the vrrp_script entry) go to FAULT state if any of these go down
     # if unweighted.
+    # reverse causes the direction of the adjustment of the priority to be reversed.
     \fBtrack_script \fR{
         <SCRIPT_NAME>
-        <SCRIPT_NAME> weight <-253..253>
+        <SCRIPT_NAME> weight <-253..253> [reverse|no_reverse]
     }
 
     # Files whose state we monitor, value is added to effective priority.
@@ -1263,9 +1265,10 @@ The syntax for vrrp_instance is :
     # The same principle as track_interface can be applied to track_script entries,
     # except that an unspecified weight means that the default weight declared in
     # the script will be used (which itself defaults to 0).
+    # reverse causes the direction of the adjustment of the priority to be reversed.
     \fBtrack_script \fR{
         <SCRIPT_NAME>
-        <SCRIPT_NAME> weight <-253..253>
+        <SCRIPT_NAME> weight <-253..253> [reverse|no_reverse]
     }
 
     # Files whose state we monitor, value is added to effective priority.

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -892,7 +892,11 @@ The syntax for bfd instance is :
     \fBmax_hops \fR<INTEGER>
 
     # Default tracking weight
-    \fBweight\fR
+    # Normally, positive weights are added to the vrrp instance priority when
+    # the bfd instance is up, negative weights reduce the priority when it is down.
+    # However, if reverse is specified, the priority is decreased when up and
+    # increased when down.
+    \fBweight\fR <-253:253> [reverse]
 }
 .fi
 .PP
@@ -1071,7 +1075,7 @@ The syntax for vrrp_sync_group is :
     \fBtrack_bfd \fR{
         <STRING>
         <STRING>
-        <STRING> weight <INTEGER: -253..253>
+        <STRING> weight <INTEGER: -253..253> [reverse|noreverse]
         ...
     }
 
@@ -1280,12 +1284,15 @@ The syntax for vrrp_instance is :
         ...
     }
 
-    # BFD instances we monitor, value is added to effective priority.
+    # BFD instances we monitor, value is added to effective priority,
+    # unless reverse is specified, when the value is subtracted.
+    # Positive weights are add/subtracted when the bfd instance is up,
+    # negative weights are subtracted/added when the bfd instance is down.
     # <STRING> is the name of a BFD instance
     \fBtrack_bfd \fR{
         <STRING>
         <STRING>
-        <STRING> weight <INTEGER: -253..253>
+        <STRING> weight <INTEGER: -253..253> [reverse|noreverse]
         ...
     }
 

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1040,7 +1040,7 @@ The syntax for vrrp_sync_group is :
     \fBtrack_interface \fR{
         eth0
         eth1
-        eth2 weight <-253..253>
+        eth2 weight <-253..253> [reverse]
         ...
     }
 
@@ -1241,17 +1241,19 @@ The syntax for vrrp_instance is :
     # instance to the FAULT state in case of failure, its priority will be
     # increased by the weight when the interface is up (for positive weights),
     # or decreased by the weight's absolute value when the interface is down
-    # (for negative weights). The weight must be comprised between -254 and +254
-    # inclusive. 0 is the default behaviour which means that a failure implies a
+    # (for negative weights), unless reverse is specified, in which case the
+    # direction of adjustment of the priority is reversed.
+    # The weight must be comprised between -253 and +253 inclusive.
+    # 0 is the default behaviour which means that a failure implies a
     # FAULT state. The common practice is to use positive weights to count a
     # limited number of good services so that the server with the highest count
     # becomes master. Negative weights are better to count unexpected failures
     # among a high number of interfaces, as it will not saturate even with high
-    # number of interfaces.
+    # number of interfaces. Use reverse to increase priority if an interfaces is down
     \fBtrack_interface \fR{
         eth0
         eth1
-        eth2 weight <-253..253>
+        eth2 weight <-253..253> [reverse]
          ...
     }
 

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -997,7 +997,7 @@ The syntax for vrrp track file is :
     \fBfile \fR<QUOTED_STRING>
 
     # optional default weight
-    \fBweight \fR<-254..254>
+    \fBweight \fR<-254..254> [reverse]
 
     # create the file and/or initialise the value
     # This causes VALUE (default 0) to be written to
@@ -1066,7 +1066,7 @@ The syntax for vrrp_sync_group is :
     # weight defaults to weight configured in vrrp_track_file
     \fBtrack_file \fR{
         <STRING>
-        <STRING> weight <-254..254>
+        <STRING> weight <-254..254> [reverse|noreverse]
         ...
     }
 
@@ -1283,7 +1283,7 @@ The syntax for vrrp_instance is :
     \fBtrack_file \fR{
         <STRING>
         <STRING>
-        <STRING> weight <-254..254>
+        <STRING> weight <-254..254> [reverse|noreverse]
         ...
     }
 

--- a/keepalived/bfd/bfd_parser.c
+++ b/keepalived/bfd/bfd_parser.c
@@ -384,6 +384,7 @@ bfd_vrrp_handler(const vector_t *strvec)
 	PMALLOC(tbfd);
 	strcpy(tbfd->bname, name);
 	tbfd->weight = 0;
+	tbfd->weight_reverse = false;
 	tbfd->bfd_up = false;
 	list_add(vrrp_data->vrrp_track_bfds, tbfd);
 }
@@ -408,6 +409,14 @@ bfd_vrrp_weight_handler(const vector_t *strvec)
 			    -253, 253);
 	} else
 		tbfd->weight = value;
+
+	if (vector_size(strvec) >= 3) {
+		if (strcmp(strvec_slot(strvec, 2), "reverse"))
+			report_config_error(CONFIG_GENERAL_ERROR, "Configuration error: BFD instance %s"
+				    " unknown weight option %s", tbfd->bname, strvec_slot(strvec, 2));
+		else
+			tbfd->weight_reverse = true;
+	}
 }
 
 static void

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1505,9 +1505,9 @@ process_if_status_change(interface_t *ifp)
 
 		if (tvp->weight) {
 			if (now_up)
-				vrrp->total_priority += abs(tvp->weight);
+				vrrp->total_priority += abs(tvp->weight) * tvp->weight_multiplier;
 			else
-				vrrp->total_priority -= abs(tvp->weight);
+				vrrp->total_priority -= abs(tvp->weight) * tvp->weight_multiplier;
 			vrrp_set_effective_priority(vrrp);
 
 			continue;

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1514,7 +1514,7 @@ process_if_status_change(interface_t *ifp)
 		}
 
 		/* This vrrp's interface or underlying interface has changed */
-		if (now_up)
+		if (now_up == (tvp->weight_multiplier == 1))
 			try_up_instance(vrrp, false);
 		else
 			down_instance(vrrp);

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -1019,8 +1019,10 @@ initialise_debug_options(void)
 #ifdef _NETWORK_TIMESTAMP_
 	do_network_timestamp = !!(network_timestamp_debug & mask);
 #endif
+#ifdef _WITH_CN_PROC_
 #ifdef _TRACK_PROCESS_DEBUG_
 	do_track_process_debug = !!(track_process_debug & mask);
+#endif
 #endif
 #ifdef _PARSER_DEBUG_
 	do_parser_debug = !!(parser_debug & mask);

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -417,7 +417,7 @@ extern int open_vrrp_read_socket(sa_family_t, int, interface_t *, bool, int);
 extern int new_vrrp_socket(vrrp_t *);
 extern void vrrp_send_adv(vrrp_t *, uint8_t);
 extern void vrrp_send_link_update(vrrp_t *, unsigned);
-extern void add_vrrp_to_interface(vrrp_t *, interface_t *, int, bool, track_t);
+extern void add_vrrp_to_interface(vrrp_t *, interface_t *, int, bool, bool, track_t);
 extern void del_vrrp_from_interface(vrrp_t *, interface_t *);
 extern bool vrrp_state_master_rx(vrrp_t *, const vrrphdr_t *, const char *, ssize_t);
 extern void vrrp_state_master_tx(vrrp_t *);

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -157,6 +157,7 @@ typedef struct _interface {
 /* Tracked interface structure definition */
 typedef struct _tracked_if {
 	int			weight;		/* tracking weight when non-zero */
+	bool			weight_reverse; /* which direction is the weight applied */
 	interface_t		*ifp;		/* interface backpointer, cannot be NULL */
 } tracked_if_t;
 

--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -162,7 +162,7 @@ typedef struct _vrrp_bfd {
 typedef struct _tracked_bfd {
 	vrrp_tracked_bfd_t	*bfd;		/* track bfd pointer, cannot be NULL */
 	int			weight;		/* Weight for bfd */
-	int			weight_multiplier; /* Which direction is weight applied */
+	bool			weight_reverse; /* which direction is the weight applied */
 } tracked_bfd_t;
 #endif
 

--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -90,6 +90,7 @@ typedef struct _vrrp_file {
 	const char		*file_path;	/* Path to file */
 	const char		*file_part;	/* Pointer to start of filename without directories */
 	int			weight;		/* Default weight */
+	bool			weight_reverse;	/* which direction is the weight applied */
 	int			wd;		/* Watch descriptor */
 	list			tracking_vrrp;	/* List of tracking_vrrp_t for vrrp instances tracking this file */
 	int			last_status;	/* Last status returned by file. Used to report changes */
@@ -99,6 +100,7 @@ typedef struct _vrrp_file {
 typedef struct _tracked_file {
 	vrrp_tracked_file_t	*file;		/* track file pointer, cannot be NULL */
 	int			weight;		/* Multiplier for file value */
+	bool			weight_reverse;	/* which direction is the weight applied */
 } tracked_file_t;
 
 #ifdef _WITH_CN_PROC_

--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -66,6 +66,7 @@ typedef struct _vrrp_script {
 	unsigned long		interval;	/* interval between script calls */
 	unsigned long		timeout;	/* microseconds before script timeout */
 	int			weight;		/* weight associated to this script */
+	bool			weight_reverse;	/* which direction is the weight applied */
 	int			result;		/* result of last call to this script: 0..R-1 = KO, R..R+F-1 = OK */
 	int			rise;		/* R: how many successes before OK */
 	int			fall;		/* F: how many failures before KO */
@@ -80,6 +81,7 @@ typedef struct _vrrp_script {
 typedef struct _tracked_sc {
 	vrrp_script_t		*scr;		/* script pointer, cannot be NULL */
 	int			weight;		/* tracking weight when non-zero */
+	bool			weight_reverse;	/* which direction is the weight applied */
 } tracked_sc_t;
 
 /* external file we read to track local processes */

--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -115,6 +115,7 @@ typedef struct _vrrp_process {
 	size_t			process_params_len; /* Total length of parameters, including NULs */
 	param_match_t		param_match;	/* Full or partial match of parameters */
 	int			weight;		/* Default weight */
+	bool			weight_reverse;	/* which direction is the weight applied */
 	unsigned		quorum;		/* Minimum number of process instances required */
 	unsigned		quorum_max;	/* Maximum number of process instances required */
 	int			fork_delay;	/* Delay before processing process fork */
@@ -132,6 +133,7 @@ typedef struct _vrrp_process {
 typedef struct _tracked_process {
 	vrrp_tracked_process_t	*process;	/* track process pointer, cannot be NULL */
 	int			weight;		/* Multiplier for process value */
+	bool			weight_reverse;	/* which direction is the weight applied */
 } tracked_process_t;
 
 /* A monitored process instance */

--- a/keepalived/include/vrrp_track.h
+++ b/keepalived/include/vrrp_track.h
@@ -147,6 +147,7 @@ typedef struct _tracked_process_instance {
 typedef struct _vrrp_bfd {
 	char			bname[BFD_INAME_MAX];	/* bfd name */
 	int			weight;		/* Default weight */
+	bool			weight_reverse;	/* apply weight in opposite direction */
 	list			tracking_vrrp;	/* List of tracking_vrrp_t for vrrp instances tracking this bfd */
 	bool			bfd_up;		/* Last status returned by bfd. Used to report changes */
 } vrrp_tracked_bfd_t;
@@ -155,6 +156,7 @@ typedef struct _vrrp_bfd {
 typedef struct _tracked_bfd {
 	vrrp_tracked_bfd_t	*bfd;		/* track bfd pointer, cannot be NULL */
 	int			weight;		/* Weight for bfd */
+	int			weight_multiplier; /* Which direction is weight applied */
 } tracked_bfd_t;
 #endif
 
@@ -178,6 +180,7 @@ typedef enum {
 /* List structure from scripts, files and interfaces to tracking vrrp */
 typedef struct _tracking_vrrp {
 	int			weight;		/* Tracking weight, or zero for down instance */
+	int			weight_multiplier; /* Which direction is weight applied */
 	struct _vrrp_t		*vrrp;		/* The vrrp instance */
 	track_t			type;		/* Type of object being tracked */
 } tracking_vrrp_t;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2465,6 +2465,7 @@ add_vrrp_to_track_script(vrrp_t *vrrp, tracked_sc_t *sc)
 	tvp = MALLOC(sizeof(tracking_vrrp_t));
 	tvp->vrrp = vrrp;
 	tvp->weight = sc->weight;
+	tvp->weight_multiplier = sc->weight_reverse ? -1 : 1;
 	list_add(sc->scr->tracking_vrrp, tvp);
 }
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2531,6 +2531,7 @@ add_vrrp_to_track_process(vrrp_t *vrrp, tracked_process_t *tpr)
 	tvp = MALLOC(sizeof(tracking_vrrp_t));
 	tvp->vrrp = vrrp;
 	tvp->weight = tpr->weight;
+	tvp->weight_multiplier = tpr->weight_reverse ? -1 : 1;
 	list_add(tpr->process->tracking_vrrp, tvp);
 }
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2552,8 +2552,10 @@ add_vrrp_to_track_bfd(vrrp_t *vrrp, tracked_bfd_t *tbfd)
 				log_message(LOG_INFO, "(%s) track_bfd %s is configured on VRRP instance and sync group. Remove vrrp instance config",
 						vrrp->iname, tbfd->bfd->bname);
 
-				if (etvp->weight)
+				if (etvp->weight) {
 					etvp->weight = tbfd->weight;
+					etvp->weight_multiplier = tbfd->weight_multiplier;
+				}
 				return;
 			}
 		}
@@ -2562,6 +2564,7 @@ add_vrrp_to_track_bfd(vrrp_t *vrrp, tracked_bfd_t *tbfd)
 	PMALLOC(tvp);
 	tvp->vrrp = vrrp;
 	tvp->weight = tbfd->weight;
+	tvp->weight_multiplier = tbfd->weight_multiplier;
 	list_add(tbfd->bfd->tracking_vrrp, tvp);
 }
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2562,7 +2562,7 @@ add_vrrp_to_track_bfd(vrrp_t *vrrp, tracked_bfd_t *tbfd)
 
 				if (etvp->weight) {
 					etvp->weight = tbfd->weight;
-					etvp->weight_multiplier = tbfd->weight_multiplier;
+					etvp->weight_multiplier = tbfd->weight_reverse ? -1 : 1;
 				}
 				return;
 			}
@@ -2572,7 +2572,7 @@ add_vrrp_to_track_bfd(vrrp_t *vrrp, tracked_bfd_t *tbfd)
 	PMALLOC(tvp);
 	tvp->vrrp = vrrp;
 	tvp->weight = tbfd->weight;
-	tvp->weight_multiplier = tbfd->weight_multiplier;
+	tvp->weight_multiplier = tbfd->weight_reverse ? -1 : 1;
 	list_add(tbfd->bfd->tracking_vrrp, tvp);
 }
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2482,16 +2482,17 @@ add_vrrp_to_track_file(vrrp_t *vrrp, tracked_file_t *tfl)
 		/* Is this file already tracking the vrrp instance directly?
 		 * For this to be the case, the file was added directly on the vrrp instance,
 		 * and now we are adding it for a sync group. */
-		for (e = LIST_HEAD(tfl->file->tracking_vrrp); e; ELEMENT_NEXT(e)) {
-			etvp = ELEMENT_DATA(e);
+		LIST_FOREACH(tfl->file->tracking_vrrp, etvp, e) {
 			if (etvp->vrrp == vrrp) {
 				/* Update the weight appropriately. We will use the sync group's
 				 * weight unless the vrrp setting is unweighted. */
 				log_message(LOG_INFO, "(%s) track_file %s is configured on VRRP instance and sync group. Remove vrrp instance config",
 						vrrp->iname, tfl->file->fname);
 
-				if (etvp->weight)
+				if (etvp->weight) {
 					etvp->weight = tfl->weight;
+					etvp->weight_multiplier = tfl->weight_reverse ? -1 : 1;
+				}
 				return;
 			}
 		}
@@ -2500,6 +2501,7 @@ add_vrrp_to_track_file(vrrp_t *vrrp, tracked_file_t *tfl)
 	tvp = MALLOC(sizeof(tracking_vrrp_t));
 	tvp->vrrp = vrrp;
 	tvp->weight = tfl->weight;
+	tvp->weight_multiplier = tfl->weight_reverse ? -1 : 1;
 	list_add(tfl->file->tracking_vrrp, tvp);
 }
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2447,16 +2447,17 @@ add_vrrp_to_track_script(vrrp_t *vrrp, tracked_sc_t *sc)
 		/* Is this script already tracking the vrrp instance directly?
 		 * For this to be the case, the script was added directly on the vrrp instance,
 		 * and now we are adding it for a sync group. */
-		for (e = LIST_HEAD(sc->scr->tracking_vrrp); e; ELEMENT_NEXT(e)) {
-			etvp = ELEMENT_DATA(e);
+		LIST_FOREACH(sc->scr->tracking_vrrp, etvp, e) {
 			if (etvp->vrrp == vrrp) {
 				/* Update the weight appropriately. We will use the sync group's
 				 * weight unless the vrrp setting is unweighted. */
 				log_message(LOG_INFO, "(%s) track_script %s is configured on VRRP instance and sync group. Remove vrrp instance config",
 						vrrp->iname, sc->scr->sname);
 
-				if (etvp->weight)
+				if (etvp->weight) {
 					etvp->weight = sc->weight;
+					etvp->weight_multiplier = sc->weight_reverse ? -1 : 1;
+				}
 				return;
 			}
 		}

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -211,7 +211,7 @@ dump_vscript(FILE *fp, const void *data)
 	conf_write(fp, "   Command = %s", cmd_str(&vscript->script));
 	conf_write(fp, "   Interval = %lu sec", vscript->interval / TIMER_HZ);
 	conf_write(fp, "   Timeout = %lu sec", vscript->timeout / TIMER_HZ);
-	conf_write(fp, "   Weight = %d", vscript->weight);
+	conf_write(fp, "   Weight = %d%s", vscript->weight, vscript->weight_reverse ? " reverse" : "");
 	conf_write(fp, "   Rise = %d", vscript->rise);
 	conf_write(fp, "   Fall = %d", vscript->fall);
 	conf_write(fp, "   Insecure = %s", vscript->insecure ? "yes" : "no");

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -254,7 +254,7 @@ dump_vfile(FILE *fp, const void *data)
 	conf_write(fp, " VRRP Track file = %s", vfile->fname);
 	conf_write(fp, "   File = %s", vfile->file_path);
 	conf_write(fp, "   Status = %d", vfile->last_status);
-	conf_write(fp, "   Weight = %d", vfile->weight);
+	conf_write(fp, "   Weight = %d%s", vfile->weight, vfile->weight_reverse ? " reverse" : "");
 	conf_write(fp, "   Tracking VRRP instances = %u", vfile->tracking_vrrp ? LIST_SIZE(vfile->tracking_vrrp) : 0);
 	if (vfile->tracking_vrrp)
 		dump_list(fp, vfile->tracking_vrrp);

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -301,7 +301,7 @@ dump_vprocess(FILE *fp, const void *data)
 		conf_write(fp, "   Max processes = %u", vprocess->quorum_max);
 	conf_write(fp, "   Current processes = %u", vprocess->num_cur_proc);
 	conf_write(fp, "   Have quorum = %s", vprocess->have_quorum ? "true" : "false");
-	conf_write(fp, "   Weight = %d", vprocess->weight);
+	conf_write(fp, "   Weight = %d%s", vprocess->weight, vprocess->weight_reverse ? " reverse" : "");
 	conf_write(fp, "   Terminate delay = %fs", (double)vprocess->terminate_delay / TIMER_HZ);
 	conf_write(fp, "   Fork delay = %fs", (double)vprocess->fork_delay / TIMER_HZ);
 	if (fp) {

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -188,7 +188,7 @@ dump_tracking_vrrp(FILE *fp, const void *data)
 	const tracking_vrrp_t *tvp = (const tracking_vrrp_t *)data;
 	const vrrp_t *vrrp = tvp->vrrp;
 
-	conf_write(fp, "     %s, weight %d%s", vrrp->iname, tvp->weight, tvp->type == TRACK_VRRP_DYNAMIC ? " (dynamic)" : "");
+	conf_write(fp, "     %s, weight %d%s%s", vrrp->iname, tvp->weight, tvp->weight_multiplier == -1 ? " reverse" : "", tvp->type == TRACK_VRRP_DYNAMIC ? " (dynamic)" : "");
 }
 
 static void
@@ -323,7 +323,7 @@ dump_vrrp_bfd(FILE *fp, const void *track_data)
 	const vrrp_tracked_bfd_t *vbfd = track_data;
 
 	conf_write(fp, " VRRP Track BFD = %s", vbfd->bname);
-	conf_write(fp, "   Weight = %d", vbfd->weight);
+	conf_write(fp, "   Weight = %d%s", vbfd->weight, vbfd->weight_reverse ? " reverse" : "");
 	conf_write(fp, "   Tracking VRRP instances = %u", vbfd->tracking_vrrp ? LIST_SIZE(vbfd->tracking_vrrp) : 0);
 	if (vbfd->tracking_vrrp)
 		dump_list(fp, vbfd->tracking_vrrp);

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -1434,7 +1434,7 @@ update_added_interface(interface_t *ifp)
 
 		if (vrrp->vmac_flags) {
 			if (tvp->type & TRACK_VRRP) {
-				add_vrrp_to_interface(vrrp, ifp->base_ifp, tvp->weight, false, TRACK_VRRP_DYNAMIC);
+				add_vrrp_to_interface(vrrp, ifp->base_ifp, tvp->weight, tvp->weight_multiplier == -1, false, TRACK_VRRP_DYNAMIC);
 				if (!IF_ISUP(vrrp->configured_ifp->base_ifp) && !vrrp->dont_track_primary)
 					vrrp->num_script_if_fault++;
 			}

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -1493,6 +1493,7 @@ vrrp_tprocess_weight_handler(const vector_t *strvec)
 		report_config_error(CONFIG_GENERAL_ERROR, "No weight specified for track process %s - ignoring", tprocess->pname);
 		return;
 	}
+
 	if (tprocess->weight) {
 		report_config_error(CONFIG_GENERAL_ERROR, "Weight already set for track process %s - ignoring %s", tprocess->pname, strvec_slot(strvec, 1));
 		return;
@@ -1502,6 +1503,13 @@ vrrp_tprocess_weight_handler(const vector_t *strvec)
 		report_config_error(CONFIG_GENERAL_ERROR, "Weight (%s) for vrrp_track_process %s must be between "
 				 "[-254..254] inclusive. Ignoring...", strvec_slot(strvec, 1), tprocess->pname);
 		return;
+	}
+
+	if (vector_size(strvec) >= 3) {
+		if (!strcmp(strvec_slot(strvec, 2), "reverse"))
+			tprocess->weight_reverse = true;
+		else
+			report_config_error(CONFIG_GENERAL_ERROR, "vrrp_track_process %s unknown weight option %s", tprocess->pname, strvec_slot(strvec, 2));
 	}
 
 	tprocess->weight = weight;

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -1228,6 +1228,13 @@ vrrp_vscript_weight_handler(const vector_t *strvec)
 	if (!read_int_strvec(strvec, 1, &weight, -253, 253, true))
 		report_config_error(CONFIG_GENERAL_ERROR, "vrrp_script %s weight %s must be in [-253, 253]", vscript->sname, strvec_slot(strvec, 1));
 	vscript->weight = weight;
+
+	if (vector_size(strvec) >= 3) {
+		if (!strcmp(strvec_slot(strvec, 2), "reverse"))
+			vscript->weight_reverse = true;
+		else
+			report_config_error(CONFIG_GENERAL_ERROR, "vrrp_script %s unknown weight option %s", vscript->sname, strvec_slot(strvec, 2));
+	}
 }
 static void
 vrrp_vscript_rise_handler(const vector_t *strvec)

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -1340,6 +1340,7 @@ vrrp_tfile_weight_handler(const vector_t *strvec)
 		report_config_error(CONFIG_GENERAL_ERROR, "No weight specified for track file %s - ignoring", tfile->fname);
 		return;
 	}
+
 	if (tfile->weight != 1) {
 		report_config_error(CONFIG_GENERAL_ERROR, "Weight already set for track file %s - ignoring %s", tfile->fname, strvec_slot(strvec, 1));
 		return;
@@ -1350,8 +1351,14 @@ vrrp_tfile_weight_handler(const vector_t *strvec)
 				 "[-254..254] inclusive. Ignoring...", strvec_slot(strvec, 1), tfile->fname);
 		weight = 1;
 	}
-
 	tfile->weight = weight;
+
+	if (vector_size(strvec) >= 3) {
+		if (!strcmp(strvec_slot(strvec, 2), "reverse"))
+			tfile->weight_reverse = true;
+		else
+			report_config_error(CONFIG_GENERAL_ERROR, "track_file %s unknown weight option %s", tfile->fname, strvec_slot(strvec, 2));
+	}
 }
 static void
 vrrp_tfile_init_handler(const vector_t *strvec)

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -734,9 +734,9 @@ vrrp_handle_bfd_event(bfd_event_t * evt)
 
 			if (tbfd->weight) {
 				if (vbfd->bfd_up)
-					vrrp->total_priority += abs(tbfd->weight);
+					vrrp->total_priority += abs(tbfd->weight) * tbfd->weight_multiplier;
 				else
-					vrrp->total_priority -= abs(tbfd->weight);
+					vrrp->total_priority -= abs(tbfd->weight) * tbfd->weight_multiplier;
 				vrrp_set_effective_priority(vrrp);
 
 				continue;

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -742,7 +742,7 @@ vrrp_handle_bfd_event(bfd_event_t * evt)
 				continue;
 			}
 
-			if (vbfd->bfd_up)
+			if (!!vbfd->bfd_up == (tbfd->weight_multiplier == 1))
 				try_up_instance(vrrp, false);
 			else
 				down_instance(vrrp);

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -645,6 +645,7 @@ vrrp_snmp_file(struct variable *vp, oid *name, size_t *length,
 	return NULL;
 }
 
+#ifdef _WITH_BFD_
 static u_char*
 vrrp_snmp_bfd(struct variable *vp, oid *name, size_t *length,
 		 int exact, size_t *var_len, WriteMethod **write_method)
@@ -676,7 +677,9 @@ vrrp_snmp_bfd(struct variable *vp, oid *name, size_t *length,
 	}
 	return NULL;
 }
+#endif
 
+#ifdef _WITH_CN_PROC_
 static u_char*
 vrrp_snmp_process(struct variable *vp, oid *name, size_t *length,
 		 int exact, size_t *var_len, WriteMethod **write_method)
@@ -752,6 +755,7 @@ vrrp_snmp_process(struct variable *vp, oid *name, size_t *length,
 	}
 	return NULL;
 }
+#endif
 
 /* Header function using a FSM. `state' is the initial state, either
    HEADER_STATE_STATIC_ADDRESS, HEADER_STATE_STATIC_ROUTE or
@@ -2573,6 +2577,7 @@ vrrp_snmp_trackedfile(struct variable *vp, oid *name, size_t *length,
 	return NULL;
 }
 
+#ifdef _WITH_BFD_
 static u_char*
 vrrp_snmp_trackedbfd(struct variable *vp, oid *name, size_t *length,
 			int exact, size_t *var_len, WriteMethod **write_method)
@@ -2665,7 +2670,9 @@ vrrp_snmp_trackedbfd(struct variable *vp, oid *name, size_t *length,
 
 	return NULL;
 }
+#endif
 
+#ifdef _WITH_CN_PROC_
 static u_char*
 vrrp_snmp_trackedprocess(struct variable *vp, oid *name, size_t *length,
 			int exact, size_t *var_len, WriteMethod **write_method)
@@ -2758,6 +2765,7 @@ vrrp_snmp_trackedprocess(struct variable *vp, oid *name, size_t *length,
 
 	return NULL;
 }
+#endif
 
 static u_char*
 vrrp_snmp_group_trackedinterface(struct variable *vp, oid *name, size_t *length,
@@ -3037,6 +3045,7 @@ vrrp_snmp_group_trackedfile(struct variable *vp, oid *name, size_t *length,
 	return NULL;
 }
 
+#ifdef _WITH_BFD_
 static u_char*
 vrrp_snmp_group_trackedbfd(struct variable *vp, oid *name, size_t *length,
 			int exact, size_t *var_len, WriteMethod **write_method)
@@ -3129,7 +3138,9 @@ vrrp_snmp_group_trackedbfd(struct variable *vp, oid *name, size_t *length,
 
 	return NULL;
 }
+#endif
 
+#ifdef _WITH_CN_PROC_
 static u_char*
 vrrp_snmp_group_trackedprocess(struct variable *vp, oid *name, size_t *length,
 			int exact, size_t *var_len, WriteMethod **write_method)
@@ -3222,6 +3233,7 @@ vrrp_snmp_group_trackedprocess(struct variable *vp, oid *name, size_t *length,
 
 	return NULL;
 }
+#endif
 
 static oid vrrp_oid[] = {VRRP_OID};
 static struct variable8 vrrp_vars[] = {
@@ -3610,6 +3622,7 @@ static struct variable8 vrrp_vars[] = {
 	{VRRP_SNMP_FILE_WEIGHT, ASN_INTEGER, RONLY, vrrp_snmp_file, 3, {13, 1, 5}},
 	{VRRP_SNMP_FILE_WEIGHT_REVERSE, ASN_INTEGER, RONLY, vrrp_snmp_file, 3, {13, 1, 6}},
 
+#ifdef _WITH_BFD_
 	/* vrrpTrackedBfdTable */
 	{VRRP_SNMP_TRACKEDBFD_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_trackedbfd, 3, {17, 1, 2}},
@@ -3623,7 +3636,9 @@ static struct variable8 vrrp_vars[] = {
 	{VRRP_SNMP_BFD_RESULT, ASN_INTEGER, RONLY, vrrp_snmp_bfd, 3, {18, 1, 3}},
 	{VRRP_SNMP_BFD_WEIGHT, ASN_INTEGER, RONLY, vrrp_snmp_bfd, 3, {18, 1, 4}},
 	{VRRP_SNMP_BFD_WEIGHT_REVERSE, ASN_INTEGER, RONLY, vrrp_snmp_bfd, 3, {18, 1, 5}},
+#endif
 
+#ifdef _WITH_CN_PROC_
 	/* vrrpTrackedProcessTable */
 	{VRRP_SNMP_TRACKEDPROCESS_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_trackedprocess, 3, {20, 1, 2}},
@@ -3646,6 +3661,7 @@ static struct variable8 vrrp_vars[] = {
 	{VRRP_SNMP_PROCESS_FULLCOMMAND, ASN_INTEGER, RONLY, vrrp_snmp_process, 3, {21, 1, 12}},
 	{VRRP_SNMP_PROCESS_CURPROC, ASN_INTEGER, RONLY, vrrp_snmp_process, 3, {21, 1, 13}},
 	{VRRP_SNMP_PROCESS_RESULT, ASN_INTEGER, RONLY, vrrp_snmp_process, 3, {21, 1, 14}},
+#endif
 
 	/* syncGroupTrackedInterfaceTable */
 	{VRRP_SNMP_SGROUPTRACKEDINTERFACE_NAME, ASN_OCTET_STR, RONLY,
@@ -3671,6 +3687,7 @@ static struct variable8 vrrp_vars[] = {
 	{VRRP_SNMP_SGROUPTRACKEDFILE_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
 	 vrrp_snmp_group_trackedfile, 3, {16, 1, 4}},
 
+#ifdef _WITH_BFD_
 	/* syncGroupTrackedBfdTable */
 	{VRRP_SNMP_SGROUPTRACKEDBFD_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_group_trackedbfd, 3, {19, 1, 2}},
@@ -3678,7 +3695,9 @@ static struct variable8 vrrp_vars[] = {
 	 vrrp_snmp_group_trackedbfd, 3, {19, 1, 3}},
 	{VRRP_SNMP_SGROUPTRACKEDBFD_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
 	 vrrp_snmp_group_trackedbfd, 3, {19, 1, 4}},
+#endif
 
+#ifdef _WITH_CN_PROC_
 	/* syncGroupTrackedProcessTable */
 	{VRRP_SNMP_SGROUPTRACKEDPROCESS_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_group_trackedprocess, 3, {22, 1, 2}},
@@ -3686,6 +3705,7 @@ static struct variable8 vrrp_vars[] = {
 	 vrrp_snmp_group_trackedprocess, 3, {22, 1, 3}},
 	{VRRP_SNMP_SGROUPTRACKEDPROCESS_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
 	 vrrp_snmp_group_trackedprocess, 3, {22, 1, 4}},
+#endif
 
 };
 

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -144,6 +144,7 @@ enum snmp_vrrp_magic {
 	VRRP_SNMP_SCRIPT_COMMAND,
 	VRRP_SNMP_SCRIPT_INTERVAL,
 	VRRP_SNMP_SCRIPT_WEIGHT,
+	VRRP_SNMP_SCRIPT_WEIGHT_REVERSE,
 	VRRP_SNMP_SCRIPT_RESULT,
 	VRRP_SNMP_SCRIPT_RISE,
 	VRRP_SNMP_SCRIPT_FALL,
@@ -151,6 +152,7 @@ enum snmp_vrrp_magic {
 	VRRP_SNMP_FILE_PATH,
 	VRRP_SNMP_FILE_RESULT,
 	VRRP_SNMP_FILE_WEIGHT,
+	VRRP_SNMP_FILE_WEIGHT_REVERSE,
 	VRRP_SNMP_ADDRESS_ADDRESSTYPE,
 	VRRP_SNMP_ADDRESS_VALUE,
 	VRRP_SNMP_ADDRESS_BROADCAST,
@@ -206,16 +208,22 @@ enum snmp_vrrp_magic {
 	VRRP_SNMP_INSTANCE_SCRIPTMASTER_RX_LOWER_PRI,
 	VRRP_SNMP_TRACKEDINTERFACE_NAME,
 	VRRP_SNMP_TRACKEDINTERFACE_WEIGHT,
+	VRRP_SNMP_TRACKEDINTERFACE_WEIGHT_REVERSE,
 	VRRP_SNMP_TRACKEDSCRIPT_NAME,
 	VRRP_SNMP_TRACKEDSCRIPT_WEIGHT,
+	VRRP_SNMP_TRACKEDSCRIPT_WEIGHT_REVERSE,
 	VRRP_SNMP_TRACKEDFILE_NAME,
 	VRRP_SNMP_TRACKEDFILE_WEIGHT,
+	VRRP_SNMP_TRACKEDFILE_WEIGHT_REVERSE,
 	VRRP_SNMP_SGROUPTRACKEDINTERFACE_NAME,
 	VRRP_SNMP_SGROUPTRACKEDINTERFACE_WEIGHT,
+	VRRP_SNMP_SGROUPTRACKEDINTERFACE_WEIGHT_REVERSE,
 	VRRP_SNMP_SGROUPTRACKEDSCRIPT_NAME,
 	VRRP_SNMP_SGROUPTRACKEDSCRIPT_WEIGHT,
+	VRRP_SNMP_SGROUPTRACKEDSCRIPT_WEIGHT_REVERSE,
 	VRRP_SNMP_SGROUPTRACKEDFILE_NAME,
 	VRRP_SNMP_SGROUPTRACKEDFILE_WEIGHT,
+	VRRP_SNMP_SGROUPTRACKEDFILE_WEIGHT_REVERSE,
 };
 
 #ifdef _HAVE_FIB_ROUTING_
@@ -547,6 +555,9 @@ vrrp_snmp_script(struct variable *vp, oid *name, size_t *length,
 	case VRRP_SNMP_SCRIPT_WEIGHT:
 		long_ret.s = scr->weight;
 		return (u_char *)&long_ret;
+	case VRRP_SNMP_SCRIPT_WEIGHT_REVERSE:
+		long_ret.u = scr->weight_reverse ? 1 : 2;
+		return (u_char *)&long_ret;
 	case VRRP_SNMP_SCRIPT_RESULT:
 		switch (scr->init_state) {
 		case SCRIPT_INIT_STATE_INIT:
@@ -595,6 +606,9 @@ vrrp_snmp_file(struct variable *vp, oid *name, size_t *length,
 		return (u_char *)&long_ret;
 	case VRRP_SNMP_FILE_WEIGHT:
 		long_ret.s = file->weight;
+		return (u_char *)&long_ret;
+	case VRRP_SNMP_FILE_WEIGHT_REVERSE:
+		long_ret.u = file->weight_reverse ? 1 : 2;
 		return (u_char *)&long_ret;
 	default:
 		break;
@@ -2226,6 +2240,9 @@ vrrp_snmp_trackedinterface(struct variable *vp, oid *name, size_t *length,
 	case VRRP_SNMP_TRACKEDINTERFACE_WEIGHT:
 		long_ret.s = bifp->weight;
 		return (u_char *)&long_ret;
+	case VRRP_SNMP_TRACKEDINTERFACE_WEIGHT_REVERSE:
+		long_ret.s = bifp->weight_reverse ? 1 : 2;
+		return (u_char *)&long_ret;
 	}
 	return NULL;
 }
@@ -2316,6 +2333,9 @@ vrrp_snmp_trackedscript(struct variable *vp, oid *name, size_t *length,
 		return ret.p;
 	case VRRP_SNMP_TRACKEDSCRIPT_WEIGHT:
 		long_ret.s = bscr->weight;
+		return (u_char *)&long_ret;
+	case VRRP_SNMP_TRACKEDSCRIPT_WEIGHT_REVERSE:
+		long_ret.s = bscr->weight_reverse ? 1 : 2;
 		return (u_char *)&long_ret;
 	}
 	return NULL;
@@ -2408,6 +2428,9 @@ vrrp_snmp_trackedfile(struct variable *vp, oid *name, size_t *length,
 	case VRRP_SNMP_TRACKEDFILE_WEIGHT:
 		long_ret.s = bfile->file->weight;
 		return (u_char *)&long_ret;
+	case VRRP_SNMP_TRACKEDFILE_WEIGHT_REVERSE:
+		long_ret.s = bfile->file->weight_reverse ? 1 : 2;
+		return (u_char *)&long_ret;
 	}
 
 	return NULL;
@@ -2494,6 +2517,9 @@ vrrp_snmp_group_trackedinterface(struct variable *vp, oid *name, size_t *length,
 		return (u_char *)bifp->ifp->ifname;
 	case VRRP_SNMP_SGROUPTRACKEDINTERFACE_WEIGHT:
 		long_ret.s = bifp->weight;
+		return (u_char *)&long_ret;
+	case VRRP_SNMP_SGROUPTRACKEDINTERFACE_WEIGHT_REVERSE:
+		long_ret.s = bifp->weight_reverse ? 1 : 2;
 		return (u_char *)&long_ret;
 	}
 	return NULL;
@@ -2586,6 +2612,9 @@ vrrp_snmp_group_trackedscript(struct variable *vp, oid *name, size_t *length,
 	case VRRP_SNMP_SGROUPTRACKEDSCRIPT_WEIGHT:
 		long_ret.s = bscr->weight;
 		return (u_char *)&long_ret;
+	case VRRP_SNMP_SGROUPTRACKEDSCRIPT_WEIGHT_REVERSE:
+		long_ret.s = bscr->weight_reverse ? 1 : 2;
+		return (u_char *)&long_ret;
 	}
 	return NULL;
 }
@@ -2676,6 +2705,9 @@ vrrp_snmp_group_trackedfile(struct variable *vp, oid *name, size_t *length,
 		return ret.p;
 	case VRRP_SNMP_SGROUPTRACKEDFILE_WEIGHT:
 		long_ret.s = bfile->file->weight;
+		return (u_char *)&long_ret;
+	case VRRP_SNMP_SGROUPTRACKEDFILE_WEIGHT_REVERSE:
+		long_ret.s = bfile->file->weight_reverse ? 1 : 2;
 		return (u_char *)&long_ret;
 	}
 
@@ -2777,12 +2809,16 @@ static struct variable8 vrrp_vars[] = {
 	 vrrp_snmp_trackedinterface, 3, {4, 1, 1}},
 	{VRRP_SNMP_TRACKEDINTERFACE_WEIGHT, ASN_INTEGER, RONLY,
 	 vrrp_snmp_trackedinterface, 3, {4, 1, 2}},
+	{VRRP_SNMP_TRACKEDINTERFACE_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
+	 vrrp_snmp_trackedinterface, 3, {4, 1, 3}},
 
 	/* vrrpTrackedScriptTable */
 	{VRRP_SNMP_TRACKEDSCRIPT_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_trackedscript, 3, {5, 1, 2}},
 	{VRRP_SNMP_TRACKEDSCRIPT_WEIGHT, ASN_INTEGER, RONLY,
 	 vrrp_snmp_trackedscript, 3, {5, 1, 3}},
+	{VRRP_SNMP_TRACKEDSCRIPT_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
+	 vrrp_snmp_trackedscript, 3, {5, 1, 4}},
 
 	/* vrrpAddressTable */
 	{VRRP_SNMP_ADDRESS_ADDRESSTYPE, ASN_INTEGER, RONLY,
@@ -3004,6 +3040,7 @@ static struct variable8 vrrp_vars[] = {
 	{VRRP_SNMP_SCRIPT_RESULT, ASN_INTEGER, RONLY, vrrp_snmp_script, 3, {9, 1, 6}},
 	{VRRP_SNMP_SCRIPT_RISE, ASN_UNSIGNED, RONLY, vrrp_snmp_script, 3, {9, 1, 7}},
 	{VRRP_SNMP_SCRIPT_FALL, ASN_UNSIGNED, RONLY, vrrp_snmp_script, 3, {9, 1, 8}},
+	{VRRP_SNMP_SCRIPT_WEIGHT_REVERSE, ASN_INTEGER, RONLY, vrrp_snmp_script, 3, {9, 1, 9}},
 
 #ifdef _HAVE_FIB_ROUTING_
 	/* vrrpRouteNextHopTable */
@@ -3054,30 +3091,40 @@ static struct variable8 vrrp_vars[] = {
 	 vrrp_snmp_trackedfile, 3, {12, 1, 2}},
 	{VRRP_SNMP_TRACKEDFILE_WEIGHT, ASN_INTEGER, RONLY,
 	 vrrp_snmp_trackedfile, 3, {12, 1, 3}},
+	{VRRP_SNMP_TRACKEDFILE_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
+	 vrrp_snmp_trackedfile, 3, {12, 1, 4}},
 
 	/* vrrpFileTable */
 	{VRRP_SNMP_FILE_NAME, ASN_OCTET_STR, RONLY, vrrp_snmp_file, 3, {13, 1, 2}},
 	{VRRP_SNMP_FILE_PATH, ASN_OCTET_STR, RONLY, vrrp_snmp_file, 3, {13, 1, 3}},
 	{VRRP_SNMP_FILE_RESULT, ASN_INTEGER, RONLY, vrrp_snmp_file, 3, {13, 1, 4}},
 	{VRRP_SNMP_FILE_WEIGHT, ASN_INTEGER, RONLY, vrrp_snmp_file, 3, {13, 1, 5}},
+	{VRRP_SNMP_FILE_WEIGHT_REVERSE, ASN_INTEGER, RONLY, vrrp_snmp_file, 3, {13, 1, 6}},
 
 	/* syncGroupTrackedInterfaceTable */
 	{VRRP_SNMP_SGROUPTRACKEDINTERFACE_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_group_trackedinterface, 3, {14, 1, 1}},
 	{VRRP_SNMP_SGROUPTRACKEDINTERFACE_WEIGHT, ASN_INTEGER, RONLY,
 	 vrrp_snmp_group_trackedinterface, 3, {14, 1, 2}},
+	{VRRP_SNMP_SGROUPTRACKEDINTERFACE_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
+	 vrrp_snmp_group_trackedinterface, 3, {14, 1, 3}},
+
 
 	/* syncGroupTrackedScriptTable */
 	{VRRP_SNMP_SGROUPTRACKEDSCRIPT_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_group_trackedscript, 3, {15, 1, 2}},
 	{VRRP_SNMP_SGROUPTRACKEDSCRIPT_WEIGHT, ASN_INTEGER, RONLY,
 	 vrrp_snmp_group_trackedscript, 3, {15, 1, 3}},
+	{VRRP_SNMP_SGROUPTRACKEDSCRIPT_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
+	 vrrp_snmp_group_trackedscript, 3, {15, 1, 4}},
 
 	/* syncGroupTrackedFileTable */
 	{VRRP_SNMP_SGROUPTRACKEDFILE_NAME, ASN_OCTET_STR, RONLY,
 	 vrrp_snmp_group_trackedfile, 3, {16, 1, 2}},
 	{VRRP_SNMP_SGROUPTRACKEDFILE_WEIGHT, ASN_INTEGER, RONLY,
 	 vrrp_snmp_group_trackedfile, 3, {16, 1, 3}},
+	{VRRP_SNMP_SGROUPTRACKEDFILE_WEIGHT_REVERSE, ASN_INTEGER, RONLY,
+	 vrrp_snmp_group_trackedfile, 3, {16, 1, 4}},
 
 };
 

--- a/keepalived/vrrp/vrrp_static_track.c
+++ b/keepalived/vrrp/vrrp_static_track.c
@@ -143,7 +143,7 @@ static_track_group_init(void)
 		}
 
 		LIST_FOREACH(addr->track_group->vrrp_instances, vrrp, e1)
-			add_vrrp_to_interface(vrrp, addr->ifp, 0, false, TRACK_SADDR);
+			add_vrrp_to_interface(vrrp, addr->ifp, 0, false, false, TRACK_SADDR);
 	}
 
 #ifdef _HAVE_FIB_ROUTING_
@@ -158,7 +158,7 @@ static_track_group_init(void)
 
 		LIST_FOREACH(route->track_group->vrrp_instances, vrrp, e1) {
 			if (route->oif)
-				add_vrrp_to_interface(vrrp, route->oif, 0, false, TRACK_SROUTE);
+				add_vrrp_to_interface(vrrp, route->oif, 0, false, false, TRACK_SROUTE);
 		}
 	}
 
@@ -172,7 +172,7 @@ static_track_group_init(void)
 
 		LIST_FOREACH(rule->track_group->vrrp_instances, vrrp, e1) {
 			if (rule->iif)
-				add_vrrp_to_interface(vrrp, rule->iif, 0, false, TRACK_SRULE);
+				add_vrrp_to_interface(vrrp, rule->iif, 0, false, false, TRACK_SRULE);
 		}
 	}
 #endif

--- a/keepalived/vrrp/vrrp_track.c
+++ b/keepalived/vrrp/vrrp_track.c
@@ -431,8 +431,7 @@ alloc_track_file(vrrp_t *vrrp, const vector_t *strvec)
 
 	if (!LIST_ISEMPTY(vrrp->track_file)) {
 		/* Check this vrrp isn't already tracking the script */
-		for (e = LIST_HEAD(vrrp->track_file); e; ELEMENT_NEXT(e)) {
-			etfile = ELEMENT_DATA(e);
+		LIST_FOREACH(vrrp->track_file, etfile, e) {
 			if (etfile->file == vsf) {
 				report_config_error(CONFIG_GENERAL_ERROR, "(%s) duplicate track_file %s - ignoring", vrrp->iname, tracked);
 				return;
@@ -447,16 +446,17 @@ alloc_track_file(vrrp_t *vrrp, const vector_t *strvec)
 					 vrrp->iname, strvec_slot(strvec, 1));
 			return;
 		}
-		if (vector_size(strvec) >= 3) {
-			if (!read_int_strvec(strvec, 2, &weight, -254, 254, true)) {
-				report_config_error(CONFIG_GENERAL_ERROR, "(%s) weight for track file %s must be in "
-						 "[-254..254] inclusive. Ignoring...", vrrp->iname, tracked);
-				weight = vsf->weight;
-			}
-		} else {
+
+		if (vector_size(strvec) == 2) {
 			report_config_error(CONFIG_GENERAL_ERROR, "(%s) weight without value specified for track file %s - ignoring",
 					vrrp->iname, tracked);
 			return;
+		}
+
+		if (!read_int_strvec(strvec, 2, &weight, -254, 254, true)) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) weight for track file %s must be in "
+					 "[-254..254] inclusive. Ignoring...", vrrp->iname, tracked);
+			weight = vsf->weight;
 		}
 	}
 
@@ -486,8 +486,7 @@ alloc_group_track_file(vrrp_sgroup_t *sgroup, const vector_t *strvec)
 
 	if (!LIST_ISEMPTY(sgroup->track_file)) {
 		/* Check this vrrp isn't already tracking the script */
-		for (e = LIST_HEAD(sgroup->track_file); e; ELEMENT_NEXT(e)) {
-			etfile = ELEMENT_DATA(e);
+		LIST_FOREACH(sgroup->track_file, etfile, e) {
 			if (etfile->file == vsf) {
 				report_config_error(CONFIG_GENERAL_ERROR, "(%s) duplicate track_file %s - ignoring", sgroup->gname, tracked);
 				return;
@@ -502,16 +501,17 @@ alloc_group_track_file(vrrp_sgroup_t *sgroup, const vector_t *strvec)
 					 sgroup->gname, strvec_slot(strvec, 1));
 			return;
 		}
-		if (vector_size(strvec) >= 3) {
-			if (!read_int_strvec(strvec, 2, &weight, -254, 254, true)) {
-				report_config_error(CONFIG_GENERAL_ERROR, "(%s) weight for track file %s must be in "
-						 "[-254..254] inclusive. Ignoring...", sgroup->gname, tracked);
-				weight = vsf->weight;
-			}
-		} else {
+
+		if (vector_size(strvec) == 2) {
 			report_config_error(CONFIG_GENERAL_ERROR, "(%s) weight without value specified for track file %s - ignoring",
 					sgroup->gname, tracked);
 			return;
+		}
+
+		if (!read_int_strvec(strvec, 2, &weight, -254, 254, true)) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) weight for track file %s must be in "
+					 "[-254..254] inclusive. Ignoring...", sgroup->gname, tracked);
+			weight = vsf->weight;
 		}
 	}
 


### PR DESCRIPTION
If "reverse" is specified after "weight" for a vrrp tracker, the priority will be decreased when the tracker is up, and increased when the tracker is down (i.e. in the opposite direction from normal.