### PR TITLE
Fix potential overflow in read_timer()

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -2021,7 +2021,7 @@ read_timer(const vector_t *strvec, size_t index, unsigned long *res, unsigned lo
 	fmax_time = (double)((max_time) ? max_time : TIMER_MAXIMUM) / TIMER_HZ;
 
 	ret = read_double_strvec(strvec, index, &timer, fmin_time, fmax_time, ignore_error);
-	*res = timer * TIMER_HZ > TIMER_MAXIMUM ? TIMER_MAXIMUM : (unsigned long)(timer * TIMER_HZ);
+	*res = timer > TIMER_MAXIMUM / TIMER_HZ ? TIMER_MAXIMUM : (unsigned long)(timer * TIMER_HZ);
 
 	return ret;
 }


### PR DESCRIPTION
As the reply
https://github.com/acassen/keepalived/pull/1346#issuecomment-507678358
says:
read_double_func() does not necessarily set a value,
so read_timer() has the risk of overflow.

Signed-off-by: Jie Liu <liujie165@huawei.com>