### PR TITLE
sll_protocol should be set to  0x806

### DIFF
--- a/keepalived/vrrp/vrrp_arp.c
+++ b/keepalived/vrrp/vrrp_arp.c
@@ -80,6 +80,7 @@ static ssize_t send_arp(ip_address_t *ipaddress, ssize_t pack_len)
 	memset(&sll, 0, sizeof(sll));
 	((struct sockaddr_large_ll *)&sll)->sll_family = AF_PACKET;
 	((struct sockaddr_large_ll *)&sll)->sll_hatype = ifp->hw_type;
+	((struct sockaddr_large_ll *)&sll)->sll_protocol = htons(ETHERTYPE_ARP);
 	((struct sockaddr_large_ll *)&sll)->sll_ifindex = (int) ifp->ifindex;
 
 	/* The values in sll_addr and sll_halen appear to be ignored */

--- a/keepalived/vrrp/vrrp_ndisc.c
+++ b/keepalived/vrrp/vrrp_ndisc.c
@@ -65,6 +65,7 @@ ndisc_send_na(ip_address_t *ipaddress)
 	/* The values in sll_ha_type, sll_addr and sll_halen appear to be ignored */
 	sll.sll_hatype = ifp->hw_type;
 	sll.sll_halen = ifp->hw_addr_len;
+	sll.sll_protocol = htons(ETH_P_IPV6);
 	memcpy(sll.sll_addr, IF_HWADDR(ifp), ifp->hw_addr_len);
 
 	if (__test_bit(LOG_DETAIL_BIT, &debug)) {


### PR DESCRIPTION
Some times , send the gratuitous ARP message should set sll_protocol , let some drivers can evaluate which protocol we use