### PR TITLE
Draft: Add logging for reasons why interfaces are going into fault state.

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1740,7 +1740,7 @@ vrrp_state_leave_master(vrrp_t * vrrp, bool advF)
 		vrrp->master_adver_int = vrrp->adver_int;
 	}
 	else if (vrrp->wantstate == VRRP_STATE_FAULT) {
-		log_message(LOG_INFO, "(%s) Entering FAULT STATE", vrrp->iname);
+		log_message(LOG_INFO, "(%s) Entering FAULT STATE (wanted)", vrrp->iname);
 		vrrp_send_adv(vrrp, VRRP_PRIO_STOP);
 	}
 	else {

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -481,7 +481,7 @@ dump_if(FILE *fp, const void *data)
 	if (IS_VLAN(ifp)) {
 		const char *if_type =
 #ifdef _HAVE_VRRP_IPVLAN
-				      ifp->if_type == IF_TYPE_IPVLAN ? "IPVLAN" : 
+				      ifp->if_type == IF_TYPE_IPVLAN ? "IPVLAN" :
 #endif
 										  "VMAC";
 		const char *vlan_type =
@@ -1436,6 +1436,8 @@ update_added_interface(interface_t *ifp)
 			if (tvp->type & TRACK_VRRP) {
 				add_vrrp_to_interface(vrrp, ifp->base_ifp, tvp->weight, tvp->weight_multiplier == -1, false, TRACK_VRRP_DYNAMIC);
 				if (!IF_ISUP(vrrp->configured_ifp->base_ifp) && !vrrp->dont_track_primary)
+					log_message(LOG_INFO, "(%s) interface %s is down",
+							vrrp->iname, vrrp->configured_ifp->base_ifp->ifname);
 					vrrp->num_script_if_fault++;
 			}
 

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -481,7 +481,7 @@ dump_if(FILE *fp, const void *data)
 	if (IS_VLAN(ifp)) {
 		const char *if_type =
 #ifdef _HAVE_VRRP_IPVLAN
-				      ifp->if_type == IF_TYPE_IPVLAN ? "IPVLAN" :
+				      ifp->if_type == IF_TYPE_IPVLAN ? "IPVLAN" : 
 #endif
 										  "VMAC";
 		const char *vlan_type =

--- a/keepalived/vrrp/vrrp_track.c
+++ b/keepalived/vrrp/vrrp_track.c
@@ -658,6 +658,7 @@ initialise_track_script_state(tracked_sc_t *tsc, vrrp_t *vrrp)
 			 (tsc->scr->result >= 0 && tsc->scr->result < tsc->scr->rise)) {
 			/* The script is in fault state */
 			vrrp->num_script_if_fault++;
+			log_message(LOG_INFO, "(%s): entering FAULT state (script %s has %i faults)", vrrp->iname, tsc->scr->sname, vrrp->num_script_if_fault);
 			vrrp->state = VRRP_STATE_FAULT;
 		}
 		return;
@@ -750,7 +751,7 @@ initialise_file_tracking_priorities(void)
 			if (status <= -254) {
 				/* The instance is down */
 				/* XXX which file? */
-				log_message(LOG_INFO, "(%s): entering FAULT state (tracked file status %i)", vrrp->iname, status);
+				log_message(LOG_INFO, "(%s): entering FAULT state (tracked file status %i)", tvp->vrrp->iname, status);
 				tvp->vrrp->state = VRRP_STATE_FAULT;
 				tvp->vrrp->num_script_if_fault++;
 			}

--- a/keepalived/vrrp/vrrp_track.c
+++ b/keepalived/vrrp/vrrp_track.c
@@ -719,6 +719,8 @@ initialise_interface_tracking_priorities(void)
 			if (!tvp->weight) {
 				if (IF_FLAGS_UP(ifp) != (tvp->weight_multiplier == 1)) {
 					/* The instance is down */
+					/* XXX note which interface is affected */
+					log_message(LOG_INFO, "(%s): entering FAULT state (interface is down)", tvp->vrrp->iname);
 					tvp->vrrp->state = VRRP_STATE_FAULT;
 					tvp->vrrp->num_script_if_fault++;
 				}
@@ -747,6 +749,8 @@ initialise_file_tracking_priorities(void)
 
 			if (status <= -254) {
 				/* The instance is down */
+				/* XXX which file? */
+				log_message(LOG_INFO, "(%s): entering FAULT state (tracked file status %i)", vrrp->iname, status);
 				tvp->vrrp->state = VRRP_STATE_FAULT;
 				tvp->vrrp->num_script_if_fault++;
 			}
@@ -773,6 +777,8 @@ initialise_process_tracking_priorities(void)
 			if (!tvp->weight) {
 				if (tprocess->have_quorum != (tvp->weight_multiplier == 1)) {
 					/* The instance is down */
+					/* XXX which process */
+					log_message(LOG_INFO, "(%s) entering FAULT state (tracked process has no qorum)", tvp->vrrp->iname);
 					tvp->vrrp->state = VRRP_STATE_FAULT;
 					tvp->vrrp->num_script_if_fault++;
 				}
@@ -802,8 +808,10 @@ initialise_vrrp_tracking_priorities(vrrp_t *vrrp)
 	/* If no src address has been specified, and the interface doesn't have
 	 * an appropriate address, put the interface into fault state */
 	if (vrrp->saddr.ss_family == AF_UNSPEC) {
-		vrrp->num_script_if_fault++;
+		/* The instance is down */
+		log_message(LOG_INFO, "(%s) entering FAULT state (no source address specified, no appropriate address found)", vrrp->iname);
 		vrrp->state = VRRP_STATE_FAULT;
+		vrrp->num_script_if_fault++;
 	}
 
 	/* Initialise the vrrp instance's tracked scripts */
@@ -849,7 +857,7 @@ initialise_tracking_priorities(void)
 			if (vrrp->state == VRRP_STATE_FAULT) {
 				if (vrrp->sync->state != VRRP_STATE_FAULT) {
 					vrrp->sync->state = VRRP_STATE_FAULT;
-					log_message(LOG_INFO, "VRRP_Group(%s): Syncing instances to FAULT state", vrrp->sync->gname);
+					log_message(LOG_INFO, "VRRP_Group(%s): Syncing instances to FAULT state due to (%s) being in FAULT state", vrrp->sync->gname, vrrp->iname);
 				}
 
 				vrrp->sync->num_member_fault++;


### PR DESCRIPTION
I had to hunt down a very surprising problem where an instance would go into fault state without telling me why.

Turns out having a v4 virtual ip (with v6 virtual excluded ips) will assign a link-local address for v6 but if the interface doesn't have a local v4 address then the instance will be down because it won't use the v6 address.

I have added a bunch of hopefully helpful logging statements that will now tell which interface caused a group to go into sync (otherwise you just see the group going to FAULT and _then_ the interfaces switching to FAULT) and why each interface went to FAULT state. I may have missed some code paths and I guess this could become a function and I'd also like to add more information (marked with XXX) with some log entries.

Right now I'd appreciate if you could let me know whether this has a chance of being merged ... 

