### PR TITLE
Add gue tunnel options for LVS

### DIFF
--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -3488,7 +3488,10 @@ RealServerEntry ::= SEQUENCE {
     realServerDelayBeforeRetryUsec Unsigned32,
     realServerWarmupUsec Unsigned32,
     realServerDelayLoopUsec Unsigned32,
-    realServerConnTimeoutUsec Unsigned32
+    realServerConnTimeoutUsec Unsigned32,
+    realServerTunnelType INTEGER,
+    realServerTunnelPort InetPortNumber,
+    realServerTunnelFlags INTEGER
 }
 
 realServerIndex OBJECT-TYPE
@@ -3944,6 +3947,30 @@ realServerConnTimeoutUsec OBJECT-TYPE
     DESCRIPTION
         "Maximum number of micro-seconds for checker to establish connection."
     ::= { realServerEntry 51 }
+
+realServerTunnelType OBJECT-TYPE
+    SYNTAX INTEGER { ipip(0), gue(1) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Default tunneling method to use for this real server."
+    ::= { realServerEntry 52 }
+
+realServerTunnelPort OBJECT-TYPE
+    SYNTAX InetPortNumber
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Destination port of the tunnel."
+    ::= { realServerEntry 53 }
+
+realServerTunnelFlags OBJECT-TYPE
+    SYNTAX INTEGER { nocsum(0), csum(1), remcsum(2) }
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Default tunneling flags to use for this real server."
+    ::= { realServerEntry 54 }
 
 lvsSyncDaemon    OBJECT IDENTIFIER ::= { check 6 }
 
@@ -4567,7 +4594,10 @@ realServerGroup OBJECT-GROUP
     realServerDelayBeforeRetryUsec,
     realServerWarmupUsec,
     realServerDelayLoopUsec,
-    realServerConnTimeoutUsec
+    realServerConnTimeoutUsec,
+    realServerTunnelType,
+    realServerTunnelPort,
+    realServerTunnelFlags
     }
     STATUS current
     DESCRIPTION

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1702,6 +1702,13 @@ The syntax for virtual_server is :
         # LVS forwarding method
         \fBlvs_method \fRNAT|DR|TUN
 
+        # Set tunnel type for TUN forwarding method (--tun-type in ipvsadm)
+        \fBtun_type \fRipip|gue
+        # Set tunnel port for TUN forwarding method (--tun-port in ipvsadm)
+        \fBtun_port \fR<PORT>
+        # Set tunnel flags for TUN forwarding method (--tun-flags in ipvsadm)
+        \fBtun_flags \fRnocsum|csum|remcsum
+
         # Script to execute when healthchecker
         # considers service as up.
         \fBnotify_up \fR<STRING>|<QUOTED-STRING> [username [groupname]]

--- a/keepalived/check/check_data.c
+++ b/keepalived/check/check_data.c
@@ -503,6 +503,26 @@ dump_rs(FILE *fp, const void *data)
 		break;
 	case IP_VS_CONN_F_TUNNEL:
 		conf_write(fp, "   Forwarding method = TUN");
+		switch (rs->tun_type) {
+		case IP_VS_CONN_F_TUNNEL_TYPE_IPIP:
+			conf_write(fp, "   Tunnel type = ipip");
+			break;
+		case IP_VS_CONN_F_TUNNEL_TYPE_GUE:
+			conf_write(fp, "   Tunnel type = gue");
+			conf_write(fp, "   Tunnel port = %d", ntohs(rs->tun_port));
+			switch (rs->tun_flags) {
+			case IP_VS_TUNNEL_ENCAP_FLAG_NOCSUM:
+				conf_write(fp, "   Tunnel flags = nocsum");
+				break;
+			case IP_VS_TUNNEL_ENCAP_FLAG_CSUM:
+				conf_write(fp, "   Tunnel flags = csum");
+				break;
+			case IP_VS_TUNNEL_ENCAP_FLAG_REMCSUM:
+				conf_write(fp, "   Tunnel flags = remcsum");
+				break;
+			}
+			break;
+		}
 		break;
 	}
 
@@ -591,6 +611,12 @@ alloc_rs(const char *ip, const char *port)
 	new->delay_before_retry = ULONG_MAX;
 	new->virtualhost = NULL;
 	new->smtp_alert = -1;
+
+	if (new->forwarding_method == IP_VS_CONN_F_TUNNEL) {
+		new->tun_type = IP_VS_CONN_F_TUNNEL_TYPE_IPIP;
+		new->tun_port = 0;
+		new->tun_flags = IP_VS_TUNNEL_ENCAP_FLAG_NOCSUM;
+	}
 
 // ??? alloc list in alloc_vs
 	if (!LIST_EXISTS(vs->rs))

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -542,6 +542,9 @@ ipvs_set_drule(int cmd, ipvs_dest_t *drule, real_server_t * rs)
 	drule->user.port = inet_sockaddrport(&rs->addr);
 	drule->user.conn_flags = rs->forwarding_method;
 	drule->user.weight = rs->weight;
+	drule->user.tun_type = rs->tun_type;
+	drule->user.tun_port = rs->tun_port;
+	drule->user.tun_flags = rs->tun_flags;
 	drule->user.u_threshold = rs->u_threshold;
 	drule->user.l_threshold = rs->l_threshold;
 }

--- a/keepalived/check/libipvs.c
+++ b/keepalived/check/libipvs.c
@@ -121,6 +121,9 @@ static struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] = {
 #ifdef _WITH_LVS_64BIT_STATS_
 	[IPVS_DEST_ATTR_STATS64]	= {.type = NLA_NESTED },
 #endif
+	[IPVS_DEST_ATTR_TUN_TYPE]	= { .type = NLA_U8 },
+	[IPVS_DEST_ATTR_TUN_PORT]	= { .type = NLA_U16 },
+	[IPVS_DEST_ATTR_TUN_FLAGS]	= { .type = NLA_U16 },
 };
 
 #ifdef _WITH_LVS_64BIT_STATS_
@@ -528,6 +531,9 @@ static int ipvs_nl_fill_dest_attr(struct nl_msg *msg, ipvs_dest_t *dst)
 	NLA_PUT_U32(msg, IPVS_DEST_ATTR_WEIGHT, (uint32_t)dst->user.weight);
 	NLA_PUT_U32(msg, IPVS_DEST_ATTR_U_THRESH, dst->user.u_threshold);
 	NLA_PUT_U32(msg, IPVS_DEST_ATTR_L_THRESH, dst->user.l_threshold);
+	NLA_PUT_U8(msg, IPVS_DEST_ATTR_TUN_TYPE, dst->user.tun_type);
+	NLA_PUT_U16(msg, IPVS_DEST_ATTR_TUN_PORT, dst->user.tun_port);
+	NLA_PUT_U16(msg, IPVS_DEST_ATTR_TUN_FLAGS, dst->user.tun_flags);
 
 	nla_nest_end(msg, nl_dest);
 	return 0;
@@ -940,6 +946,15 @@ static int ipvs_dests_parse_cb(struct nl_msg *msg, void *arg)
 	d->user.entrytable[i].user.activeconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_ACTIVE_CONNS]);
 	d->user.entrytable[i].user.inactconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_INACT_CONNS]);
 	d->user.entrytable[i].user.persistconns = nla_get_u32(dest_attrs[IPVS_DEST_ATTR_PERSIST_CONNS]);
+	attr_tun_type = dest_attrs[IPVS_DEST_ATTR_TUN_TYPE];
+	if (attr_tun_type)
+		d->user.entrytable[i].user.tun_type = nla_get_u8(attr_tun_type);
+	attr_tun_port = dest_attrs[IPVS_DEST_ATTR_TUN_PORT];
+	if (attr_tun_port)
+		d->user.entrytable[i].user.tun_port = nla_get_u16(attr_tun_port);
+	attr_tun_flags = dest_attrs[IPVS_DEST_ATTR_TUN_FLAGS];
+	if (attr_tun_flags)
+		d->user.entrytable[i].user.tun_flags = nla_get_u16(attr_tun_flags);
 #if HAVE_DECL_IPVS_DEST_ATTR_ADDR_FAMILY
 	attr_addr_family = dest_attrs[IPVS_DEST_ATTR_ADDR_FAMILY];
 	if (attr_addr_family)

--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -66,6 +66,9 @@ typedef struct _real_server {
 	int				pweight;	/* previous weight
 							 * used for reloading */
 	unsigned			forwarding_method; /* NAT/TUN/DR */
+	uint16_t			tun_type;	/* tunnel type */
+	__be16				tun_port;	/* tunnel port */
+	uint16_t			tun_flags;	/* tunnel flags */
 	uint32_t			u_threshold;   /* Upper connection limit. */
 	uint32_t			l_threshold;   /* Lower connection limit. */
 	int				inhibit;	/* Set weight to 0 instead of removing


### PR DESCRIPTION
According to:
http://archive.linuxvirtualserver.org/html/lvs-devel/2019-03/msg00013.html

```
The struct ip_vs_dest_user can not be changed anymore, it is
for the old setsockopt interface, for the new netlink interface we
extend only struct ip_vs_dest_user_kern which is not visible to
user space.
```

This requires a patched version of ip_vs.h

https://gist.github.com/hudayou/455b9564f396b1aec10a33cd0fa135d1

The related ipvsadm change is here:
https://git.kernel.org/pub/scm/utils/kernel/ipvsadm/ipvsadm.git/commit/?id=c3c2c3c6ae12e316218493e0174ae8c8cf597faa


