### PR TITLE
Do not use VS persistence and scheduler type or RS forwarding when comparing at reload

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1662,7 +1662,7 @@ The syntax for virtual_server is :
     \fBlvs_method \fRNAT|DR
     or
     \fBlvs_method \fRTUN [type {ipip|gue port NUM|gre} [nocsum|csum|remcsum]]
-    # LVS persistence engine name
+    # LVS persistence engine name (currently only sip supported)
     \fBpersistence_engine \fR<STRING>
     # LVS persistence timeout in seconds, default 6 minutes
     \fBpersistence_timeout \fR[<INTEGER>]

--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -38,23 +38,6 @@
 #include "check_daemon.h"
 
 static bool __attribute((pure))
-vs_script_iseq(const notify_script_t *sa, const notify_script_t *sb)
-{
-	if (!sa != !sb)
-		return false;
-
-	if (!sa)
-		return true;
-
-	if (!notify_script_compare(sa, sb) ||
-	    sa->uid != sb->uid ||
-	    sa->gid != sb->gid)
-		return false;
-
-	return true;
-}
-
-static bool __attribute((pure))
 vs_iseq(const virtual_server_t *vs_a, const virtual_server_t *vs_b)
 {
 	if (!vs_a->vsgname != !vs_b->vsgname)
@@ -71,24 +54,10 @@ vs_iseq(const virtual_server_t *vs_a, const virtual_server_t *vs_b)
 			return false;
 	} else {
 		if (vs_a->af != vs_b->af ||
+		    vs_a->service_type != vs_b->service_type ||
 		    !sockstorage_equal(&vs_a->addr, &vs_b->addr))
 			return false;
 	}
-
-	if (vs_a->service_type != vs_b->service_type ||
-	    vs_a->forwarding_method != vs_b->forwarding_method ||
-#ifdef _HAVE_IPVS_TUN_TYPE_
-	    vs_a->tun_type != vs_b->tun_type ||
-	    vs_a->tun_port != vs_b->tun_port ||
-#ifdef _HAVE_IPVS_TUN_CSUM_
-	    vs_a->tun_flags != vs_b->tun_flags ||
-#endif
-#endif
-	    !vs_script_iseq(vs_a->notify_quorum_up, vs_b->notify_quorum_up) ||
-	    !vs_script_iseq(vs_a->notify_quorum_down, vs_b->notify_quorum_down) ||
-	    !vs_a->virtualhost != !vs_b->virtualhost ||
-	    (vs_a->virtualhost && strcmp(vs_a->virtualhost, vs_b->virtualhost)))
-		return false;
 
 	return true;
 }


### PR DESCRIPTION
Virtual server persistence and scheduler configuration, and real server forwarding methods can be updated without removing and recreating the virtual or real server, so don't use them when comparing old and new virtual/real servers, and update the relevant parameters if they are changed on reload.