### PR TITLE
Allow new virtual routes to use new VIPs on reload

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -4024,15 +4024,15 @@ clear_diff_vrrp(void)
 			 * If this vrrp instance exist in new
 			 * data, then perform a VIP|EVIP diff.
 			 */
-			clear_diff_vrrp_vip(vrrp, new_vrrp);
-
 #ifdef _HAVE_FIB_ROUTING_
-			/* virtual routes diff */
-			clear_diff_vrrp_vroutes(vrrp, new_vrrp);
-
 			/* virtual rules diff */
 			clear_diff_vrrp_vrules(vrrp, new_vrrp);
+
+			/* virtual routes diff */
+			clear_diff_vrrp_vroutes(vrrp, new_vrrp);
 #endif
+
+			clear_diff_vrrp_vip(vrrp, new_vrrp);
 
 #ifdef _HAVE_VRRP_VMAC_
 			/*

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -529,11 +529,11 @@ start_vrrp(data_t *prev_global_data)
 		if (reload) {
 			kernel_netlink_set_recv_bufs();
 
-			clear_diff_saddresses();
 #ifdef _HAVE_FIB_ROUTING_
 			clear_diff_srules();
 			clear_diff_sroutes();
 #endif
+			clear_diff_saddresses();
 			clear_diff_script();
 #ifdef _WITH_BFD_
 			clear_diff_bfd();

--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -295,10 +295,9 @@ add_nexthops(ip_route_t *route, struct nlmsghdr *nlh, struct rtmsg *rtm)
 }
 
 /* Add/Delete IP route to/from a specific interface */
-static int
+static bool
 netlink_route(ip_route_t *iproute, int cmd)
 {
-	int status = 1;
 	struct {
 		struct nlmsghdr n;
 		struct rtmsg r;
@@ -512,10 +511,10 @@ netlink_route(ip_route_t *iproute, int cmd)
 		/* If an expiry was set on the route, it may have disappeared already */
 		if (cmd != IPROUTE_DEL || !(iproute->mask & IPROUTE_BIT_EXPIRES))
 #endif
-			status = -1;
+			return true;
 	}
 
-	return status;
+	return false;
 }
 
 /* Add/Delete a list of IP routes */
@@ -529,10 +528,9 @@ netlink_rtlist(list rt_list, int cmd)
 	if (LIST_ISEMPTY(rt_list))
 		return;
 
-	for (e = LIST_HEAD(rt_list); e; ELEMENT_NEXT(e)) {
-		iproute = ELEMENT_DATA(e);
+	LIST_FOREACH(rt_list, iproute, e) {
 		if ((cmd == IPROUTE_DEL) == iproute->set) {
-			if (netlink_route(iproute, cmd) > 0)
+			if (!netlink_route(iproute, cmd))
 				iproute->set = (cmd == IPROUTE_ADD);
 			else
 				iproute->set = false;
@@ -1836,8 +1834,7 @@ clear_diff_routes(list l, list n)
 		return;
 	}
 
-	for (e = LIST_HEAD(l); e; ELEMENT_NEXT(e)) {
-		iproute = ELEMENT_DATA(e);
+	LIST_FOREACH(l, iproute, e) {
 		if (iproute->set) {
 			if (!(new_iproute = route_exist(n, iproute))) {
 				log_message(LOG_INFO, "ip route %s/%d ... , no longer exist"
@@ -1866,7 +1863,7 @@ reinstate_static_route(ip_route_t *route)
 {
 	char buf[256];
 
-	route->set = (netlink_route(route, IPROUTE_ADD) > 0);
+	route->set = !netlink_route(route, IPROUTE_ADD);
 
 	format_iproute(route, buf, sizeof(buf));
 	log_message(LOG_INFO, "Restoring deleted static route %s", buf);

--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -510,7 +510,7 @@ netlink_route(ip_route_t *iproute, int cmd)
 	if (netlink_talk(&nl_cmd, &req.n) < 0) {
 #if HAVE_DECL_RTA_EXPIRES
 		/* If an expiry was set on the route, it may have disappeared already */
-		if (cmd != IPADDRESS_DEL || !(iproute->mask & IPROUTE_BIT_EXPIRES))
+		if (cmd != IPROUTE_DEL || !(iproute->mask & IPROUTE_BIT_EXPIRES))
 #endif
 			status = -1;
 	}


### PR DESCRIPTION
Issue #1390, after the original issue identified was resolved, added an additional issue relating to virtual routes not being added if they were configured using a new VIP. Although changing VIPs in a vrrp_instance on a reload seems dubious (backup instances will reject the adverts since the advertised addresses don't match), it has been possible to change the code to handle the issue.