### PR TITLE
Fix building with --enable-debug option, but add deliberate error

### DIFF
--- a/genhash/ssl.c
+++ b/genhash/ssl.c
@@ -141,7 +141,7 @@ ssl_connect_complete_thread(thread_ref_t thread)
 		thread_add_write(thread->master, ssl_connect_complete_thread, sock_obj,
 				sock_obj->fd, req->timeout, true);
 	} else {
-		DBG("  SSL_connect return code = %d on fd:%d\n", ret, thread->u.fd);
+		DBG("  SSL_connect return code = %d on fd:%d\n", ret, thread->u.f.fd);
 		ssl_printerr(error);
 		sock_obj->status = connect_error;
 		thread_add_terminate_event(thread->master);
@@ -201,7 +201,7 @@ ssl_connect(thread_ref_t thread)
 		return 1;
 	}
 
-	DBG("  SSL_connect return code = %d on fd:%d\n", ret, thread->u.fd);
+	DBG("  SSL_connect return code = %d on fd:%d\n", ret, thread->u.f.fd);
 	ssl_printerr(error);
 
 	return (ret > 0);

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -199,6 +199,7 @@ bfd_validate_config(void)
 	start_bfd(NULL);
 }
 
+#ifndef _DEBUG_
 static int
 print_bfd_thread(__attribute__((unused)) thread_ref_t thread)
 {
@@ -206,7 +207,6 @@ print_bfd_thread(__attribute__((unused)) thread_ref_t thread)
         return 0;
 }
 
-#ifndef _DEBUG_
 /* Reload handler */
 static void
 sigreload_bfd(__attribute__ ((unused)) void *v,

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -117,7 +117,7 @@ dns_final(thread_ref_t thread, int error, const char *fmt, ...)
 
 	checker_t *checker = THREAD_ARG(thread);
 
-	DNS_DBG("final error=%d attempts=%d retry=%d", error,
+	DNS_DBG("final error=%d attempts=%u retry=%u", error,
 		checker->retry_it, checker->retry);
 
 	if (thread->type != THREAD_TIMER)
@@ -202,7 +202,7 @@ dns_recv_thread(thread_ref_t thread)
 	}
 
 	if (ret < (ssize_t) sizeof (r_header)) {
-		DNS_DBG("too small message. (%d bytes)", ret);
+		DNS_DBG("too small message. (%ld bytes)", ret);
 		thread_add_read(thread->master, dns_recv_thread, checker,
 				thread->u.f.fd, timeout, true);
 		return 0;

--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -1521,7 +1521,7 @@ http_request_thread(thread_ref_t thread)
 			http_get_check->http_protocol == HTTP_PROTOCOL_1_0C || http_get_check->http_protocol == HTTP_PROTOCOL_1_1 ? "Connection: close\r\n" : "",
 			request_host, request_host_port);
 
-	DBG("Processing url(%s) of %s.", url->path, FMT_CHK(checker));
+	DBG("Processing url(%s) of %s.", fetched_url->path, FMT_CHK(checker));
 
 	/* Send the GET request to remote Web server */
 	if (http_get_check->proto == PROTO_SSL)

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -220,6 +220,11 @@ static char parser_debug;
 static char dump_keywords;
 #endif
 
+#ifdef _DEBUG_
+/* Ensure that the --enable-debug option is really wanted, and that the user is prepared to edit the source code */
+#error "configure option --enable-debug is not expected to work properly and is only for debugging purposes. If you really want to use it comment out this #error statement"
+#endif
+
 void
 free_parent_mallocs_startup(bool am_child)
 {


### PR DESCRIPTION
Issue #1444 identified that keepalived would not build with the
--enable-debug option. This commits resolves the compilation errors
but also adds a #error statement if --enable-debug is selected, so
that the source code has to be editted to be able to build with the
option.

Since --enable-debug is not expected to work properly and is only
for debugging purposes, the #error statement will stop it being used
accidentally or being enabled in a distro's build of keepalived, for
example as Gentoo had done. Only developers/maintainers who are
prepared to edit the source code will be able to use --enable-debug.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>