### PR TITLE
fix: unknown keyword 'mh-fallback' and 'mh-port'

### DIFF
--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -964,6 +964,8 @@ init_check_keywords(bool active)
 	install_keyword("flag-3", &lbflags_handler);
 	install_keyword("sh-port", &lbflags_handler);
 	install_keyword("sh-fallback", &lbflags_handler);
+	install_keyword("mh-port", &lbflags_handler);
+	install_keyword("mh-fallback", &lbflags_handler);
 #endif
 	install_keyword("lb_kind", &forwarding_handler);
 	install_keyword("lvs_method", &forwarding_handler);


### PR DESCRIPTION
'mh-fallback' and 'mh-port' cannot be used in the configuration file