### PR TITLE
Fix detecting of kill failure for MISC_CHECK scripts

### DIFF
--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -337,7 +337,7 @@ misc_check_child_thread(thread_ref_t thread)
 		if (timeout) {
 			/* If kill returns an error, we can't kill the process since either the process has terminated,
 			 * or we don't have permission. If we can't kill it, there is no point trying again. */
-			if (!kill(-pid, sig_num)) {
+			if (kill(-pid, sig_num)) {
 				if (errno == ESRCH) {
 					/* The process does not exist, and we should
 					 * have reaped its exit status, otherwise it


### PR DESCRIPTION
github @lankstra pointed out that the check for kill failing for
misc check scripts was inverted, so this commit corrects that, and
the code now matches the similar code in vrrp_script_child_thread().

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>