### PR TITLE
Updates for iptables/nftables use.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,11 +1,8 @@
-Don't allow nft/iptables changes at reload
 Test LVS forwarding via VIP if no_accept set
 
-Don't load nftables and iptables rules
-Detect iptables using nftables
 Fix warnings on Rpi builds
-vrrp-strict and nftables
-If iptables command adds nftables commands, we mustn't use iptables
+
+PKG_CONFIG_* autoconf options - see man pkg.m4
 
 Whatever you want !
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,5 @@
+Test LVS forwarding via VIP if no_accept set
+
 Don't load nftables and iptables rules
 Detect iptables using nftables
 Fix warnings on Rpi builds

--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
+Don't allow nft/iptables changes at reload
 Test LVS forwarding via VIP if no_accept set
 
 Don't load nftables and iptables rules

--- a/configure.ac
+++ b/configure.ac
@@ -2124,14 +2124,14 @@ if test "$enable_snmp" = yes -o \
   # For further information, see https://bugzilla.redhat.com/show_bug.cgi?id=1544527
   # and the other bugs referred to in it.
   for spec in `echo $NETSNMP_LIBS | sed -e "s? ?\n?g" | grep "^-specs="`; do
-    SPEC_FILE=`echo $spec | sed -e "s?^-spaces=??"`
+    SPEC_FILE=`echo $spec | sed -e "s?^-specs=??"`
     if test ! -f $SPEC_FILE; then
       NETSNMP_LIBS=`echo $NETSNMP_LIBS | sed -e "s? *$spec *? ?"`
       AC_MSG_WARN([Removing $spec from NETSNMP_LIBS since spec file not installed])
     fi
   done
   for spec in `echo $NETSNMP_CFLAGS | sed -e "s? ?\n?g" | grep "^-specs="`; do
-    SPEC_FILE=`echo $spec | sed -e "s?^-spaces=??"`
+    SPEC_FILE=`echo $spec | sed -e "s?^-specs=??"`
     if test ! -f $SPEC_FILE; then
       NETSNMP_CFLAGS=`echo $NETSNMP_CFLAGS | sed -e "s? *$spec *? ?"`
       AC_MSG_WARN([Removing $spec from NETSNMP_CFLAGS since spec file not installed])

--- a/configure.ac
+++ b/configure.ac
@@ -1919,38 +1919,34 @@ if test "$enable_vrrp" != no; then
   if test $MACVLAN_SUPPORT = Yes; then
     AC_DEFINE([_HAVE_VRRP_VMAC_], [ 1 ], [Define to 1 if have MAC VLAN support])
     add_system_opt([VRRP_VMAC])
-  fi
-  CPPFLAGS="$SAV_CPPFLAGS"
 
-  dnl ----[ Checks for kernel IPVLAN support ]----
-  SAV_CPPFLAGS="$CPPFLAGS"
-  CPPFLAGS="$CPPFLAGS $kernelinc"
-  IPVLAN_SUPPORT=Yes
-  dnl -- Since Linux 3.19
-  AC_CHECK_DECLS([
-      IFLA_IPVLAN_MODE], [],
-    [
-      IPVLAN_SUPPORT=No
-      break
-    ], [[
-      #include <sys/socket.h>
+    dnl ----[ Checks for kernel IPVLAN support ]----
+    IPVLAN_SUPPORT=Yes
+    dnl -- Since Linux 3.19
+    AC_CHECK_DECLS([IFLA_IPVLAN_MODE], [],
+      [
+        IPVLAN_SUPPORT=No
+        break
+      ], [[
+        #include <sys/socket.h>
+        #include <linux/if_link.h>
+      ]])
+    if test $IPVLAN_SUPPORT = Yes; then
+      AC_DEFINE([_HAVE_VRRP_IPVLAN_], [ 1 ], [Define to 1 if have IP VLAN support])
+      add_system_opt([VRRP_IPVLAN])
+    fi
+
+    dnl ----[ Check for IFLA_LINK_NETNSID support ]---- since Linux v4.0
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
       #include <linux/if_link.h>
-    ]])
-  if test $IPVLAN_SUPPORT = Yes; then
-    AC_DEFINE([_HAVE_VRRP_IPVLAN_], [ 1 ], [Define to 1 if have IP VLAN support])
-    add_system_opt([VRRP_IPVLAN])
+      int main(void) { int var = IFLA_LINK_NETNSID; }
+      ]])],
+      [
+        AC_DEFINE([HAVE_IFLA_LINK_NETNSID], [ 1 ], [Define to 1 if IFLA_LINK_NETNSID supported])
+        add_system_opt([IFLA_LINK_NETNSID])
+      ])
   fi
   CPPFLAGS="$SAV_CPPFLAGS"
-
-  dnl ----[ Check for IFLA_LINK_NETNSID support ]---- since Linux v4.0
-  AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-    #include <linux/if_link.h>
-    int main(void) { int var = IFLA_LINK_NETNSID; }
-    ]])],
-    [
-      AC_DEFINE([HAVE_IFLA_LINK_NETNSID], [ 1 ], [Define to 1 if IFLA_LINK_NETNSID supported])
-      add_system_opt([IFLA_LINK_NETNSID])
-    ])
 
   dnl ----[ JSON output or not ? ]----
   if test "${enable_json}" = yes; then
@@ -2073,9 +2069,10 @@ fi
 CPPFLAGS="$SAV_CPPFLAGS"
 
 dnl ----[ Checks for kernel IFLA_VRF_... support ]----
-SAV_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="$CPPFLAGS $kernelinc"
 if test ${MACVLAN_SUPPORT} = Yes; then
+  SAV_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$CPPFLAGS $kernelinc"
+
   # Introduced in Linux 4.3
   AC_CHECK_DECLS([IFLA_VRF_MAX],
     [
@@ -2084,8 +2081,8 @@ if test ${MACVLAN_SUPPORT} = Yes; then
     ], [], [[
       #include <linux/if_link.h>
     ]])
+  CPPFLAGS="$SAV_CPPFLAGS"
 fi
-CPPFLAGS="$SAV_CPPFLAGS"
 
 dnl ----[ Checks for SNMP support ]----
 SNMP_SUPPORT=No

--- a/configure.ac
+++ b/configure.ac
@@ -2596,7 +2596,7 @@ if test "${enable_log_file}" = yes; then
   add_config_opt([FILE_LOGGING])
 fi
 
-if test ${ENABLE_LOG_FILE_APPEND} = Yes; then
+if test "${ENABLE_LOG_FILE_APPEND}" = Yes; then
   AC_DEFINE([ENABLE_LOG_FILE_APPEND], [ 1 ], [Define if appending to log files is allowed])
   add_config_opt([LOG_FILE_APPEND])
 fi
@@ -2697,7 +2697,7 @@ AS_IF([test .$enable_dump_keywords = .yes],
     add_config_opt([DUMP_KEYWORDS])
   ])
 
-if test ${NEED_LIBDL} = Yes; then
+if test "${NEED_LIBDL}" = Yes; then
   add_to_var([KA_LIBS], [-ldl])
 fi
 

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -302,35 +302,16 @@ and
     # (default: 2, but IPv6 instances will use version 3)
     \fBvrrp_version \fR<2 or 3>
 
-    # Specify the iptables chain for ensuring a version 3 instance
-    # doesn't respond on addresses that it doesn't own.
-    # Note: it is necessary for the specified chain to exist in
-    # the iptables and/or ip6tables configuration, and for the chain
-    # to be called from an appropriate point in the iptables configuration.
-    # It will probably be necessary to have this filtering after accepting
-    # any ESTABLISHED,RELATED packets, because IPv4 might select the VIP as
-    # the source address for outgoing connections.
-    # (default: INPUT)
-    \fBvrrp_iptables \fRkeepalived
+    # keepalived uses a firewall (either nftables or iptables) for two purposes:
+    #  i)  To implement no_accept mode
+    #  ii) To stop IGMP/MLD packets being sent on VMAC interfaces, and to move
+    #      them onto the underlying interface.
+    # If both vrrp_iptables and vrrp_nftables are specified, keepalived will use
+    # nftables and not iptables. Similarly, if the iptables command is generating
+    # nftables configuration, or there is no iptables command installed,
+    # keepalived will use nftables rather than iptables.
 
-    # or for outbound filtering as well
-    # Note, outbound filtering won't work with IPv4, since the VIP can be
-    # selected as the source address for an outgoing connection. With IPv6
-    # this is unlikely since the addresses are deprecated.
-    \fBvrrp_iptables \fRkeepalived_in keepalived_out
-
-    # or to not add any iptables rules:
-    \fBvrrp_iptables\fR
-
-    # Keepalived may have the option to use ipsets in conjunction with
-    # iptables. If so, then the ipset names can be specified, defaults
-    # as below. If no names are specified, ipsets will not be used,
-    # otherwise any omitted names will be constructed by adding "_if"
-    # and/or "6" and _igmp/_mld to previously specified names.
-    \fBvrrp_ipsets \fR[keepalived [keepalived6 [keepalived_if6 [keepalived_igmp [keepalived_mld]]]]]
-
-    # Use nftables to implement no_accept mode and only send IGMP/MLD
-    #   messages on the parent interface of a VMAC.
+    # Use nftables as the firewall.
     #   TABLENAME must not exist, and must be different for each
     #   instance of keepalived running in the same network namespace.
     #   Default tablename is keepalived, and priority is -1.
@@ -346,6 +327,32 @@ and
     \fBnftables_priority \fRPRIORITY
     \fBnftables_counters\fR
     \fBnftables_ifindex\fR
+
+    # Use iptables as the firewall.
+    # Note: it is necessary for the specified chain to exist in
+    # the iptables and/or ip6tables configuration, and for the chain
+    # to be called from an appropriate point in the iptables configuration.
+    # It will probably be necessary to have this filtering after accepting
+    # any ESTABLISHED,RELATED packets, because IPv4 might select the VIP as
+    # the source address for outgoing connections.
+    # (default: INPUT)
+    \fBvrrp_iptables \fRkeepalived
+
+    # or for outbound filtering as well
+    # Note, outbound filtering won't work with IPv4, since the VIP can be
+    # selected as the source address for an outgoing connection. With IPv6
+    # this is unlikely since the addresses are deprecated.
+    \fBvrrp_iptables \fRkeepalived_in keepalived_out
+
+    # or to to use default chains (INPUT and OUTPUT)
+    \fBvrrp_iptables\fR
+
+    # Keepalived may have the option to use ipsets in conjunction with
+    # iptables. If so, then the ipset names can be specified, defaults
+    # as below. If no names are specified, ipsets will not be used,
+    # otherwise any omitted names will be constructed by adding "_if"
+    # and/or "6" and _igmp/_mld to previously specified names.
+    \fBvrrp_ipsets \fR[keepalived [keepalived6 [keepalived_if6 [keepalived_igmp [keepalived_mld]]]]]
 
     # The following enables checking that when in unicast mode, the
     # source address of a VRRP packet is one of our unicast peers.

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -310,6 +310,8 @@ and
     # nftables and not iptables. Similarly, if the iptables command is generating
     # nftables configuration, or there is no iptables command installed,
     # keepalived will use nftables rather than iptables.
+    # If neither vrrp_nftables or vrrp_iptables are specified but VMACs are in use
+    # or no_accept is specified, keepalived will use nftables if it is available.
 
     # Use nftables as the firewall.
     #   TABLENAME must not exist, and must be different for each

--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -302,33 +302,8 @@ and
     # (default: 2, but IPv6 instances will use version 3)
     \fBvrrp_version \fR<2 or 3>
 
-    # keepalived uses a firewall (either nftables or iptables) for two purposes:
-    #  i)  To implement no_accept mode
-    #  ii) To stop IGMP/MLD packets being sent on VMAC interfaces, and to move
-    #      them onto the underlying interface.
-    # If both vrrp_iptables and vrrp_nftables are specified, keepalived will use
-    # nftables and not iptables. Similarly, if the iptables command is generating
-    # nftables configuration, or there is no iptables command installed,
-    # keepalived will use nftables rather than iptables.
-
-    # Use nftables as the firewall.
-    #   TABLENAME must not exist, and must be different for each
-    #   instance of keepalived running in the same network namespace.
-    #   Default tablename is keepalived, and priority is -1.
-    #   keepalived will create base chains in the table.
-    #   counters means counters are added to the rules (primarily for
-    #   debugging purposes).
-    #   ifindex means create IPv6 link local sets using ifindex rather
-    #   than ifnames. This is the default unless the vrrp_instance has
-    #   set dont_track_primary. The alternative is to use interface names
-    #   as part of the set key, but the nft utility prior to v0.8.3 will
-    #   then not output interface names properly.
-    \fBnftables \fR[TABLENAME]
-    \fBnftables_priority \fRPRIORITY
-    \fBnftables_counters\fR
-    \fBnftables_ifindex\fR
-
-    # Use iptables as the firewall.
+    # Specify the iptables chain for ensuring a version 3 instance
+    # doesn't respond on addresses that it doesn't own.
     # Note: it is necessary for the specified chain to exist in
     # the iptables and/or ip6tables configuration, and for the chain
     # to be called from an appropriate point in the iptables configuration.
@@ -353,6 +328,24 @@ and
     # otherwise any omitted names will be constructed by adding "_if"
     # and/or "6" and _igmp/_mld to previously specified names.
     \fBvrrp_ipsets \fR[keepalived [keepalived6 [keepalived_if6 [keepalived_igmp [keepalived_mld]]]]]
+
+    # Use nftables to implement no_accept mode and only send IGMP/MLD
+    #   messages on the parent interface of a VMAC.
+    #   TABLENAME must not exist, and must be different for each
+    #   instance of keepalived running in the same network namespace.
+    #   Default tablename is keepalived, and priority is -1.
+    #   keepalived will create base chains in the table.
+    #   counters means counters are added to the rules (primarily for
+    #   debugging purposes).
+    #   ifindex means create IPv6 link local sets using ifindex rather
+    #   than ifnames. This is the default unless the vrrp_instance has
+    #   set dont_track_primary. The alternative is to use interface names
+    #   as part of the set key, but the nft utility prior to v0.8.3 will
+    #   then not output interface names properly.
+    \fBnftables \fR[TABLENAME]
+    \fBnftables_priority \fRPRIORITY
+    \fBnftables_counters\fR
+    \fBnftables_ifindex\fR
 
     # The following enables checking that when in unicast mode, the
     # source address of a VRRP packet is one of our unicast peers.

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -107,13 +107,6 @@ set_vrrp_defaults(data_t * data)
 	data->vrrp_version = VRRP_VERSION_2;
 #ifdef _HAVE_LIBIPSET_
 	data->using_ipsets = true;
-	strcpy(data->vrrp_ipset_address, DEFAULT_IPSET_NAME);
-	strcpy(data->vrrp_ipset_address6, DEFAULT_IPSET_NAME "6");
-	strcpy(data->vrrp_ipset_address_iface6, DEFAULT_IPSET_NAME "if6");
-#ifdef HAVE_IPSET_ATTR_IFACE
-	strcpy(data->vrrp_ipset_igmp, DEFAULT_IPSET_NAME "_igmp");
-	strcpy(data->vrrp_ipset_mld, DEFAULT_IPSET_NAME "_mld");
-#endif
 #endif
 	data->vrrp_check_unicast_src = false;
 	data->vrrp_skip_check_adv_addr = false;
@@ -360,6 +353,19 @@ free_global_data(data_t * data)
 	FREE_CONST_PTR(data->default_ifname);
 	FREE_CONST_PTR(data->vrrp_notify_fifo.name);
 	free_notify_script(&data->vrrp_notify_fifo.script);
+#ifdef _WITH_IPTABLES_
+	FREE_CONST_PTR(data->vrrp_iptables_inchain);
+	FREE_CONST_PTR(data->vrrp_iptables_outchain);
+#ifdef _HAVE_LIBIPSET_
+	FREE_CONST_PTR(data->vrrp_ipset_address);
+	FREE_CONST_PTR(data->vrrp_ipset_address6);
+	FREE_CONST_PTR(data->vrrp_ipset_address_iface6);
+#ifdef HAVE_IPSET_ATTR_IFACE
+	FREE_CONST_PTR(data->vrrp_ipset_igmp);
+	FREE_CONST_PTR(data->vrrp_ipset_mld);
+#endif
+#endif
+#endif
 #ifdef _WITH_NFTABLES_
 	FREE_CONST_PTR(data->vrrp_nf_table_name);
 #endif
@@ -544,23 +550,23 @@ dump_global_data(FILE *fp, data_t * data)
 	conf_write(fp, " Gratuitous NA interval = %f", data->vrrp_gna_interval / TIMER_HZ_DOUBLE);
 	conf_write(fp, " VRRP default protocol version = %d", data->vrrp_version);
 #ifdef _WITH_IPTABLES_
-	if (data->vrrp_iptables_inchain[0]) {
+	if (data->vrrp_iptables_inchain) {
 		conf_write(fp," Iptables input chain = %s", data->vrrp_iptables_inchain);
-		if (data->vrrp_iptables_outchain[0])
+		if (data->vrrp_iptables_outchain)
 			conf_write(fp," Iptables output chain = %s", data->vrrp_iptables_outchain);
 #ifdef _HAVE_LIBIPSET_
 		conf_write(fp, " Using ipsets = %s", data->using_ipsets ? "true" : "false");
 		if (data->using_ipsets) {
-			if (data->vrrp_ipset_address[0])
+			if (data->vrrp_ipset_address)
 				conf_write(fp," ipset IPv4 address set = %s", data->vrrp_ipset_address);
-			if (data->vrrp_ipset_address6[0])
+			if (data->vrrp_ipset_address6)
 				conf_write(fp," ipset IPv6 address set = %s", data->vrrp_ipset_address6);
-			if (data->vrrp_ipset_address_iface6[0])
+			if (data->vrrp_ipset_address_iface6)
 				conf_write(fp," ipset IPv6 address,iface set = %s", data->vrrp_ipset_address_iface6);
 #ifdef HAVE_IPSET_ATTR_IFACE
-			if (data->vrrp_ipset_igmp[0])
+			if (data->vrrp_ipset_igmp)
 				conf_write(fp," ipset IGMP set = %s", data->vrrp_ipset_igmp);
-			if (data->vrrp_ipset_mld[0])
+			if (data->vrrp_ipset_mld)
 				conf_write(fp," ipset MLD set = %s", data->vrrp_ipset_mld);
 #endif
 		}

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -110,8 +110,10 @@ set_vrrp_defaults(data_t * data)
 	strcpy(data->vrrp_ipset_address, DEFAULT_IPSET_NAME);
 	strcpy(data->vrrp_ipset_address6, DEFAULT_IPSET_NAME "6");
 	strcpy(data->vrrp_ipset_address_iface6, DEFAULT_IPSET_NAME "if6");
+#ifdef HAVE_IPSET_ATTR_IFACE
 	strcpy(data->vrrp_ipset_igmp, DEFAULT_IPSET_NAME "_igmp");
 	strcpy(data->vrrp_ipset_mld, DEFAULT_IPSET_NAME "_mld");
+#endif
 #endif
 	data->vrrp_check_unicast_src = false;
 	data->vrrp_skip_check_adv_addr = false;
@@ -555,10 +557,12 @@ dump_global_data(FILE *fp, data_t * data)
 				conf_write(fp," ipset IPv6 address set = %s", data->vrrp_ipset_address6);
 			if (data->vrrp_ipset_address_iface6[0])
 				conf_write(fp," ipset IPv6 address,iface set = %s", data->vrrp_ipset_address_iface6);
+#ifdef HAVE_IPSET_ATTR_IFACE
 			if (data->vrrp_ipset_igmp[0])
 				conf_write(fp," ipset IGMP set = %s", data->vrrp_ipset_igmp);
 			if (data->vrrp_ipset_mld[0])
 				conf_write(fp," ipset MLD set = %s", data->vrrp_ipset_mld);
+#endif
 		}
 #endif
 	}

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -106,7 +106,7 @@ set_vrrp_defaults(data_t * data)
 	data->vrrp_higher_prio_send_advert = false;
 	data->vrrp_version = VRRP_VERSION_2;
 #ifdef _HAVE_LIBIPSET_
-	data->using_ipsets = true;
+	data->using_ipsets = PARAMETER_UNSET;
 #endif
 	data->vrrp_check_unicast_src = false;
 	data->vrrp_skip_check_adv_addr = false;

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -573,9 +573,6 @@ dump_global_data(FILE *fp, data_t * data)
 		conf_write(fp," nftables base chain priority = %d", data->vrrp_nf_chain_priority);
 		conf_write(fp," nftables with%s counters", data->vrrp_nf_counters ? "" : "out");
 		conf_write(fp," nftables %sforce use ifindex for link local IPv6", data->vrrp_nf_ifindex ? "" : "don't ");
-		if (data->nft_version)
-			conf_write(fp," nft version %u.%u.%u", data->nft_version >> 16,
-					(data->nft_version >> 8) & 0xff, data->nft_version & 0xff);
 		conf_write(fp," libnftnl version %u.%u.%u", LIBNFTNL_VERSION >> 16,
 			       (LIBNFTNL_VERSION >> 8) & 0xff, LIBNFTNL_VERSION & 0xff);
 	}

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -925,6 +925,7 @@ vrrp_ipsets_handler(const vector_t *strvec)
 		global_data->vrrp_ipset_address_iface6[sizeof(global_data->vrrp_ipset_address_iface6) - 5] = '\0';
 		strcat(global_data->vrrp_ipset_address_iface6, "_if6");
 	}
+#ifdef HAVE_IPSET_ATTR_IFACE
 	if (vector_size(strvec) >= 5) {
 		if (strlen(strvec_slot(strvec,4)) >= sizeof(global_data->vrrp_ipset_igmp)-1) {
 			report_config_error(CONFIG_GENERAL_ERROR, "VRRP Error : ipset IGMP name too long - ignored");
@@ -951,6 +952,7 @@ vrrp_ipsets_handler(const vector_t *strvec)
 		global_data->vrrp_ipset_mld[sizeof(global_data->vrrp_ipset_mld) - 5] = '\0';
 		strcat(global_data->vrrp_ipset_mld, "_mld");
 	}
+#endif
 }
 #endif
 #endif

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -882,20 +882,6 @@ vrrp_iptables_handler(const vector_t *strvec)
 		global_data->vrrp_iptables_inchain = STRDUP(DEFAULT_IPTABLES_CHAIN_IN);
 		global_data->vrrp_iptables_outchain = STRDUP(DEFAULT_IPTABLES_CHAIN_OUT);
 	}
-	if (global_data->using_ipsets) {
-		if (!global_data->vrrp_ipset_address)
-			global_data->vrrp_ipset_address = STRDUP(DEFAULT_IPSET_NAME);
-		if (!global_data->vrrp_ipset_address6)
-			global_data->vrrp_ipset_address6 = STRDUP(DEFAULT_IPSET_NAME "6");
-		if (!global_data->vrrp_ipset_address_iface6)
-			global_data->vrrp_ipset_address_iface6 = STRDUP(DEFAULT_IPSET_NAME "_if6");
-#ifdef HAVE_IPSET_ATTR_IFACE
-		if (!global_data->vrrp_ipset_igmp)
-			global_data->vrrp_ipset_igmp = STRDUP(DEFAULT_IPSET_NAME "_igmp");
-		if (!global_data->vrrp_ipset_mld)
-			global_data->vrrp_ipset_mld = STRDUP(DEFAULT_IPSET_NAME "_mld");
-#endif
-	}
 }
 #ifdef _HAVE_LIBIPSET_
 static void

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -977,7 +977,11 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 						else
 							is_tracking_saddr = false;
 
-						if (ifp == (vrrp->family == AF_INET ? VRRP_CONFIGURED_IFP(vrrp) : vrrp->ifp) &&
+						if (ifp == (
+#ifdef _HAVE_VRRP_VMAC_
+							    vrrp->family == AF_INET ? VRRP_CONFIGURED_IFP(vrrp) :
+#endif
+							    vrrp->ifp) &&
 						    vrrp->num_script_if_fault &&
 						    vrrp->family == ifa->ifa_family &&
 						    vrrp->saddr.ss_family == AF_UNSPEC &&
@@ -1077,7 +1081,11 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 				LIST_FOREACH(ifp->tracking_vrrp, tvp, e) {
 					vrrp = tvp->vrrp;
 
-					if (ifp != vrrp->ifp && ifp != VRRP_CONFIGURED_IFP(vrrp))
+					if (ifp != vrrp->ifp
+#ifdef _HAVE_VRRP_VMAC_
+					    && ifp != VRRP_CONFIGURED_IFP(vrrp)
+#endif
+									       )
 						continue;
 					if (vrrp->family != ifa->ifa_family)
 						continue;
@@ -1109,7 +1117,11 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 					}
 					else
 #endif
-					     if (ifp == (vrrp->family == AF_INET ? VRRP_CONFIGURED_IFP(vrrp) : vrrp->ifp) &&
+					     if (ifp == (
+#ifdef _HAVE_VRRP_VMAC_
+							 vrrp->family == AF_INET ? VRRP_CONFIGURED_IFP(vrrp) :
+#endif
+							 vrrp->ifp) &&
 						 vrrp->family == ifa->ifa_family &&
 						 vrrp->saddr.ss_family != AF_UNSPEC &&
 						 (!vrrp->saddr_from_config || is_tracking_saddr)) {
@@ -1667,7 +1679,9 @@ netlink_if_link_populate(interface_t *ifp, struct rtattr *tb[], struct ifinfomsg
 	/* Fill the interface structure */
 	strcpy_safe(ifp->ifname, name);
 	ifp->ifindex = (ifindex_t)ifi->ifi_index;
+#ifdef _HAVE_VRRP_VMAC_
 	ifp->if_type = IF_TYPE_STANDARD;
+#endif
 #ifdef HAVE_IFLA_LINK_NETNSID						/* from Linux v4.0 */
 	ifp->base_netns_id = -1;
 #endif

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -40,7 +40,6 @@
 #include <getopt.h>
 #include <linux/version.h>
 #include <ctype.h>
-#include <stdlib.h>
 
 #include "main.h"
 #include "global_data.h"
@@ -1955,12 +1954,6 @@ keepalived_main(int argc, char **argv)
 	struct utsname uname_buf;
 	char *end;
 	int exit_code = KEEPALIVED_EXIT_OK;
-#ifdef _WITH_NFTABLES_
-	FILE *fp;
-	char nft_ver_buf[128];
-	char *p;
-	unsigned nft_major = 0, nft_minor = 0, nft_release = 0;
-#endif
 
 	/* Ignore reloading signals till signal_init call */
 	signals_ignore();
@@ -2093,23 +2086,8 @@ keepalived_main(int argc, char **argv)
 	init_global_data(global_data, NULL, false);
 
 #ifdef _WITH_NFTABLES_
-	if (global_data->vrrp_nf_table_name) {
-		/* We are using nftables. Find the version of nft. */
-		fp = popen("nft -v 2>/dev/null", "r");
-		if (fgets(nft_ver_buf, sizeof(nft_ver_buf) - 1, fp)) {
-			p = strchr(nft_ver_buf, ' ');
-			while (*p == ' ')
-				p++;
-			if (*p == 'v')
-				p++;
-
-			if (sscanf(p, "%u.%u.%u", &nft_major, &nft_minor, &nft_release) >= 2)
-				global_data->nft_version = (nft_major * 0x100 + nft_minor) * 0x100 + nft_release;
-		}
-		pclose(fp);
-
+	if (global_data->vrrp_nf_table_name)
 		set_nf_ifname_type();
-	}
 #endif
 
 	/* Update process name if necessary */

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -151,16 +151,16 @@ typedef struct _data {
 	bool				vrrp_higher_prio_send_advert;
 	int				vrrp_version;		/* VRRP version (2 or 3) */
 #ifdef _WITH_IPTABLES_
-	char				vrrp_iptables_inchain[XT_EXTENSION_MAXNAMELEN];
-	char				vrrp_iptables_outchain[XT_EXTENSION_MAXNAMELEN];
+	const char			*vrrp_iptables_inchain;
+	const char			*vrrp_iptables_outchain;
 #ifdef _HAVE_LIBIPSET_
 	bool				using_ipsets;
-	char				vrrp_ipset_address[IPSET_MAXNAMELEN];
-	char				vrrp_ipset_address6[IPSET_MAXNAMELEN];
-	char				vrrp_ipset_address_iface6[IPSET_MAXNAMELEN];
+	const char			*vrrp_ipset_address;
+	const char			*vrrp_ipset_address6;
+	const char			*vrrp_ipset_address_iface6;
 #ifdef HAVE_IPSET_ATTR_IFACE
-	char				vrrp_ipset_igmp[IPSET_MAXNAMELEN];
-	char				vrrp_ipset_mld[IPSET_MAXNAMELEN];
+	const char			*vrrp_ipset_igmp;
+	const char			*vrrp_ipset_mld;
 #endif
 #endif
 #endif

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -154,7 +154,7 @@ typedef struct _data {
 	const char			*vrrp_iptables_inchain;
 	const char			*vrrp_iptables_outchain;
 #ifdef _HAVE_LIBIPSET_
-	bool				using_ipsets;
+	unsigned			using_ipsets;
 	const char			*vrrp_ipset_address;
 	const char			*vrrp_ipset_address6;
 	const char			*vrrp_ipset_address_iface6;

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -169,7 +169,6 @@ typedef struct _data {
 	int				vrrp_nf_chain_priority;
 	bool				vrrp_nf_counters;
 	bool				vrrp_nf_ifindex;
-	unsigned			nft_version;
 #endif
 	bool				vrrp_check_unicast_src;
 	bool				vrrp_skip_check_adv_addr;

--- a/keepalived/include/vrrp_ipset.h
+++ b/keepalived/include/vrrp_ipset.h
@@ -31,18 +31,20 @@
 
 struct ipset_session;
 
-bool add_vip_ipsets(struct ipset_session **, uint8_t, bool);
+extern bool add_vip_ipsets(struct ipset_session **, uint8_t, bool);
 #ifdef HAVE_IPSET_ATTR_IFACE
-bool add_igmp_ipsets(struct ipset_session **, uint8_t, bool);
+extern bool add_igmp_ipsets(struct ipset_session **, uint8_t, bool);
 #endif
-bool remove_vip_ipsets(struct ipset_session **, uint8_t);
-bool remove_igmp_ipsets(struct ipset_session **, uint8_t);
-bool ipset_initialise(void);
-void* ipset_session_start(void);
-void ipset_session_end(void *);
-void ipset_entry(void *, int, const ip_address_t*);
+extern bool remove_vip_ipsets(struct ipset_session **, uint8_t);
+extern bool remove_igmp_ipsets(struct ipset_session **, uint8_t);
+extern bool ipset_initialise(void);
+extern void* ipset_session_start(void);
+extern void ipset_session_end(void *);
+extern void ipset_entry(void *, int, const ip_address_t*);
 #ifdef HAVE_IPSET_ATTR_IFACE
-void ipset_entry_igmp(void*, int, const char *, uint8_t);
+extern void ipset_entry_igmp(void*, int, const char *, uint8_t);
 #endif
+extern void set_default_ipsets(void);
+extern void disable_ipsets(void);
 
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2843,8 +2843,8 @@ vrrp_complete_instance(vrrp_t * vrrp)
 			}
 #endif
 		}
-#endif
 	}
+#endif
 
 	if (vrrp->garp_lower_prio_rep == PARAMETER_UNSET)
 		vrrp->garp_lower_prio_rep = vrrp->strict_mode ? 0 : global_data->vrrp_garp_lower_prio_rep;
@@ -3180,8 +3180,8 @@ vrrp_complete_instance(vrrp_t * vrrp)
 			global_data->vrrp_iptables_outchain = STRDUP(DEFAULT_IPTABLES_CHAIN_OUT);
 
 #ifdef _HAVE_LIBIPSET_
-			if (!data->using_ipsets) {
-				data->using_ipsets = true;
+			if (!global_data->using_ipsets) {
+				global_data->using_ipsets = true;
 				set_default_ipsets();
 			}
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3907,23 +3907,6 @@ vrrp_complete_init(void)
 
 	alloc_vrrp_buffer(max_mtu_len);
 
-#if defined _WITH_IPTABLES && defined _WITH_NFTABLES_
-	/* It doesn't make sense to use both iptables and nftables; prefer nftables */
-	if (global_data->vrrp_iptables_inchain[0] && global_data->vrrp_nf_table_name) {
-		log_message(LOG_INFO, "Both iptables and nftables have been specified - ignoring iptables");
-		global_data->vrrp_iptables_inchain[0] = '\0';
-		global_data->vrrp_iptables_outchain[0] = '\0';
-		global_data->using_ipsets = false;
-	}
-#endif
-
-#if defined _WITH_IPTABLES_ && defined _HAVE_LIBIPSET_
-	if (!global_data->vrrp_iptables_inchain[0] && global_data->using_ipsets) {
-		log_message(LOG_INFO, "vrrp_ipsets has been specified but not vrrp_iptables - vrrp_ipsets will be ignored");
-		global_data->using_ipsets = false;
-	}
-#endif
-
 	return true;
 }
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3216,8 +3216,11 @@ vrrp_complete_instance(vrrp_t * vrrp)
 		 * ensure that VIPs don't cause it to be tracked. */
 		if (!vip->dont_track &&
 		    (!vrrp->dont_track_primary ||
-		     (vip->ifp != vrrp->ifp &&
-		      vip->ifp != IF_BASE_IFP(vrrp->ifp))))
+		     (vip->ifp != vrrp->ifp
+#ifdef _HAVE_VRRP_VMAC_
+		      && vip->ifp != IF_BASE_IFP(vrrp->ifp)
+#endif
+							   )))
 			add_vrrp_to_interface(vrrp, vip->ifp, 0, false, false, TRACK_ADDR);
 	}
 	LIST_FOREACH(vrrp->evip, vip, e) {
@@ -3228,8 +3231,11 @@ vrrp_complete_instance(vrrp_t * vrrp)
 		 * ensure that eVIPs don't cause it to be tracked. */
 		if (!vip->dont_track &&
 		    (!vrrp->dont_track_primary ||
-		     (vip->ifp != vrrp->ifp &&
-		      vip->ifp != IF_BASE_IFP(vrrp->ifp))))
+		     (vip->ifp != vrrp->ifp
+#ifdef _HAVE_VRRP_VMAC_
+		      && vip->ifp != IF_BASE_IFP(vrrp->ifp)
+#endif
+							   )))
 			add_vrrp_to_interface(vrrp, vip->ifp, 0, false, false, TRACK_ADDR);
 
 		if (vip->ifa.ifa_family == AF_INET)

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -225,15 +225,11 @@ check_vrrp_script_security(void)
 
 	/* Set the insecure flag of any insecure scripts */
 	if (!LIST_ISEMPTY(vrrp_data->vrrp_script)) {
-		for (e = LIST_HEAD(vrrp_data->vrrp_script); e; ELEMENT_NEXT(e)) {
-			vscript = ELEMENT_DATA(e);
+		LIST_FOREACH(vrrp_data->vrrp_script, vscript, e)
 			script_flags |= check_track_script_secure(vscript, magic);
-		}
 	}
 
-	for (e = LIST_HEAD(vrrp_data->vrrp); e; ELEMENT_NEXT(e)) {
-		vrrp = ELEMENT_DATA(e);
-
+	LIST_FOREACH(vrrp_data->vrrp, vrrp, e) {
 		script_flags |= check_notify_script_secure(&vrrp->script_backup, magic);
 		script_flags |= check_notify_script_secure(&vrrp->script_master, magic);
 		script_flags |= check_notify_script_secure(&vrrp->script_fault, magic);
@@ -244,10 +240,7 @@ check_vrrp_script_security(void)
 		if (LIST_ISEMPTY(vrrp->track_script))
 			continue;
 
-		for (e1 = LIST_HEAD(vrrp->track_script); e1; e1 = next) {
-			next = e1->next;
-			track_script = ELEMENT_DATA(e1);
-
+		LIST_FOREACH_NEXT(vrrp->track_script, track_script, e1, next) {
 			if (track_script->scr->insecure) {
 				/* Remove it from the vrrp instance's queue */
 				free_list_element(vrrp->track_script, e1);
@@ -256,18 +249,14 @@ check_vrrp_script_security(void)
 	}
 
 	if (!LIST_ISEMPTY(vrrp_data->vrrp_sync_group)) {
-		for (e = LIST_HEAD(vrrp_data->vrrp_sync_group); e; ELEMENT_NEXT(e)) {
-			sg = ELEMENT_DATA(e);
+		LIST_FOREACH(vrrp_data->vrrp_sync_group, sg, e) {
 			script_flags |= check_notify_script_secure(&sg->script_backup, magic);
 			script_flags |= check_notify_script_secure(&sg->script_master, magic);
 			script_flags |= check_notify_script_secure(&sg->script_fault, magic);
 			script_flags |= check_notify_script_secure(&sg->script_stop, magic);
 			script_flags |= check_notify_script_secure(&sg->script, magic);
 
-			for (e1 = LIST_HEAD(sg->track_script); e1; e1 = next) {
-				next = e1->next;
-				track_script = ELEMENT_DATA(e1);
-
+			LIST_FOREACH_NEXT(sg->track_script, track_script, e1, next) {
 				if (track_script->scr->insecure) {
 					/* Remove it from the vrrp sync group's queue */
 					free_list_element(sg->track_script, e1);
@@ -290,10 +279,7 @@ check_vrrp_script_security(void)
 		ka_magic_close(magic);
 
 	/* Now walk through the vrrp_script list, removing any that aren't used */
-	for (e = LIST_HEAD(vrrp_data->vrrp_script); e; e = next) {
-		next = e->next;
-		vscript = ELEMENT_DATA(e);
-
+	LIST_FOREACH_NEXT(vrrp_data->vrrp_script, vscript, e, next) {
 		if (vscript->insecure)
 			free_list_element(vrrp_data->vrrp_script, e);
 	}

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3700,6 +3700,16 @@ vrrp_complete_init(void)
 	}
 #endif
 
+	/* NOTE: A reload which changes the iptables/nftables configuration will not
+	 * work properly. However, it is hard to check it. We could check here that everything
+	 * matches between old_global_data and global_data, because vrrp_complete_instance() can
+	 * update the need for using iptables/nftables, and also because it can update the
+	 * requirement if there is a VMAC, at this point we don't have a clear picture of what
+	 * the firewall situation is.
+	 *
+	 * So, if someone changes the configuration, it will be a bit confused, but it is unlikely
+	 * to happen. */
+
 	/* Mark any scripts as insecure */
 	check_vrrp_script_security();
 

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3907,6 +3907,23 @@ vrrp_complete_init(void)
 
 	alloc_vrrp_buffer(max_mtu_len);
 
+#if defined _WITH_IPTABLES && defined _WITH_NFTABLES_
+	/* It doesn't make sense to use both iptables and nftables; prefer nftables */
+	if (global_data->vrrp_iptables_inchain[0] && global_data->vrrp_nf_table_name) {
+		log_message(LOG_INFO, "Both iptables and nftables have been specified - ignoring iptables");
+		global_data->vrrp_iptables_inchain[0] = '\0';
+		global_data->vrrp_iptables_outchain[0] = '\0';
+		global_data->using_ipsets = false;
+	}
+#endif
+
+#if defined _WITH_IPTABLES_ && defined _HAVE_LIBIPSET_
+	if (!global_data->vrrp_iptables_inchain[0] && global_data->using_ipsets) {
+		log_message(LOG_INFO, "vrrp_ipsets has been specified but not vrrp_iptables - vrrp_ipsets will be ignored");
+		global_data->using_ipsets = false;
+	}
+#endif
+
 	return true;
 }
 

--- a/keepalived/vrrp/vrrp_firewall.c
+++ b/keepalived/vrrp/vrrp_firewall.c
@@ -100,7 +100,8 @@ check_iptables_nft(void)
 	FREE_CONST_PTR(global_data->vrrp_iptables_inchain);
 	FREE_CONST_PTR(global_data->vrrp_iptables_outchain);
 #ifdef _HAVE_LIBISPET_
-	global_data->using_ipsets = false;
+	if (global_data->using_ipsets)
+		disable_ipsets();
 #endif
 
 	/* If nftables table name not set up, set it to default */

--- a/keepalived/vrrp/vrrp_firewall.c
+++ b/keepalived/vrrp/vrrp_firewall.c
@@ -55,8 +55,8 @@ check_iptables_nft(void)
 	checked_iptables_nft = true;
 
 	/* If using iptables is not configured, we don't need to do anything */
-	if (!global_data->vrrp_iptables_inchain[0] &&
-	    !global_data->vrrp_iptables_outchain[0])
+	if (!global_data->vrrp_iptables_inchain &&
+	    !global_data->vrrp_iptables_outchain)
 		return;
 
 	fp = popen("iptables -V", "r");
@@ -97,8 +97,8 @@ check_iptables_nft(void)
 		log_message(LOG_INFO, "Not using iptables since iptables uses nf_tables - please update configuration");
 	}
 
-	global_data->vrrp_iptables_inchain[0] = '\0';
-	global_data->vrrp_iptables_outchain[0] = '\0';
+	FREE_CONST_PTR(global_data->vrrp_iptables_inchain);
+	FREE_CONST_PTR(global_data->vrrp_iptables_outchain);
 #ifdef _HAVE_LIBISPET_
 	global_data->using_ipsets = false;
 #endif
@@ -123,7 +123,7 @@ firewall_handle_accept_mode(vrrp_t *vrrp, int cmd,
 #endif
 
 #ifdef _WITH_IPTABLES_
-	if (global_data->vrrp_iptables_inchain[0])
+	if (global_data->vrrp_iptables_inchain)
 		handle_iptables_accept_mode(vrrp, cmd, force);
 #endif
 
@@ -143,7 +143,7 @@ void
 firewall_remove_rule_to_iplist(list ip_list)
 {
 #ifdef _WITH_IPTABLES_
-	if (global_data->vrrp_iptables_inchain[0])
+	if (global_data->vrrp_iptables_inchain)
 		handle_iptable_rule_to_iplist(ip_list, NULL, IPADDRESS_DEL, false);
 #endif
 
@@ -163,7 +163,7 @@ firewall_add_vmac(const vrrp_t *vrrp)
 #endif
 
 #ifdef _WITH_IPTABLES_
-	if (global_data->vrrp_iptables_outchain[0])
+	if (global_data->vrrp_iptables_outchain)
 		iptables_add_vmac(vrrp);
 #endif
 
@@ -177,7 +177,7 @@ void
 firewall_remove_vmac(const vrrp_t *vrrp)
 {
 #ifdef _WITH_IPTABLES_
-	if (global_data->vrrp_iptables_outchain[0])
+	if (global_data->vrrp_iptables_outchain)
 		iptables_remove_vmac(vrrp);
 #endif
 
@@ -192,8 +192,8 @@ void
 firewall_fini(void)
 {
 #ifdef _WITH_IPTABLES_
-	if (global_data->vrrp_iptables_inchain[0] ||
-	    global_data->vrrp_iptables_outchain[0])
+	if (global_data->vrrp_iptables_inchain ||
+	    global_data->vrrp_iptables_outchain)
 		iptables_fini();
 #endif
 

--- a/keepalived/vrrp/vrrp_firewall.c
+++ b/keepalived/vrrp/vrrp_firewall.c
@@ -22,11 +22,6 @@
 
 #include "config.h"
 
-#include <stdio.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include "vrrp_firewall.h"
 #ifdef _WITH_IPTABLES_
 #include "vrrp_iptables.h"
@@ -36,76 +31,7 @@
 #endif
 #include "global_data.h"
 #include "vrrp_ipaddress.h"
-#include "bitops.h"
-#include "logger.h"
 
-#if defined _WITH_IPTABLES_ && defined _WITH_NFTABLES_
-static bool checked_iptables_nft;
-
-static void
-check_iptables_nft(void)
-{
-	FILE *fp;
-	char buf[40];
-	size_t len;
-	char *res;
-
-	/* Increasingly the iptables command is being provided as a front end to nftables. If so,
-	 * then if we are built with nftables support, we should use nftables. */
-	checked_iptables_nft = true;
-
-	/* If using iptables is not configured, we don't need to do anything */
-	if (!global_data->vrrp_iptables_inchain[0] &&
-	    !global_data->vrrp_iptables_outchain[0])
-		return;
-
-	fp = popen("iptables -V", "r");
-	if (!fp) {
-		/* No iptables command, so we need to use nftables */
-		if (__test_bit(LOG_DETAIL_BIT, &debug))
-			log_message(LOG_INFO, "Using nftables since no iptables command found - please update configuration");
-
-		global_data->vrrp_iptables_inchain[0] = '\0';
-		global_data->vrrp_iptables_outchain[0] = '\0';
-
-		/* If nftables table name not set up, set it to default */
-		if (!global_data->vrrp_nf_table_name) {
-			global_data->vrrp_nf_table_name = res = MALLOC(strlen(DEFAULT_NFTABLES_TABLE) + 1);
-			strcpy(res, DEFAULT_NFTABLES_TABLE);
-		}
-
-		return;
-	}
-
-	res = fgets(buf, sizeof buf, fp);
-	pclose(fp);
-
-	if (!res) {
-		if (__test_bit(LOG_DETAIL_BIT, &debug))
-			log_message(LOG_INFO, "popen(\"iptables -V\" read failed - errno %d - %m", errno);
-		return;
-	}
-
-	/* iptables will either have no type, or the type will be "nf_tables" or "legacy" */
-	if ((len = strlen(buf)) && buf[len-1] == '\n')
-		buf[--len] = '\0';
-
-	if (len > 10 && buf[len-1] == ')') {
-		if (!strncmp(buf + len - 1 - 9, "nf_tables", 9)) {
-			log_message(LOG_INFO, "Not using iptables since iptables uses nf_tables - please update configuration");
-
-			global_data->vrrp_iptables_inchain[0] = '\0';
-			global_data->vrrp_iptables_outchain[0] = '\0';
-
-			/* If nftables table name not set up, set it to default */
-			if (global_data->vrrp_nf_table_name) {
-				global_data->vrrp_nf_table_name = res = MALLOC(strlen(DEFAULT_NFTABLES_TABLE) + 1);
-				strcpy(res, DEFAULT_NFTABLES_TABLE);
-			}
-		}
-	}
-}
-#endif
 
 /* add/remove iptables/nftables drop rules */
 void
@@ -115,11 +41,6 @@ firewall_handle_accept_mode(vrrp_t *vrrp, int cmd,
 #endif
 						    bool force)
 {
-#if defined _WITH_IPTABLES_ && defined _WITH_NFTABLES_
-	if (!checked_iptables_nft)
-		check_iptables_nft();
-#endif
-
 #ifdef _WITH_IPTABLES_
 	if (global_data->vrrp_iptables_inchain[0])
 		handle_iptables_accept_mode(vrrp, cmd, force);
@@ -155,11 +76,6 @@ firewall_remove_rule_to_iplist(list ip_list)
 void
 firewall_add_vmac(const vrrp_t *vrrp)
 {
-#if defined _WITH_IPTABLES_ && defined _WITH_NFTABLES_
-	if (!checked_iptables_nft)
-		check_iptables_nft();
-#endif
-
 #ifdef _WITH_IPTABLES_
 	if (global_data->vrrp_iptables_outchain[0])
 		iptables_add_vmac(vrrp);

--- a/keepalived/vrrp/vrrp_firewall.c
+++ b/keepalived/vrrp/vrrp_firewall.c
@@ -22,6 +22,11 @@
 
 #include "config.h"
 
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "vrrp_firewall.h"
 #ifdef _WITH_IPTABLES_
 #include "vrrp_iptables.h"
@@ -31,7 +36,78 @@
 #endif
 #include "global_data.h"
 #include "vrrp_ipaddress.h"
+#include "bitops.h"
+#include "logger.h"
 
+#if defined _WITH_IPTABLES_ && defined _WITH_NFTABLES_
+static bool checked_iptables_nft;
+
+static void
+check_iptables_nft(void)
+{
+	FILE *fp;
+	char buf[40];
+	size_t len;
+	char *res;
+
+	/* Increasingly the iptables command is being provided as a front end to nftables. If so,
+	 * then if we are built with nftables support, we should use nftables. */
+	checked_iptables_nft = true;
+
+	/* If using iptables is not configured, we don't need to do anything */
+	if (!global_data->vrrp_iptables_inchain[0] &&
+	    !global_data->vrrp_iptables_outchain[0])
+		return;
+
+	fp = popen("iptables -V", "r");
+	if (!fp) {
+		/* No iptables command, so we need to use nftables */
+		log_message(LOG_INFO, "Using nftables since no iptables command found - please update configuration");
+	} else {
+		res = fgets(buf, sizeof buf, fp);
+		pclose(fp);
+
+		if (!res) {
+			if (__test_bit(LOG_DETAIL_BIT, &debug))
+				log_message(LOG_INFO, "popen(\"iptables -V\" read failed - errno %d - %m", errno);
+			return;
+		}
+
+		/* iptables will either have no type, or the type will be "nf_tables" or "legacy" */
+		if ((len = strlen(buf)) && buf[len-1] == '\n')
+			buf[--len] = '\0';
+
+		if (len <= 10 || buf[len-1] != ')')
+			return;
+
+		/* If the type is not nf_tables, then iptables command is creating iptables configuration */
+		if (strncmp(buf + len - 1 - 9, "nf_tables", 9))
+			return;
+
+#ifdef ALLOW_IPTABLES_LEGACY
+		fp = popen("iptables-legacy -V", "r");
+		fclose(fp);
+
+		if (fp) {
+			/* The iptables-legacy command exists, so can use iptables */
+			return;
+		}
+#endif
+
+		log_message(LOG_INFO, "Not using iptables since iptables uses nf_tables - please update configuration");
+	}
+
+	global_data->vrrp_iptables_inchain[0] = '\0';
+	global_data->vrrp_iptables_outchain[0] = '\0';
+#ifdef _HAVE_LIBISPET_
+	global_data->using_ipsets = false;
+#endif
+
+	/* If nftables table name not set up, set it to default */
+	if (!global_data->vrrp_nf_table_name)
+		global_data->vrrp_nf_table_name = STRDUP(DEFAULT_NFTABLES_TABLE);
+}
+#endif
 
 /* add/remove iptables/nftables drop rules */
 void
@@ -41,6 +117,11 @@ firewall_handle_accept_mode(vrrp_t *vrrp, int cmd,
 #endif
 						    bool force)
 {
+#if defined _WITH_IPTABLES_ && defined _WITH_NFTABLES_
+	if (!checked_iptables_nft)
+		check_iptables_nft();
+#endif
+
 #ifdef _WITH_IPTABLES_
 	if (global_data->vrrp_iptables_inchain[0])
 		handle_iptables_accept_mode(vrrp, cmd, force);
@@ -76,6 +157,11 @@ firewall_remove_rule_to_iplist(list ip_list)
 void
 firewall_add_vmac(const vrrp_t *vrrp)
 {
+#if defined _WITH_IPTABLES_ && defined _WITH_NFTABLES_
+	if (!checked_iptables_nft)
+		check_iptables_nft();
+#endif
+
 #ifdef _WITH_IPTABLES_
 	if (global_data->vrrp_iptables_outchain[0])
 		iptables_add_vmac(vrrp);

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -128,8 +128,8 @@ if_get_by_ifname(const char *ifname, if_lookup_t create)
 	strcpy_safe(ifp->ifname, ifname);
 #ifdef _HAVE_VRRP_VMAC_
 	ifp->base_ifp = ifp;
-#endif
 	ifp->if_type = IF_TYPE_STANDARD;
+#endif
 	ifp->sin_addr_l = alloc_list(free_list_element_simple, NULL);
 	ifp->sin6_addr_l = alloc_list(free_list_element_simple, NULL);
 
@@ -1269,7 +1269,11 @@ cleanup_lost_interface(interface_t *ifp)
 		vrrp = tvp->vrrp;
 
 		/* If this is just a tracking interface, we don't need to do anything */
-		if (vrrp->ifp != ifp && IF_BASE_IFP(vrrp->ifp) != ifp && VRRP_CONFIGURED_IFP(vrrp) != ifp)
+		if (vrrp->ifp != ifp
+#ifdef _HAVE_VRRP_VMAC_
+		    && IF_BASE_IFP(vrrp->ifp) != ifp && VRRP_CONFIGURED_IFP(vrrp) != ifp
+#endif
+											)
 			continue;
 
 		/* If the vrrp instance's interface doesn't exist, skip it */
@@ -1537,7 +1541,11 @@ update_added_interface(interface_t *ifp)
 #endif
 
 		/* If this is just a tracking interface, we don't need to do anything */
-		if (vrrp->ifp != ifp && IF_BASE_IFP(vrrp->ifp) != ifp)
+		if (vrrp->ifp != ifp
+#ifdef _HAVE_VRRP_VMAC_
+		    && IF_BASE_IFP(vrrp->ifp) != ifp
+#endif
+						    )
 			continue;
 
 		/* Reopen any socket on this interface if necessary */

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -837,7 +837,7 @@ if_join_vrrp_group(sa_family_t family, int *sd, interface_t *ifp)
 	    ifp->if_type == IF_TYPE_MACVLAN &&
 	    ifp->is_ours) {
 #ifdef _WITH_IPTABLES_
-		if (global_data->vrrp_iptables_outchain[0])
+		if (global_data->vrrp_iptables_outchain)
 			send_on_base_if = true;
 #endif
 #ifdef _WITH_NFTABLES_

--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -178,8 +178,11 @@ netlink_ipaddress(ip_address_t *ipaddress, int cmd)
 	/* If the state of the interface or its parent is down, it might be because the interface
 	 * has been deleted, but we get the link status change message before the RTM_DELLINK message */
 	if (cmd == IPADDRESS_DEL &&
-	    (((ipaddress->ifp->ifi_flags & (IFF_UP | IFF_RUNNING)) != (IFF_UP | IFF_RUNNING)) ||
-	     ((IF_BASE_IFP(ipaddress->ifp)->ifi_flags & (IFF_UP | IFF_RUNNING)) != (IFF_UP | IFF_RUNNING))))
+	    (((ipaddress->ifp->ifi_flags & (IFF_UP | IFF_RUNNING)) != (IFF_UP | IFF_RUNNING))
+#ifdef _HAVE_VRRP_VMAC_
+	     || ((IF_BASE_IFP(ipaddress->ifp)->ifi_flags & (IFF_UP | IFF_RUNNING)) != (IFF_UP | IFF_RUNNING))
+#endif
+													     ))
 		netlink_error_ignore = ENODEV;
 	if (netlink_talk(&nl_cmd, &req.n) < 0)
 		status = -1;

--- a/keepalived/vrrp/vrrp_ipset.c
+++ b/keepalived/vrrp/vrrp_ipset.c
@@ -194,7 +194,13 @@ has_ipset_setname(struct ipset_session* session, const char *setname)
 }
 
 static bool
-create_sets(struct ipset_session **session, const char* addr4, const char* addr6, const char* addr_if6, const char *igmp, const char *mld, bool is_reload)
+create_sets(struct ipset_session **session, const char* addr4, const char* addr6, const char* addr_if6,
+#ifdef HAVE_IPSET_ATTR_IFACE
+		const char *igmp, const char *mld,
+#else
+		__attribute__((unused)) const char *igmp, __attribute__((unused)) const char *mld,
+#endif
+		bool is_reload)
 {
 	if (!*session)
 #ifdef LIBIPSET_PRE_V7_COMPAT

--- a/keepalived/vrrp/vrrp_ipset.c
+++ b/keepalived/vrrp/vrrp_ipset.c
@@ -462,3 +462,28 @@ void ipset_entry_igmp(void* vsession, int cmd, const char* ifname, uint8_t famil
 	do_ipset_cmd(session, (cmd == IPADDRESS_DEL) ? IPSET_CMD_DEL : IPSET_CMD_ADD, set, &addr, 0, 0, ifname);
 }
 #endif
+
+void
+set_default_ipsets(void)
+{
+	global_data->vrrp_ipset_address = STRDUP(DEFAULT_IPSET_NAME);
+	global_data->vrrp_ipset_address6 = STRDUP(DEFAULT_IPSET_NAME "6");
+	global_data->vrrp_ipset_address_iface6 = STRDUP(DEFAULT_IPSET_NAME "_if6");
+#ifdef HAVE_IPSET_ATTR_IFACE
+	global_data->vrrp_ipset_igmp = STRDUP(DEFAULT_IPSET_NAME "_igmp");
+	global_data->vrrp_ipset_mld = STRDUP(DEFAULT_IPSET_NAME "_mld");
+#endif
+}
+
+void
+disable_ipsets(void)
+{
+	global_data->using_ipsets = false;
+	FREE_CONST_PTR(global_data->vrrp_ipset_address);
+	FREE_CONST_PTR(global_data->vrrp_ipset_address6);
+	FREE_CONST_PTR(global_data->vrrp_ipset_address_iface6);
+#ifdef HAVE_IPSET_ATTR_IFACE
+	FREE_CONST_PTR(global_data->vrrp_ipset_igmp);
+	FREE_CONST_PTR(global_data->vrrp_ipset_mld);
+#endif
+}

--- a/keepalived/vrrp/vrrp_iptables.c
+++ b/keepalived/vrrp/vrrp_iptables.c
@@ -229,6 +229,7 @@ add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family)
 		igmp_addr.u.sin6_addr.s6_addr32[3] = htonl(0x16);
 	}
 
+#ifdef HAVE_IPSET_ATTR_IFACE
 	if (global_data->using_ipsets) {
 		if (family == AF_INET) {
 			if (h->h4 || (h->h4 = ip4tables_open("filter"))) {
@@ -246,6 +247,7 @@ add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family)
 
 		return;
 	}
+#endif
 }
 #endif
 #endif

--- a/keepalived/vrrp/vrrp_iptables.c
+++ b/keepalived/vrrp/vrrp_iptables.c
@@ -162,9 +162,9 @@ add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_err
 {
 	if (family == AF_INET) {
 		if (h->h4 || (h->h4 = ip4tables_open("filter"))) {
-			if (global_data->vrrp_iptables_inchain[0])
+			if (global_data->vrrp_iptables_inchain)
 				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address, IPPROTO_NONE, 0, cmd, ignore_errors);
-			if (global_data->vrrp_iptables_outchain[0])
+			if (global_data->vrrp_iptables_outchain)
 				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address, IPPROTO_NONE, 0, cmd, ignore_errors);
 		}
 
@@ -173,7 +173,7 @@ add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_err
 	}
 
 	if (h->h6 || (h->h6 = ip6tables_open("filter"))) {
-		if (global_data->vrrp_iptables_inchain[0]) {
+		if (global_data->vrrp_iptables_inchain) {
 #ifdef HAVE_IPSET_ATTR_IFACE
 			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
 			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
@@ -190,7 +190,7 @@ add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_err
 			h->updated_v6 = true;
 		}
 
-		if (global_data->vrrp_iptables_outchain[0]) {
+		if (global_data->vrrp_iptables_outchain) {
 #ifdef HAVE_IPSET_ATTR_IFACE
 			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
 			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
@@ -216,7 +216,7 @@ add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_er
 {
 	ip_address_t igmp_addr;
 
-	if (!global_data->vrrp_iptables_outchain[0])
+	if (!global_data->vrrp_iptables_outchain)
 		return;
 
 	if (family == AF_INET) {
@@ -313,12 +313,12 @@ check_chains_exist(uint8_t family)
 			return INIT_FAILED;
 		}
 
-		if (global_data->vrrp_iptables_inchain[0] &&
+		if (global_data->vrrp_iptables_inchain &&
 		    !ip4tables_is_chain(h4, global_data->vrrp_iptables_inchain)) {
 			log_message(LOG_INFO, "iptables chain %s doesn't exist", global_data->vrrp_iptables_inchain);
 			ret = INIT_FAILED;
 		}
-		if (global_data->vrrp_iptables_outchain[0] &&
+		if (global_data->vrrp_iptables_outchain &&
 		    !ip4tables_is_chain(h4, global_data->vrrp_iptables_outchain)) {
 			log_message(LOG_INFO, "iptables chain %s doesn't exist", global_data->vrrp_iptables_outchain);
 			ret = INIT_FAILED;
@@ -336,12 +336,12 @@ check_chains_exist(uint8_t family)
 		return INIT_FAILED;
 	}
 
-	if (global_data->vrrp_iptables_inchain[0] &&
+	if (global_data->vrrp_iptables_inchain &&
 	    !ip6tables_is_chain(h6, global_data->vrrp_iptables_inchain)) {
 		log_message(LOG_INFO, "ip6tables chain %s doesn't exist", global_data->vrrp_iptables_inchain);
 		ret = INIT_FAILED;
 	}
-	if (global_data->vrrp_iptables_outchain[0] &&
+	if (global_data->vrrp_iptables_outchain &&
 	    !ip6tables_is_chain(h6, global_data->vrrp_iptables_outchain)) {
 		log_message(LOG_INFO, "ip6tables chain %s doesn't exist", global_data->vrrp_iptables_outchain);
 		ret = INIT_FAILED;
@@ -380,13 +380,13 @@ handle_iptable_rule_to_vip(ip_address_t *ipaddress, int cmd, struct ipt_handle *
 			XTC_LABEL_DROP, NULL, ipaddress, ifname, NULL,
 			IPPROTO_NONE, 0, cmd, 0, force);
 
-	if (global_data->vrrp_iptables_outchain[0])
+	if (global_data->vrrp_iptables_outchain)
 		iptables_entry(h, family, global_data->vrrp_iptables_outchain, 0,
 				XTC_LABEL_DROP, ipaddress, NULL, NULL, ifname,
 				IPPROTO_NONE, 0, cmd, 0, force);
 
-	if (family == AF_INET6 && global_data->vrrp_iptables_inchain[0]) {
-		if (global_data->vrrp_iptables_outchain[0]) {
+	if (family == AF_INET6 && global_data->vrrp_iptables_inchain) {
+		if (global_data->vrrp_iptables_outchain) {
 			iptables_entry(h, AF_INET6, global_data->vrrp_iptables_outchain, 0,
 					XTC_LABEL_ACCEPT, ipaddress, NULL, NULL, ifname,
 					IPPROTO_ICMPV6, 135, cmd, 0, force);
@@ -585,7 +585,7 @@ handle_iptables_accept_mode(vrrp_t *vrrp, int cmd, bool force)
 static inline void
 handle_iptable_rule_for_igmp(const char *ifname, int cmd, int family, struct ipt_handle *h)
 {
-	if (global_data->vrrp_iptables_outchain[0] == '\0' ||
+	if (!global_data->vrrp_iptables_outchain ||
 	    igmp_setup[family != AF_INET] == INIT_FAILED)
 		return;
 

--- a/keepalived/vrrp/vrrp_iptables.c
+++ b/keepalived/vrrp/vrrp_iptables.c
@@ -146,6 +146,7 @@ add_del_vip_sets(struct ipt_handle *h, int cmd, uint8_t family, bool reload)
 		remove_vip_ipsets(&h->session, family);
 }
 
+#ifdef HAVE_IPSET_ATTR_IFACE
 static void
 add_del_igmp_sets(struct ipt_handle *h, int cmd, uint8_t family, bool reload)
 {
@@ -154,6 +155,7 @@ add_del_igmp_sets(struct ipt_handle *h, int cmd, uint8_t family, bool reload)
 	else
 		remove_igmp_ipsets(&h->session, family);
 }
+#endif
 
 static void
 add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_errors)
@@ -500,10 +502,12 @@ iptables_fini(void)
 				add_del_vip_sets(h, IPADDRESS_DEL, family, false);
 				vips_setup[family != AF_INET] = NOT_INIT;
 			}
+#ifdef HAVE_IPSET_ATTR_IFACE
 			if (igmp_setup[family != AF_INET] == INIT_SUCCESS) {
 				add_del_igmp_sets(h, IPADDRESS_DEL, family, false);
 				igmp_setup[family != AF_INET] = NOT_INIT;
 			}
+#endif
 			family = family == AF_INET ? AF_INET6 : 0;
 		} while (family);
 

--- a/keepalived/vrrp/vrrp_iptables.c
+++ b/keepalived/vrrp/vrrp_iptables.c
@@ -208,7 +208,6 @@ add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family)
 		}
 	}
 }
-#endif
 
 #if defined _HAVE_VRRP_VMAC_ && defined HAVE_IPSET_ATTR_IFACE
 static void
@@ -248,6 +247,7 @@ add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family)
 		return;
 	}
 }
+#endif
 #endif
 
 static struct ipt_handle*
@@ -346,7 +346,6 @@ check_chains_exist(uint8_t family)
 	return ret;
 }
 
-#if defined _HAVE_VRRP_VMAC_
 static void
 handle_iptable_rule_to_vip(ip_address_t *ipaddress, int cmd, struct ipt_handle *h, bool force)
 {
@@ -524,8 +523,10 @@ handle_iptable_vip_list(struct ipt_handle *h, list ip_list, int cmd, bool force)
 			}
 
 #ifdef _HAVE_LIBIPSET_
-			add_del_vip_sets(h, IPADDRESS_ADD, family);
-			add_del_vip_rules(h, IPADDRESS_ADD, family);
+			if (global_data->using_ipsets) {
+				add_del_vip_sets(h, IPADDRESS_ADD, family);
+				add_del_vip_rules(h, IPADDRESS_ADD, family);
+			}
 #endif
 
 			vips_setup[family != AF_INET] = INIT_SUCCESS;
@@ -598,7 +599,6 @@ handle_iptable_rule_for_igmp(const char *ifname, int cmd, int family, struct ipt
 	}
 
 #ifdef HAVE_IPSET_ATTR_IFACE
-// Check sets with ifname
 	if (global_data->using_ipsets)
 	{
 		if (!h->session)
@@ -624,7 +624,6 @@ handle_iptable_rule_for_igmp(const char *ifname, int cmd, int family, struct ipt
 	iptables_entry(h, family, global_data->vrrp_iptables_outchain, APPEND_RULE,
 			XTC_LABEL_DROP, NULL, &igmp_addr, NULL, ifname,
 			IPPROTO_NONE, 0, cmd, 0, false);
-#endif
 }
 
 static void

--- a/keepalived/vrrp/vrrp_iptables.c
+++ b/keepalived/vrrp/vrrp_iptables.c
@@ -135,37 +135,37 @@ iptables_entry(struct ipt_handle* h, uint8_t family, const char* chain_name, uns
 
 #ifdef _HAVE_LIBIPSET_
 static void
-add_del_vip_sets(struct ipt_handle *h, int cmd, uint8_t family, bool reload)
+add_del_vip_sets(struct ipt_handle *h, int cmd, uint8_t family)
 {
 	if (!global_data->using_ipsets)
 		return;
 
 	if (cmd == IPADDRESS_ADD)
-		add_vip_ipsets(&h->session, family, reload);
+		add_vip_ipsets(&h->session, family, false);
 	else
 		remove_vip_ipsets(&h->session, family);
 }
 
-#ifdef HAVE_IPSET_ATTR_IFACE
+#if defined _HAVE_VRRP_VMAC_ && defined HAVE_IPSET_ATTR_IFACE
 static void
-add_del_igmp_sets(struct ipt_handle *h, int cmd, uint8_t family, bool reload)
+add_del_igmp_sets(struct ipt_handle *h, int cmd, uint8_t family)
 {
 	if (cmd == IPADDRESS_ADD)
-		add_igmp_ipsets(&h->session, family, reload);
+		add_igmp_ipsets(&h->session, family, false);
 	else
 		remove_igmp_ipsets(&h->session, family);
 }
 #endif
 
 static void
-add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_errors)
+add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family)
 {
 	if (family == AF_INET) {
 		if (h->h4 || (h->h4 = ip4tables_open("filter"))) {
 			if (global_data->vrrp_iptables_inchain)
-				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address, IPPROTO_NONE, 0, cmd, ignore_errors);
+				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address, IPPROTO_NONE, 0, cmd, false);
 			if (global_data->vrrp_iptables_outchain)
-				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address, IPPROTO_NONE, 0, cmd, ignore_errors);
+				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address, IPPROTO_NONE, 0, cmd, false);
 		}
 
 		h->updated_v4 = true;
@@ -175,34 +175,34 @@ add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_err
 	if (h->h6 || (h->h6 = ip6tables_open("filter"))) {
 		if (global_data->vrrp_iptables_inchain) {
 #ifdef HAVE_IPSET_ATTR_IFACE
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, ignore_errors);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_TWO_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, false);
 #else
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, ignore_errors);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, false);
 #endif
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_NONE, 0, cmd, ignore_errors);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 135, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 136, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_inchain, APPEND_RULE, IPSET_DIM_ONE, 0, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_NONE, 0, cmd, false);
 
 			h->updated_v6 = true;
 		}
 
 		if (global_data->vrrp_iptables_outchain) {
 #ifdef HAVE_IPSET_ATTR_IFACE
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, ignore_errors);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, false);
 #else
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, ignore_errors);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 135, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_ICMPV6, 136, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address_iface6, IPPROTO_NONE, 0, cmd, false);
 #endif
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 135, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 136, cmd, ignore_errors);
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_NONE, 0, cmd, ignore_errors);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 135, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_ACCEPT, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_ICMPV6, 136, cmd, false);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_ONE, IPSET_DIM_ONE_SRC, XTC_LABEL_DROP, NULL, NULL, global_data->vrrp_ipset_address6, IPPROTO_NONE, 0, cmd, false);
 
 			h->updated_v6 = true;
 		}
@@ -210,9 +210,9 @@ add_del_vip_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_err
 }
 #endif
 
-#ifdef _HAVE_VRRP_VMAC_
+#if defined _HAVE_VRRP_VMAC_ && defined HAVE_IPSET_ATTR_IFACE
 static void
-add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_errors)
+add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family)
 {
 	ip_address_t igmp_addr;
 
@@ -230,11 +230,10 @@ add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_er
 		igmp_addr.u.sin6_addr.s6_addr32[3] = htonl(0x16);
 	}
 
-#ifdef HAVE_IPSET_ATTR_IFACE
 	if (global_data->using_ipsets) {
 		if (family == AF_INET) {
 			if (h->h4 || (h->h4 = ip4tables_open("filter"))) {
-				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, 0, XTC_LABEL_DROP, NULL, &igmp_addr, global_data->vrrp_ipset_igmp, IPPROTO_NONE, 0, cmd, ignore_errors);
+				ip4tables_add_rules(h->h4, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, 0, XTC_LABEL_DROP, NULL, &igmp_addr, global_data->vrrp_ipset_igmp, IPPROTO_NONE, 0, cmd, false);
 				h->updated_v4 = true;
 			}
 
@@ -242,17 +241,12 @@ add_del_igmp_rules(struct ipt_handle *h, int cmd, uint8_t family, bool ignore_er
 		}
 
 		if (h->h6 || (h->h6 = ip6tables_open("filter"))) {
-			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, 0, XTC_LABEL_DROP, NULL, &igmp_addr, global_data->vrrp_ipset_mld, IPPROTO_NONE, 0, cmd, ignore_errors);
+			ip6tables_add_rules(h->h6, global_data->vrrp_iptables_outchain, APPEND_RULE, IPSET_DIM_TWO, 0, XTC_LABEL_DROP, NULL, &igmp_addr, global_data->vrrp_ipset_mld, IPPROTO_NONE, 0, cmd, false);
 			h->updated_v6 = true;
 		}
 
 		return;
 	}
-#endif
-
-	iptables_entry(h, family, global_data->vrrp_iptables_outchain, APPEND_RULE,
-			XTC_LABEL_RETURN, NULL, &igmp_addr, NULL, NULL,
-			IPPROTO_NONE, 0, cmd, IPT_INV_DSTIP, ignore_errors);
 }
 #endif
 
@@ -465,54 +459,48 @@ iptables_init(int family)
 void
 iptables_fini(void)
 {
+#ifdef _HAVE_LIBIPSET_
 	uint8_t family;
 	struct ipt_handle *h;
 
-// TODO - just have a single call to remove all sets
+	if (!global_data->using_ipsets)
+		return;
+
 	h = iptables_open(IPADDRESS_DEL);
 	family = AF_INET;
 	do {
-#ifdef _HAVE_LIBIPSET_
-		if (global_data->using_ipsets) {
-			if (vips_setup[family != AF_INET] == INIT_SUCCESS)
-				add_del_vip_rules(h, IPADDRESS_DEL, family, false);
-			if (igmp_setup[family != AF_INET] == INIT_SUCCESS)
-				add_del_igmp_rules(h, IPADDRESS_DEL, family, false);
-		}
-		else
+		if (vips_setup[family != AF_INET] == INIT_SUCCESS)
+			add_del_vip_rules(h, IPADDRESS_DEL, family);
+#if defined _HAVE_VRRP_VMAC_ && defined HAVE_IPSET_ATTR_IFACE
+		if (igmp_setup[family != AF_INET] == INIT_SUCCESS)
+			add_del_igmp_rules(h, IPADDRESS_DEL, family);
 #endif
-		{
-			if (igmp_setup[family != AF_INET] == INIT_SUCCESS) {
-				add_del_igmp_rules(h, IPADDRESS_DEL, family, false);
-				igmp_setup[family != AF_INET] = NOT_INIT;
-			}
-		}
+
 		family = family == AF_INET ? AF_INET6 : 0;
 	} while (family);
 
 	iptables_close(h);
 
 	/* The sets must not be in use when the ipset session starts */
-#ifdef _HAVE_LIBIPSET_
-	if (global_data->using_ipsets) {
-		h = iptables_open(IPADDRESS_DEL);
-		family = AF_INET;
-		do {
-			if (vips_setup[family != AF_INET] == INIT_SUCCESS) {
-				add_del_vip_sets(h, IPADDRESS_DEL, family, false);
-				vips_setup[family != AF_INET] = NOT_INIT;
-			}
+	h = iptables_open(IPADDRESS_DEL);
+	family = AF_INET;
+	do {
+		if (vips_setup[family != AF_INET] == INIT_SUCCESS) {
+			add_del_vip_sets(h, IPADDRESS_DEL, family);
+			vips_setup[family != AF_INET] = NOT_INIT;
+		}
+#ifdef _HAVE_VRRP_VMAC_
 #ifdef HAVE_IPSET_ATTR_IFACE
-			if (igmp_setup[family != AF_INET] == INIT_SUCCESS) {
-				add_del_igmp_sets(h, IPADDRESS_DEL, family, false);
-				igmp_setup[family != AF_INET] = NOT_INIT;
-			}
+		if (igmp_setup[family != AF_INET] == INIT_SUCCESS)
+			add_del_igmp_sets(h, IPADDRESS_DEL, family);
 #endif
-			family = family == AF_INET ? AF_INET6 : 0;
+		igmp_setup[family != AF_INET] = NOT_INIT;
+#endif
+
+		family = family == AF_INET ? AF_INET6 : 0;
 		} while (family);
 
-		iptables_close(h);
-	}
+	iptables_close(h);
 #endif
 }
 
@@ -536,9 +524,8 @@ handle_iptable_vip_list(struct ipt_handle *h, list ip_list, int cmd, bool force)
 			}
 
 #ifdef _HAVE_LIBIPSET_
-// Is last parameter for next two calls ever used ?
-			add_del_vip_sets(h, IPADDRESS_ADD, family, false);
-			add_del_vip_rules(h, IPADDRESS_ADD, family, false);
+			add_del_vip_sets(h, IPADDRESS_ADD, family);
+			add_del_vip_rules(h, IPADDRESS_ADD, family);
 #endif
 
 			vips_setup[family != AF_INET] = INIT_SUCCESS;
@@ -585,25 +572,28 @@ handle_iptables_accept_mode(vrrp_t *vrrp, int cmd, bool force)
 static inline void
 handle_iptable_rule_for_igmp(const char *ifname, int cmd, int family, struct ipt_handle *h)
 {
+	ip_address_t igmp_addr;
+
 	if (!global_data->vrrp_iptables_outchain ||
 	    igmp_setup[family != AF_INET] == INIT_FAILED)
 		return;
 
 	if (igmp_setup[family != AF_INET] == NOT_INIT) {
-		iptables_init(family);
+		if (setup[family != AF_INET] == NOT_INIT)
+			iptables_init(family);
 
 		if (setup[family != AF_INET] == INIT_FAILED) {
 			igmp_setup[family != AF_INET] = INIT_FAILED;
 			return;
 		}
 
-// Is last parameter for next two calls ever used ?
 #ifdef HAVE_IPSET_ATTR_IFACE
-		if (global_data->using_ipsets)
-			add_del_igmp_sets(h, IPADDRESS_ADD, family, false);
+		if (global_data->using_ipsets) {
+			add_del_igmp_sets(h, IPADDRESS_ADD, family);
+			add_del_igmp_rules(h, IPADDRESS_ADD, family);
+		}
 #endif
 
-		add_del_igmp_rules(h, IPADDRESS_ADD, family, false);
 		igmp_setup[family != AF_INET] = INIT_SUCCESS;
 	}
 
@@ -620,8 +610,19 @@ handle_iptable_rule_for_igmp(const char *ifname, int cmd, int family, struct ipt
 	}
 #endif
 
+	if (family == AF_INET) {
+		igmp_addr.ifa.ifa_family = AF_INET;
+		igmp_addr.u.sin.sin_addr.s_addr = htonl(0xe0000016);
+	} else {
+		igmp_addr.ifa.ifa_family = AF_INET6;
+		igmp_addr.u.sin6_addr.s6_addr32[0] = htonl(0xff020000);
+		igmp_addr.u.sin6_addr.s6_addr32[1] = 0;
+		igmp_addr.u.sin6_addr.s6_addr32[2] = 0;
+		igmp_addr.u.sin6_addr.s6_addr32[3] = htonl(0x16);
+	}
+
 	iptables_entry(h, family, global_data->vrrp_iptables_outchain, APPEND_RULE,
-			XTC_LABEL_DROP, NULL, NULL, NULL, ifname,
+			XTC_LABEL_DROP, NULL, &igmp_addr, NULL, ifname,
 			IPPROTO_NONE, 0, cmd, 0, false);
 #endif
 }

--- a/keepalived/vrrp/vrrp_nftables.c
+++ b/keepalived/vrrp/vrrp_nftables.c
@@ -101,7 +101,9 @@ enum udata_set_type {
 /* Local definitions */
 #define NO_REG (NFT_REG_MAX+1)
 
+#ifdef _HAVE_VRRP_VMAC_
 static const char vmac_map_name[] = "vmac_map";
+#endif
 
 static struct mnl_socket *nl;
 static unsigned int portid;
@@ -351,7 +353,7 @@ add_lookup(struct nftnl_rule *r, uint32_t base, uint32_t dreg, const char *set_n
 	nftnl_rule_add_expr(r, e);
 }
 
-#if HAVE_DECL_NFTA_DUP_MAX
+#if HAVE_DECL_NFTA_DUP_MAX && defined _HAVE_VRRP_VMAC_
 static void
 add_dup(struct nftnl_rule *r, uint32_t addr_reg, uint32_t dev_reg)
 {
@@ -391,7 +393,7 @@ add_immediate_verdict(struct nftnl_rule *r, uint32_t verdict, const char *chain)
 	nftnl_rule_add_expr(r, e);
 }
 
-#if HAVE_DECL_NFTA_DUP_MAX
+#if HAVE_DECL_NFTA_DUP_MAX && defined _HAVE_VRRP_VMAC_
 static void
 add_immediate_data(struct nftnl_rule *r, uint32_t reg, const void *data, uint32_t data_len)
 {
@@ -2001,10 +2003,12 @@ nft_cleanup(void)
 
 	ipv4_table_setup = false;
 	ipv4_vips_setup = false;
-	ipv4_igmp_setup = false;
 	ipv6_table_setup = false;
 	ipv6_vips_setup = false;
+#ifdef _HAVE_VRRP_VMAC_
+	ipv4_igmp_setup = false;
 	ipv6_igmp_setup = false;
+#endif
 	setup_ll_ifname = false;
 	setup_ll_ifindex = false;
 }

--- a/lib/memory.h
+++ b/lib/memory.h
@@ -96,7 +96,7 @@ typedef union _ptr_hack {
 	const void *cp;
 } ptr_hack_t;
 
-#define FREE_CONST(ptr) { ptr_hack_t ptr_hack = { .cp = ptr }; FREE(ptr_hack.p); }
+#define FREE_CONST(ptr) { ptr_hack_t ptr_hack = { .cp = ptr }; FREE(ptr_hack.p); ptr = NULL; }
 #define FREE_CONST_ONLY(ptr) { ptr_hack_t ptr_hack = { .cp = ptr }; FREE_ONLY(ptr_hack.p); }
 #define REALLOC_CONST(ptr, n) ({ ptr_hack_t ptr_hack = { .cp = ptr }; REALLOC(ptr_hack.p, n); })
 


### PR DESCRIPTION
Use either iptables or nftables but not both
Use nftables instead of iptables configuration if the iptables command is iptables-nft
Automatically use nftables if iptables and nftables are not configured and no_accept or vmacs are configured
Various tidying up of the nftables/iptables code