### PR TITLE
Improve handling by parent process of children terminating

### DIFF
--- a/lib/signals.c
+++ b/lib/signals.c
@@ -185,7 +185,7 @@ signal_pending(void)
 /* Signal flag */
 #ifndef HAVE_SIGNALFD
 static void
-signal_handler(uint32_t sig)
+signal_handler(int sig)
 {
 	if (write(signal_pipe[1], &sig, sizeof(uint32_t)) != sizeof(uint32_t))
 		log_message(LOG_INFO, "BUG - write to signal_pipe[1] error %d (%s) - please report", errno, strerror(errno));


### PR DESCRIPTION
Issue #1561 identified that if a child process segfaulted while it was
terminating, the segfault was not reported by the parent process, making
the termination look as though nothig had failed.

This commit now ensures that if a child process does not exit cleanly then
the parent process will report it.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>