### PR TITLE
ipvs: allow to locate ipvs rules in a namespace

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -128,6 +128,11 @@ and
 # Note: the namespace cannot be changed on a configuration reload.
 \fBnet_namespace \fRNAME
 
+# run all ipvs operations within the mentioned namespace. It allows to easily
+# split the VIP traffic on a given namespace and keep the healthchecks traffic
+# in another namespace (such as the root namespace).
+\fBnet_namespace_ipvs\fR
+
 # ipsets wasn't network namespace aware until Linux 3.13, and so
 # if running with # an earlier version of the kernel, by default
 # use of ipsets is disabled if using a namespace and vrrp_ipsets

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -42,6 +42,9 @@
 #include "logger.h"
 #include "libipvs.h"
 #include "main.h"
+#if HAVE_DECL_CLONE_NEWNET
+#include "namespaces.h"
+#endif
 
 static bool no_ipvs = false;
 
@@ -94,6 +97,12 @@ ipvs_start(void)
 			return IPVS_ERROR;
 		}
 	}
+#if HAVE_DECL_CLONE_NEWNET
+	if (global_data->network_namespace_ipvs && init_ipvs_namespaces(global_data->network_namespace_ipvs) < 0) {
+		log_message(LOG_ERR, "Unable to set network namespace for ipvs %s - exiting", global_data->network_namespace_ipvs);
+		return IPVS_ERROR;
+	}
+#endif
 
 	return IPVS_SUCCESS;
 }
@@ -105,6 +114,10 @@ ipvs_stop(void)
 		return;
 
 	ipvs_close();
+#if HAVE_DECL_CLONE_NEWNET
+	if (global_data->network_namespace_ipvs)
+		close_ipvs_namespaces();
+#endif
 }
 
 void

--- a/keepalived/check/libipvs.c
+++ b/keepalived/check/libipvs.c
@@ -53,6 +53,9 @@
 #include "logger.h"
 #include "utils.h"
 
+#if HAVE_DECL_CLONE_NEWNET
+#include "namespaces.h"
+#endif
 
 typedef struct ipvs_servicedest_s {
 	struct ip_vs_service_user	svc;
@@ -247,7 +250,7 @@ open_nl_sock(void)
 	if (!(sock = nl_socket_alloc()))
 		return -1;
 
-	if (genl_connect(sock) < 0 ||
+	if (nl_ipvs_connect(sock) < 0 ||
 	    (family = genl_ctrl_resolve(sock, IPVS_GENL_NAME)) < 0) {
 		nl_socket_free(sock);
 		sock = NULL;
@@ -359,7 +362,8 @@ int ipvs_init(void)
 	try_nl = false;
 #endif
 
-	if ((sockfd = socket(AF_INET, SOCK_RAW | SOCK_CLOEXEC, IPPROTO_RAW)) == -1)
+	sockfd = socket_netns(ipvs_namespace, AF_INET, SOCK_RAW | SOCK_CLOEXEC, IPPROTO_RAW);
+	if (sockfd == -1)
 		return -1;
 
 #if !HAVE_DECL_SOCK_CLOEXEC

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -231,6 +231,10 @@ init_global_data(data_t * data, data_t *prev_global_data, bool copy_unchangeable
 			data->network_namespace = prev_global_data->network_namespace;
 			prev_global_data->network_namespace = NULL;
 
+			FREE_CONST_PTR(data->network_namespace_ipvs);
+			data->network_namespace_ipvs = prev_global_data->network_namespace_ipvs;
+			prev_global_data->network_namespace_ipvs = NULL;
+
 			FREE_CONST_PTR(data->instance_name);
 			data->instance_name = prev_global_data->instance_name;
 			prev_global_data->instance_name = NULL;
@@ -321,6 +325,7 @@ free_global_data(data_t * data)
 	free_list(&data->email);
 #if HAVE_DECL_CLONE_NEWNET
 	FREE_CONST_PTR(data->network_namespace);
+	FREE_CONST_PTR(data->network_namespace_ipvs);
 #endif
 	FREE_CONST_PTR(data->instance_name);
 	FREE_CONST_PTR(data->process_name);
@@ -402,6 +407,7 @@ dump_global_data(FILE *fp, data_t * data)
 
 #if HAVE_DECL_CLONE_NEWNET
 	conf_write(fp, " Network namespace = %s", data->network_namespace ? data->network_namespace : "(default)");
+	conf_write(fp, " Network namespace ipvs = %s", data->network_namespace_ipvs ? data->network_namespace_ipvs : "(default)");
 #endif
 	if (data->instance_name)
 		conf_write(fp, " Instance name = %s", data->instance_name);

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -1427,6 +1427,23 @@ net_namespace_handler(const vector_t *strvec)
 }
 
 static void
+net_namespace_ipvs_handler(const vector_t *strvec)
+{
+	if (!strvec)
+		return;
+
+	if (vector_size(strvec) < 2) {
+		report_config_error(CONFIG_GENERAL_ERROR, "net_namespace_ipvs name missing - ignoring");
+		return;
+	}
+
+	if (!global_data->network_namespace_ipvs)
+		global_data->network_namespace_ipvs = set_value(strvec);
+	else
+		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate net_namespace_ipvs definition %s - ignoring", strvec_slot(strvec, 1));
+}
+
+static void
 namespace_ipsets_handler(const vector_t *strvec)
 {
 	if (!strvec)
@@ -1950,6 +1967,7 @@ init_global_keywords(bool global_active)
 #endif
 #if HAVE_DECL_CLONE_NEWNET
 	install_keyword_root("net_namespace", &net_namespace_handler, global_active);
+	install_keyword_root("net_namespace_ipvs", &net_namespace_ipvs_handler, global_active);
 	install_keyword_root("namespace_with_ipsets", &namespace_ipsets_handler, global_active);
 #endif
 	install_keyword_root("use_pid_dir", &use_pid_dir_handler, global_active);

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -94,8 +94,9 @@ typedef struct _data {
 	const char			*bfd_process_name;
 #endif
 #if HAVE_DECL_CLONE_NEWNET
-	const char			*network_namespace;	/* network namespace name */
-	bool				namespace_with_ipsets;	/* override for namespaces with ipsets on Linux < 3.13 */
+	const char			*network_namespace;		/* network namespace name */
+	const char			*network_namespace_ipvs;	/* network namespace name for ipvs */
+	bool				namespace_with_ipsets;		/* override for namespaces with ipsets on Linux < 3.13 */
 #endif
 	const char			*local_name;
 	const char			*instance_name;		/* keepalived instance name */

--- a/keepalived/include/namespaces.h
+++ b/keepalived/include/namespaces.h
@@ -25,8 +25,24 @@
 
 #include <stdbool.h>
 
+#ifdef LIBIPVS_USE_NL
+#include <netlink/socket.h>
+#ifdef _LIBNL_DYNAMIC_
+#include "libnl_link.h"
+#endif
+#endif
+
 extern void free_dirname(void);
 extern bool set_namespaces(const char*);
 extern void clear_namespaces(void);
+extern int socket_netns(int, int, int, int);
+
+/* ipvs namespaces */
+extern int init_ipvs_namespaces(const char *);
+extern int close_ipvs_namespaces(void);
+#ifdef LIBIPVS_USE_NL
+extern int nl_ipvs_connect(struct nl_sock *);
+#endif
+extern int ipvs_namespace;
 
 #endif


### PR DESCRIPTION
- this patch adds `net_namespace_ipvs` parameter
- when set, ipvs socket is created in the targeted namespace

it allows to properly split traffic between healthchecks and ipvs
without having to use any complex setup with veth/bridge/iptables:
- do the healthcheck traffic in the root namespace
- receive the VIP traffic in a given namespace

the patch had the necessary plumbing for two cases:
- without libnl, we use a generic `socket_netns` function to create given
  socket - if no namespace has been specified, the effect is the same as
  before, we only create a socket. If a namespace was previously
  specified, we first switch to the namespace, then create the socket,
  and move back to the root namespace
  this function could be used in the future in any other extension while
  opening a socket.
- with libnl, it is about the same operation but we do the namespace
  changes around `genl_connect` as it is the function which creates and
  bind the socket.

All this patch is widely inspired by haproxy implementation which allows
to bind each IP in a given namespace.

this is a proposal for github issue #1575