### PR TITLE
build: fix out-of-tree builds when SNMP is enabled

### DIFF
--- a/genhash/Makefile.am
+++ b/genhash/Makefile.am
@@ -4,13 +4,13 @@
 #
 # Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
 
-AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
+AM_CPPFLAGS		= -I$(srcdir)/../lib
+AM_CPPFLAGS		+= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
 AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBTOOLFLAGS	= $(KA_LIBTOOLFLAGS)
 
 bin_PROGRAMS		= genhash
-AM_CPPFLAGS		+= -I$(srcdir)/../lib
 
 genhash_SOURCES		= main.c sock.c layer4.c http.c ssl.c
 genhash_LDADD		= ../lib/liblib.a $(KA_LIBS) $(GENHASH_LIBS)

--- a/keepalived/Makefile.am
+++ b/keepalived/Makefile.am
@@ -4,7 +4,8 @@
 #
 # Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
 
-AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
+AM_CPPFLAGS		= -I$(srcdir)/include -I $(top_srcdir)/lib
+AM_CPPFLAGS		+= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
 AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBTOOLFLAGS	= $(KA_LIBTOOLFLAGS)
@@ -21,8 +22,6 @@ sbin_PROGRAMS		= keepalived
 keepalived_SOURCES	= main.c
 
 noinst_HEADERS		= $(srcdir)/include/*.h
-
-AM_CPPFLAGS		+= -I$(srcdir)/include -I $(top_srcdir)/lib
 
 TRACKER_SUBDIR		= trackers
 TRACKER_LIB		= trackers/libtracker.a

--- a/keepalived/bfd/Makefile.am
+++ b/keepalived/bfd/Makefile.am
@@ -4,7 +4,8 @@
 #
 # Copyright (C) 2017-2017 Alexandre Cassen, <acassen@gmail.com>
 
-AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
+AM_CPPFLAGS		= -I$(srcdir)/../include -I$(srcdir)/../../lib
+AM_CPPFLAGS		+= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
 AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBS		= $(KA_LIBS)
@@ -15,8 +16,6 @@ noinst_LIBRARIES	= libbfd.a
 libbfd_a_SOURCES = \
 	bfd.c bfd_data.c bfd_parser.c bfd_daemon.c bfd_scheduler.c \
 	bfd_event.c
-
-AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 
 EXTRA_libbfd_a_SOURCES =
 libbfd_a_LIBADD =

--- a/keepalived/check/Makefile.am
+++ b/keepalived/check/Makefile.am
@@ -4,7 +4,8 @@
 #
 # Copyright (C) 2001-2018 Alexandre Cassen, <acassen@gmail.com>
 
-AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
+AM_CPPFLAGS		= -I$(srcdir)/../include -I$(srcdir)/../../lib
+AM_CPPFLAGS		+= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
 AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBS		= $(KA_LIBS)
@@ -18,8 +19,6 @@ libcheck_a_SOURCES = \
 	check_smtp.c check_misc.c check_dns.c check_print.c \
 	ipwrapper.c ipvswrapper.c libipvs.c check_udp.c check_ping.c \
 	check_file.c
-
-AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 
 EXTRA_libcheck_a_SOURCES =
 libcheck_a_LIBADD =

--- a/keepalived/core/Makefile.am
+++ b/keepalived/core/Makefile.am
@@ -4,7 +4,8 @@
 #
 # Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
 
-AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS) -DLOCAL_STATE_DIR=\"@localstatedir@\"
+AM_CPPFLAGS		= -I$(srcdir)/../include -I$(srcdir)/../../lib
+AM_CPPFLAGS		+= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS) -DLOCAL_STATE_DIR=\"@localstatedir@\"
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
 AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBS		= $(KA_LIBS)
@@ -14,8 +15,6 @@ noinst_LIBRARIES	= libcore.a
 
 libcore_a_SOURCES	= main.c daemon.c pidfile.c layer4.c smtp.c \
 			  global_data.c global_parser.c keepalived_netlink.c
-
-AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 
 libcore_a_LIBADD =
 EXTRA_libcore_a_SOURCES =

--- a/keepalived/trackers/Makefile.am
+++ b/keepalived/trackers/Makefile.am
@@ -4,13 +4,12 @@
 #
 # Copyright (C) 2001-2020 Alexandre Cassen, <acassen@gmail.com>
 
-AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
+AM_CPPFLAGS		= -I$(srcdir)/../include -I$(srcdir)/../../lib
+AM_CPPFLAGS		+= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
 AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBS		= $(KA_LIBS)
 # AM_LIBTOOLFLAGS	= $(KA_LIBTOOLFLAGS)
-
-AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 
 noinst_LIBRARIES	= libtracker.a
 

--- a/keepalived/vrrp/Makefile.am
+++ b/keepalived/vrrp/Makefile.am
@@ -4,13 +4,12 @@
 #
 # Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
 
-AM_CPPFLAGS		= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
+AM_CPPFLAGS		= -I$(srcdir)/../include -I$(srcdir)/../../lib
+AM_CPPFLAGS		+= $(KA_CPPFLAGS) $(DEBUG_CPPFLAGS)
 AM_CFLAGS		= $(KA_CFLAGS) $(DEBUG_CFLAGS)
 AM_LDFLAGS		= $(KA_LDFLAGS) $(DEBUG_LDFLAGS)
 # AM_LIBS		= $(KA_LIBS)
 # AM_LIBTOOLFLAGS	= $(KA_LIBTOOLFLAGS)
-
-AM_CPPFLAGS		+= -I$(srcdir)/../include -I$(srcdir)/../../lib
 
 noinst_LIBRARIES	= libvrrp.a
 


### PR DESCRIPTION
NetSNMP will add Perl headers to the search path in CPPFLAGS. It
contains `parser.h` which will conflict with Keepalived's one. Just
move the search path for other directories before the remaining
CPPFLAGS to fix this.