### PR TITLE
Fix Document bug: Update configuration_synopsis.rst

### DIFF
--- a/doc/source/configuration_synopsis.rst
+++ b/doc/source/configuration_synopsis.rst
@@ -27,7 +27,7 @@ global_defs                 identify the global def configuration block
 notification_email          email accounts that will receive the notification mail  List
 notification_email_from     email to use when processing “MAIL FROM:” SMTP command  List
 smtp_server remote SMTP     server to use for sending mail notifications            alphanum
-smtp_connection_timeout     specify a timeout for SMTP stream processing            numerical
+smtp_connect_timeout        specify a timeout for SMTP stream processing            numerical
 lvs_id                      specify the name of the LVS director                    alphanum
 ========================    ======================================================  =========
 

--- a/doc/source/configuration_synopsis.rst
+++ b/doc/source/configuration_synopsis.rst
@@ -17,7 +17,7 @@ Global Definitions Synopsis
         **notification_email_from** email
         **smtp_server** host
         **smtp_connect_timeout** num
-        **lvs_id** string
+        **router_id** string
     }
 
 ========================    ======================================================  =========
@@ -28,7 +28,7 @@ notification_email          email accounts that will receive the notification ma
 notification_email_from     email to use when processing “MAIL FROM:” SMTP command  List
 smtp_server remote SMTP     server to use for sending mail notifications            alphanum
 smtp_connect_timeout        specify a timeout for SMTP stream processing            numerical
-lvs_id                      specify the name of the LVS director                    alphanum
+router_id                   specify the name of the LVS director                    string
 ========================    ======================================================  =========
 
 Email type: Is a string using charset as specified into the SMTP RFC eg: “user@domain.com”


### PR DESCRIPTION
The keyword `smtp_connect_timeout` in table is wrongly `smtp_connection_timeout`, so fix it.