### PR TITLE
To facilitate log analysis，all checker timeout logs use the same format

### DIFF
--- a/keepalived/check/check_ping.c
+++ b/keepalived/check/check_ping.c
@@ -328,7 +328,7 @@ icmp_check_thread(thread_ref_t thread)
 	if (thread->type == THREAD_READ_TIMEOUT) {
 		if (checker->is_up &&
 		    (global_data->checker_log_all_failures || checker->log_all_failures))
-			log_message(LOG_INFO, "ICMP connection to address %s Timeout.", FMT_CHK(checker));
+			log_message(LOG_INFO, "ICMP connection to address %s timeout.", FMT_CHK(checker));
 		status = connect_error;
 	} else
 		status = checker->co->dst.ss_family == AF_INET ?

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -166,7 +166,7 @@ tcp_check_thread(thread_ref_t thread)
 	case connect_timeout:
 		if (checker->is_up &&
 		    (global_data->checker_log_all_failures || checker->log_all_failures))
-			log_message(LOG_INFO, "TCP connection to %s timedout."
+			log_message(LOG_INFO, "TCP connection to %s timeout."
 					, FMT_CHK(checker));
 		tcp_epilog(thread, false);
 		break;


### PR DESCRIPTION
Signed-off-by: wangxp006 <wangxiaopeng7@huawei.com>