### PR TITLE
bugfix epoll_count is reversed

### DIFF
--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -649,6 +649,7 @@ thread_event_cancel(const thread_t *thread_cp)
 	rb_erase(&event->n, &m->io_events);
 	if (event == m->current_event)
 		m->current_event = NULL;
+	thread_events_resize(m, -1);
 	FREE(thread->event);
 	return 0;
 }


### PR DESCRIPTION
fix issue#1631
keepalived running too long，which lead to print “scheduler：epoll_wait error ：invalid argument”