### PR TITLE
Fix abnormally DNS checker timer after RS port is down

### DIFF
--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -297,7 +297,7 @@ dns_send(thread_ref_t thread)
 	unsigned long timeout;
 	ssize_t ret;
 
-	timeout = timer_long(thread->sands) - timer_long(time_now);
+	timeout = checker->co->connection_to;
 
 	ret = send(thread->u.f.fd, dns_check->sbuf, dns_check->slen, 0);
 	if (ret == -1) {


### PR DESCRIPTION
thread->sands is letter than time_now, timeout will be a extremely large value。
Timeout should be assigned to the value configured in the configuration file