### PR TITLE
fix-persistence_timeout-range

### DIFF
--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -506,7 +506,7 @@ pto_handler(const vector_t *strvec)
 		return;
 	}
 
-	if (!read_unsigned_strvec(strvec, 1, &timeout, 1, UINT32_MAX, false)) {
+	if (!read_unsigned_strvec(strvec, 1, &timeout, 1, LVS_MAX_TIMEOUT, false)) {
 		report_config_error(CONFIG_GENERAL_ERROR, "persistence_timeout invalid");
 		return;
 	}

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -62,10 +62,6 @@
 #define TASK_COMM_LEN	16
 #endif
 
-#ifdef _WITH_LVS_
-#define LVS_MAX_TIMEOUT		(86400*31)	/* 31 days */
-#endif
-
 /* data handlers */
 /* Global def handlers */
 #ifdef _WITH_LINKBEAT_

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -68,6 +68,10 @@
 #define RX_BUFS_SIZE			0x04
 #endif
 
+#ifdef _WITH_LVS_
+#define LVS_MAX_TIMEOUT			(86400*31)      /* 31 days */
+#endif
+
 /* email link list */
 typedef struct _email {
 	char				*addr;


### PR DESCRIPTION
although it's type is unsigned ,timeout is must <=UINT_MAX / HZ.  ip_vs_add_service function in ipvs module  check it by u->timeout > (UINT_MAX / HZ).  LVS_MAX_TIMEOUT value is 
appropriate. at the same time ipvsadm use 31 days always.