### PR TITLE
Fix build with Linux kernel headers v4.15

### DIFF
--- a/keepalived/vrrp/vrrp_arp.c
+++ b/keepalived/vrrp/vrrp_arp.c
@@ -23,6 +23,7 @@
 #include "config.h"
 
 /* system includes */
+#include <netinet/in.h>
 #include <unistd.h>
 #include <net/ethernet.h>
 #include <net/if_arp.h>

--- a/keepalived/vrrp/vrrp_ndisc.c
+++ b/keepalived/vrrp/vrrp_ndisc.c
@@ -23,11 +23,11 @@
 #include "config.h"
 
 /* system includes */
+#include <netinet/in.h>
 #include <unistd.h>
 #include <net/ethernet.h>
 #include <linux/if_packet.h>
 #include <netinet/icmp6.h>
-#include <netinet/in.h>
 #include <stdint.h>
 #include <errno.h>
 

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -23,6 +23,7 @@
 #include "config.h"
 
 /* global include */
+#include <netinet/in.h>
 #ifdef NETLINK_H_NEEDS_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif


### PR DESCRIPTION
Same issue that was fixed by 947248af144bcab6376ccddab8dc40f313b14281 but raised again when bumping keepalived from version 2.0.15 to 2.1.2 in buildroot

Fixes:
 - http://autobuild.buildroot.org/results/db7f149f63e9180b22460caa74850673362aa17c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>