### PR TITLE
Say what delay_before_retry default value is

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1883,7 +1883,7 @@ The syntax for virtual_server is :
     # of an alive server fails. Default: 1 unless specified below
     \fBretry \fR<INTEGER>
 
-    # delay before retry after failure
+    # delay before retry after failure. Defaults to delay_loop
     \fBdelay_before_retry \fR<TIMER>
 
     # Optional random delay to start the initial check


### PR DESCRIPTION
At least with dns_check on 2.0.20, delay_before_retry defaults to the value of delay_loop.