### PR TITLE
Support rollback if necessary configuration is missing during reload

### DIFF
--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -281,8 +281,12 @@ dns_make_query(thread_ref_t thread)
 		memcpy(p, s, n);
 		p += n;
 	}
-	*(p++) = 0;	/* Terminate the name */
 
+	n = strlen(dns_check->name);
+	if ( n != 1 || dns_check->name[--n] != '.') {
+		*(p++) = 0;
+	}
+	
 	APPEND16(p, dns_check->type);
 	APPEND16(p, 1);		/* IN */
 

--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -281,12 +281,8 @@ dns_make_query(thread_ref_t thread)
 		memcpy(p, s, n);
 		p += n;
 	}
+	*(p++) = 0;	/* Terminate the name */
 
-	n = strlen(dns_check->name);
-	if ( n != 1 || dns_check->name[--n] != '.') {
-		*(p++) = 0;
-	}
-	
 	APPEND16(p, dns_check->type);
 	APPEND16(p, 1);		/* IN */
 

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -416,6 +416,23 @@ checker_log_all_failures_handler(const vector_t *strvec)
 
 	global_data->checker_log_all_failures = res;
 }
+
+static void
+reload_enable_rollback_handler(const vector_t *strvec)
+{
+	int res = true;
+
+	if (vector_size(strvec) >= 2) {
+		res = check_true_false(strvec_slot(strvec,1));
+		if (res < 0) {
+			report_config_error(CONFIG_GENERAL_ERROR, "Invalid value for reload_enable_rollback specified");
+			return;
+		}
+	}
+
+	global_data->reload_enable_rollback = res;
+}
+
 #endif
 #ifdef _WITH_VRRP_
 static void
@@ -1991,6 +2008,7 @@ init_global_keywords(bool global_active)
 #ifdef _WITH_LVS_
 	install_keyword("smtp_alert_checker", &smtp_alert_checker_handler);
 	install_keyword("checker_log_all_failures", &checker_log_all_failures_handler);
+	install_keyword("reload_enable_rollback",   &reload_enable_rollback_handler);
 #endif
 #ifdef _WITH_VRRP_
 	install_keyword("dynamic_interfaces", &dynamic_interfaces_handler);

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -140,7 +140,8 @@ typedef struct _data {
 	int				lvs_tcpfin_timeout;
 	int				lvs_udp_timeout;
 	int				smtp_alert_checker;
-	bool				checker_log_all_failures;
+	bool			checker_log_all_failures;
+	bool			reload_enable_rollback;  /* rollback necessary configuration items are missing in the reload process*/	
 #ifdef _WITH_VRRP_
 	struct lvs_syncd_config		lvs_syncd;
 #endif

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -456,6 +456,7 @@ extern void clear_diff_vrrp(void);
 extern void clear_diff_script(void);
 extern void clear_diff_bfd(void);
 extern void vrrp_restore_interface(vrrp_t *, bool, bool);
+extern void vrrp_notify_fifo_script_exit(__attribute__((unused)) thread_ref_t thread);
 #ifdef THREAD_DUMP
 extern void register_vrrp_fifo_addresses(void);
 #endif

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -259,6 +259,7 @@ extern void cleanup_lost_interface(interface_t *);
 extern void recreate_vmac_thread(thread_ref_t);
 void update_mtu(interface_t *);
 extern void update_added_interface(interface_t *);
+extern void recovery_garp_delay(void);
 #ifdef THREAD_DUMP
 extern void register_vrrp_if_addresses(void);
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -112,7 +112,7 @@ bool do_network_timestamp;
 bool do_checksum_debug;
 #endif
 
-static void
+void
 vrrp_notify_fifo_script_exit(__attribute__((unused)) thread_ref_t thread)
 {
 	log_message(LOG_INFO, "vrrp notify fifo script terminated");

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -459,6 +459,15 @@ start_vrrp(data_t *prev_global_data)
 
 	init_data(conf_file, vrrp_init_keywords);
 
+	if (get_config_misssing_flag() && global_data->reload_enable_rollback && reload) {
+		return;
+	}
+
+	if (get_config_misssing_flag()) {
+		set_config_misssing_flag(false);
+		exit(KEEPALIVED_EXIT_CONFIG);
+	}
+
 	/* Update process name if necessary */
 	if ((!reload && global_data->vrrp_process_name) ||
 	    (reload &&
@@ -759,6 +768,8 @@ reload_vrrp_thread(__attribute__((unused)) thread_ref_t thread)
 	bool start_daemon, stop_daemon;
 	bool start_extra, start_backup, stop_extra, stop_backup;
 #endif
+	timeval_t timer;
+	timer = timer_now();
 
 	log_message(LOG_INFO, "Reloading");
 
@@ -821,6 +832,21 @@ reload_vrrp_thread(__attribute__((unused)) thread_ref_t thread)
 
 	/* Reload the conf */
 	start_vrrp(old_global_data);
+
+	if (get_config_misssing_flag() && global_data->reload_enable_rollback ) {
+		log_message(LOG_INFO, "Got SIGHUP, vrrp new conf failed! Rollback to prev configuration!");
+		set_config_misssing_flag(false);
+		free_vrrp_data(old_vrrp_data);
+		free_global_data(old_global_data);
+		vrrp_data = old_vrrp_data;
+		global_data = old_global_data;
+		recovery_garp_delay();
+		notify_fifo_open(&global_data->notify_fifo, &global_data->vrrp_notify_fifo, vrrp_notify_fifo_script_exit, "vrrp_");
+		UNSET_RELOAD;
+		set_time_now();
+		log_message(LOG_INFO, "Reload finished in %lu usec", -timer_long(timer_sub_now(timer)));
+		return 0;
+	}
 
 #ifdef _WITH_LVS_
 	/* We don't want to stop and start the IPVS sync daemon unnecessarily, so
@@ -887,6 +913,8 @@ reload_vrrp_thread(__attribute__((unused)) thread_ref_t thread)
 	free_old_interface_queue();
 
 	UNSET_RELOAD;
+	set_time_now();
+	log_message(LOG_INFO, "Reload finished in %lu usec", -timer_long(timer_sub_now(timer)));
 }
 
 static void

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -843,6 +843,12 @@ reset_interface_queue(void)
 	}
 }
 
+void recovery_garp_delay(void)
+{
+	free_garp_delay_list(&garp_delay);
+	list_copy(&garp_delay,&old_garp_delay);
+}
+
 void
 init_interface_queue(void)
 {

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -142,6 +142,7 @@ static unsigned int random_seed;
 static bool random_seed_configured;
 static LIST_HEAD_INITIALIZE(seq_list);	/* seq_t */
 static unsigned seq_list_count = 0;
+static bool config_missing_flag = false;
 
 /* Parameter definitions */
 static LIST_HEAD_INITIALIZE(defs); /* def_t */
@@ -200,7 +201,7 @@ null_strvec(const vector_t *strvec, size_t index)
 	else
 		report_config_error(CONFIG_MISSING_PARAMETER, "*** Configuration line starting `%s` is missing a parameter at word position %zu", vector_slot(strvec, 0) ? (char *)vector_slot(strvec, 0) : "***MISSING ***", index + 1);
 
-	exit(KEEPALIVED_EXIT_CONFIG);
+	config_missing_flag = true;
 }
 
 static bool
@@ -2474,3 +2475,16 @@ init_data(const char *conf_file, const vector_t * (*init_keywords) (void))
 #endif
 	notify_resource_release();
 }
+
+bool get_config_misssing_flag(void)
+{
+	return config_missing_flag;
+}
+
+void set_config_misssing_flag(bool flag)
+{
+	config_missing_flag = flag;
+}
+
+
+

--- a/lib/parser.h
+++ b/lib/parser.h
@@ -135,5 +135,6 @@ extern bool read_timer(const vector_t *, size_t, unsigned long *, unsigned long,
 extern int check_true_false(const char *) __attribute__ ((pure));
 extern void skip_block(bool);
 extern void init_data(const char *, const vector_t * (*init_keywords) (void));
-
+extern bool get_config_misssing_flag(void);
+extern void set_config_misssing_flag(bool flag);
 #endif


### PR DESCRIPTION
After the user modifies the keepalived configuration, the process of keepalived will exit if necessary configuration items are missing during the reload process.

For example,  configuration is as follows：
virtual_server 22.22.22.237 80 {
    delay_loop 6
    lb_algo rr
    lb_kind DR
    protocol TCP
    #alpha
    hysteresis 0
    quorum 1
    quorum_up "/usr/sbin/ip addr add 22.22.22.237 dev lo"

    real_server 22.22.83.49 80 {
        weight 1
        HTTP_GET {
            url {
                path /
            }
            connect_port    **# missing checker port**
            connect_timeout 5
            retry 3
            delay_before_retry 3
        }
    }
}
[root@openEuler keepalived]# systemctl status keepalived
● keepalived.service - LVS and VRRP High Availability Monitor
   Loaded: loaded (/usr/lib/systemd/system/keepalived.service; disabled; vendor preset: disabled)
   Active: inactive (dead)

Jun 27 20:58:10 openEuler Keepalived_healthcheckers[28594]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 27 20:58:10 openEuler Keepalived_healthcheckers[28594]: (Line 26) *** Configuration line starting `connect_port` is missing a parameter after keyword `connect_port` at word position 2
Jun 27 20:58:10 openEuler Keepalived_healthcheckers[28594]: (Line 26) WARNING - number '' outside range [1, 65535]
Jun 27 20:58:10 openEuler Keepalived_healthcheckers[28594]: (Line 26) *** Configuration line starting `connect_port` is missing a parameter after keyword `connect_port` at word position 2
Jun 27 20:58:10 openEuler Keepalived_healthcheckers[28594]: (Line 26) Invalid checker connect_port ''
Jun 27 20:58:10 openEuler Keepalived[28593]: pid 28594 exited with permanent error CONFIG. Terminating
Jun 27 20:58:10 openEuler Keepalived[28593]: CPU usage (self/children) user: 0.000000/0.000000 system: 0.002874/0.014846
Jun 27 20:58:10 openEuler systemd[1]: Reloaded LVS and VRRP High Availability Monitor.
Jun 27 20:58:10 openEuler Keepalived[28593]: Stopped Keepalived v2.1.3 (unknown)
Jun 27 20:58:10 openEuler systemd[1]: keepalived.service: Succeeded.


When keepalived exits abnormally, the data in IPVS will not be cleared, leaving dirty data.
[root@openEuler keepalived]# ipvsadm -Ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  22.22.22.237:80 rr
  -> 22.22.83.49:80               Route   1      0      
  
This MR provides a method. When the user configures the reload_enable_rollback configuration, if the configuration after reload is missing the necessary configuration, it does not directly exit abnormally
  Instead, roll back to the previous configuration content and remind the user through the log that the current configuration is missing the configuration
  The test results are as follows:

 root@openEuler keepalived]# systemctl reload keepalived
[root@openEuler keepalived]# systemctl status keepalived
● keepalived.service - LVS and VRRP High Availability Monitor
   Loaded: loaded (/usr/lib/systemd/system/keepalived.service; disabled; vendor preset: disabled)
   Active: active (running) since Sat 2020-06-27 21:00:36 CST; 23s ago
  Process: 28752 ExecStart=/usr/sbin/keepalived $KEEPALIVED_OPTIONS (code=exited, status=0/SUCCESS)
  Process: 28804 ExecReload=/bin/kill -HUP $MAINPID (code=exited, status=0/SUCCESS)
 Main PID: 28753 (keepalived)
    Tasks: 2
   Memory: 4.7M
   CGroup: /system.slice/keepalived.service
           ├─28753 /usr/sbin/keepalived -D
           └─28754 /usr/sbin/keepalived -D

Jun 27 21:00:53 openEuler Keepalived[28753]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: Reloading
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: Got SIGHUP, reloading checker configuration
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: Opening file '/etc/keepalived/keepalived.conf'.
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: (Line 25) *** Configuration line starting `connect_port` is missing a parameter after keyword `connect_port` at word position 2
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: (Line 25) WARNING - number '' outside range [1, 65535]
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: (Line 25) *** Configuration line starting `connect_port` is missing a parameter after keyword `connect_port` at word position 2
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: (Line 25) Invalid checker connect_port ''
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: Got SIGHUP, check new conf failed! Rollback to prev configuration!
Jun 27 21:00:53 openEuler Keepalived_healthcheckers[28754]: Reload finished in 395 usec
 
The configuration is as follows
 global_defs {
        **reload_enable_rollback   on**
 }

virtual_server 22.22.22.237 80 {
    delay_loop 6
    lb_algo rr
    lb_kind DR
    protocol TCP
    #alpha
    hysteresis 0
    quorum 1
    quorum_up "/usr/sbin/ip addr add 22.22.22.237 dev lo"

    real_server 22.22.83.49 80 {
        weight 1
        HTTP_GET {
            ## all urls should work
            url {
                path /
            }
            connect_port   **# missing checker port**
            connect_timeout 5
            retry 3
            delay_before_retry 3
        }
    }

}


