### PR TITLE
[doc] MCast address normally is in 244.0.0.0/24

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -233,8 +233,8 @@ and
     # (default: local host name)
     \fBrouter_id \fR<STRING>
 
-    # Multicast Group to use for IPv4 VRRP adverts
-    # (default: 224.0.0.18)
+    # Multicast Group to use for IPv4 VRRP adverts (default: 224.0.0.18).
+    # An RFC5771 "Local subnetwork" address must be in 244.0.0.0/24
     \fBvrrp_mcast_group4 \fR224.0.0.18
 
     # Multicast Group to use for IPv6 VRRP adverts


### PR DESCRIPTION
Clearify, that in normal case, a Keepalived multicast group address is of RFC5771 type "Local subnetwork" address and therefore must be in 244.0.0.0/24.