### PR TITLE
[doc]  Typically don't change default MCast address

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -234,7 +234,8 @@ and
     \fBrouter_id \fR<STRING>
 
     # Multicast Group to use for IPv4 VRRP adverts
-    # (default: 224.0.0.18)
+    # Defaults to the RFC5798 IANA assigned VRRP multicast address 224.0.0.18
+    # which You typically do not want to change.
     \fBvrrp_mcast_group4 \fR224.0.0.18
 
     # Multicast Group to use for IPv6 VRRP adverts


### PR DESCRIPTION
Since I have two keepalived clusters (old one and new one) in the same LAN in parallel,
I wanted to be sure that they do not intefere with VRRP messages. Since authentication is deprecated and should no be used,
I did not want to only rely on the virtual router ID, but also use a separate multicast address for the second cluster.
So I set vrrp_mcast_group4 to 224.0.**10**.18 without researching multicast address assigning (and here in the doc was nothing said about which address one could set).
But with 224.0.**10**.18 there came the message "Receive advertisement timeout" and both nodes had the virtual IP addresses (split brain).
So, VRRP simply did not work.
Then I researched and saw that the network where the default address 224.0.0.18 is in, is 224.0.0.0/24.
So I changed vrrp_mcast_group4 to 224.0.0.**2**8 and with this address, VRRP works.

I do not know what other networks could work also, but at least address 224.0.**10**.18 does not work.
So, with "normal" I mean using the network in which the default address is in.
