### PR TITLE
dns_checker cannot go online correctly when using the default dns name '.'

### DIFF
--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -281,7 +281,9 @@ dns_make_query(thread_ref_t thread)
 		memcpy(p, s, n);
 		p += n;
 	}
-	*(p++) = 0;	/* Terminate the name */
+	
+	if (dns_check->name[0] != '.' || dns_check->name[1] != '\0')
+		*(p++) = 0;
 
 	APPEND16(p, dns_check->type);
 	APPEND16(p, 1);		/* IN */


### PR DESCRIPTION
**When using dns_checker, if the type and name are not configured, the default type SOA and the default name ‘.’ will be used. When the default value is used, it cannot go online.
```
	dns_check->type = DNS_DEFAULT_TYPE;
	dns_check->name = DNS_DEFAULT_NAME;
```
The configuration file is as follows:**

```
virtual_server 22.22.4.149 53 {
    delay_loop 6
    lb_algo rr
    lb_kind DR
    protocol UDP
    alpha
    hysteresis 0
    quorum 1
    quorum_up "/usr/sbin/ip addr add 22.22.4.149 dev lo"

    real_server 22.22.38.68 53 {
        weight 2
        DNS_CHECK {
            connect_port 53
            connect_timeout 1
            retry 1
            bindto 22.22.24.104
        }
    }
}
```

[root@openEuler keepalived]# ipvsadm -Ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
UDP  22.22.4.149:53 rr

**I noticed that the current problem was caused by the modification of #1463. The previous modification fixed the problem that the name could not go online when the last character was '.'.  
But this modification makes the dns name  '.’ of the root zone can not be parsed.**

**The revised verification report is as follows:
1. The last character of dns name is '.'**
```
virtual_server 22.22.4.149 53 {
    delay_loop 6
    lb_algo rr
    lb_kind DR
    protocol UDP
    #alpha
    hysteresis 0
    quorum 1
    quorum_up "/usr/sbin/ip addr add 22.22.4.149 dev lo"

    real_server 22.22.38.68 53 {
        weight 2
        DNS_CHECK {
            connect_port 53
            connect_timeout 1
            retry 1
            type A
            name lvs-test.com.
            bindto 22.22.24.104
        }
    }
}
```
[root@openEuler keepalived]# ipvsadm -Ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
UDP  22.22.4.149:53 rr
  -> 22.22.38.68:53               Route   2      0          0     


**2. default dns name is ‘.’**
```
virtual_server 22.22.4.149 53 {
    delay_loop 6
    lb_algo rr
    lb_kind DR
    protocol UDP
    alpha
    hysteresis 0
    quorum 1
    quorum_up "/usr/sbin/ip addr add 22.22.4.149 dev lo"

    real_server 22.22.38.68 53 {
        weight 2
        DNS_CHECK {
            connect_port 53
            connect_timeout 1
            retry 1
            bindto 22.22.24.104
        }
    }
}

```

[root@openEuler keepalived]# ipvsadm -Ln
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
UDP  22.22.4.149:53 rr
  -> 22.22.38.68:53               Route   2      0          0 