### PR TITLE
fix failure of udp checker caused leakage of fd

### DIFF
--- a/keepalived/check/check_udp.c
+++ b/keepalived/check/check_udp.c
@@ -220,8 +220,10 @@ udp_connect_thread(thread_ref_t thread)
 	status = udp_bind_connect(fd, co);
 
 	/* handle udp connection status & register check worker thread */
-	if (udp_icmp_check_state(fd, status, thread, udp_check_thread, co->connection_to))
+	if (udp_icmp_check_state(fd, status, thread, udp_check_thread, co->connection_to)) {
+		close(fd);
 		udp_epilog(thread, false);
+	}
 
 	return;
 }


### PR DESCRIPTION
close fd to avoid leak when udp checker failed 