### PR TITLE
Fix misc_check log of failed retry check

### DIFF
--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -435,8 +435,20 @@ misc_check_child_thread(thread_ref_t thread)
 	if (script_exit_type) {
 		char message[40];
 
-		if (!script_success && checker->retry)
-			snprintf(message, sizeof(message), " after %u retries", checker->retry);
+		if (!script_success)
+			/*
+			 * retry is always the fixed value of config parameter retry
+			 * If retry > 0 then on the regular scheduled check fail retry_it is 1, on the first retry check fail retry_it is 2 and so on
+			 * but on the last retry check fail, retry_it is 0
+			 */
+			if (checker->retry)
+				if (checker->retry_it == 1) /* fail on regulary scheduled check */
+					snprintf(message, sizeof(message), ", will do %u %s", checker->retry, checker->retry > 1 ? "retries" : "retry");
+				else /* fail on retry check */
+					snprintf(message, sizeof(message), " on retry %u/%u", checker->retry_it ? checker->retry_it - 1 : checker->retry, checker->retry);
+			else
+				snprintf(message, sizeof(message), " with retry disabled");
+
 		else
 			message[0] = '\0';
 


### PR DESCRIPTION
With keepalived 2.0.20 a failed misc_check with retry=2 is logged as following:
```
Jul  1 15:51:33 nodename Keepalived_healthcheckers[30447]: Misc check for [[10.7.2.223]:tcp:53 VS [10.7.2.26]:tcp:53] by [/usr/bin/dig] failed after 2 retries (exited with status 9).
Jul  1 15:51:43 nodename Keepalived_healthcheckers[30447]: Misc check for [[10.7.2.223]:tcp:53 VS [10.7.2.26]:tcp:53] by [/usr/bin/dig] failed after 2 retries (exited with status 9).
Jul  1 15:51:53 nodename Keepalived_healthcheckers[30447]: Misc check for [[10.7.2.223]:tcp:53 VS [10.7.2.26]:tcp:53] by [/usr/bin/dig] failed after 2 retries (exited with status 9).
Jul  1 15:51:53 nodename Keepalived_healthcheckers[30447]: Removing service [10.7.2.223]:tcp:53 to VS [10.7.2.26]:tcp:53
```
So there always is printed "failed after 2 retries". I tested with retry=4 then there is always printed "failed after 4 retries". So this is a bug.

My patch should correct the log to:
```
Jul  1 15:51:33 nodename Keepalived_healthcheckers[30447]: Misc check for [[10.7.2.223]:tcp:53 VS [10.7.2.26]:tcp:53] by [/usr/bin/dig] failed, will retry (exited with status 9).
Jul  1 15:51:43 nodename Keepalived_healthcheckers[30447]: Misc check for [[10.7.2.223]:tcp:53 VS [10.7.2.26]:tcp:53] by [/usr/bin/dig] failed on retry 1/2 (exited with status 9).
Jul  1 15:51:53 nodename Keepalived_healthcheckers[30447]: Misc check for [[10.7.2.223]:tcp:53 VS [10.7.2.26]:tcp:53] by [/usr/bin/dig] failed on retry 2/2 (exited with status 9).
Jul  1 15:51:53 nodename Keepalived_healthcheckers[30447]: Removing service [10.7.2.223]:tcp:53 to VS [10.7.2.26]:tcp:53
```
so there is logged ", will retry" on the first failed check. Then there is logged "failed on retry 1/2" for the first of two retries, "failed on retry 2/2" for the second (and last) of two retries, before the real server is removed from the virtual server.
For retry=0, there will be logged ", will not retry" on the one and only failed check, before real server is removed.