### PR TITLE
tcp checker and dns checker will not go offline when interface link to RS is down

### DIFF
--- a/keepalived/check/check_dns.c
+++ b/keepalived/check/check_dns.c
@@ -433,10 +433,7 @@ dns_connect_thread(thread_ref_t thread)
 	/* handle connection status & register check worker thread */
 	if (socket_connection_state(fd, status, thread, dns_check_thread, co->connection_to)) {
 		close(fd);
-		dns_log_message(thread, LOG_INFO,
-				"UDP socket bind failed. Rescheduling.");
-		thread_add_timer(thread->master, dns_connect_thread, checker,
-				 checker->delay_loop);
+		dns_final(thread, true, "UDP socket bind failed. Rescheduling.");
 	}
 }
 

--- a/keepalived/check/check_tcp.c
+++ b/keepalived/check/check_tcp.c
@@ -226,6 +226,7 @@ tcp_connect_thread(thread_ref_t thread)
 			tcp_epilog(thread, false);
 		} else {
 			log_message(LOG_INFO, "TCP socket bind failed. Rescheduling.");
+			tcp_epilog(thread, false);
 			thread_add_timer(thread->master, tcp_connect_thread, checker,
 					checker->delay_loop);
 		}


### PR DESCRIPTION
tcp checker and dns checker will not go offline when interface link to RS is down
Detail is here #1679 