### PR TITLE
Document checker_log_all_failures for MISC_CHECK

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -221,9 +221,8 @@ and
     # Sets default state for checker smtp_alerts
     \fBsmtp_alert_checker \fR<BOOL>
 
-    # Logs every failed real server check in syslog
-    # (nevertheless, SMTP alert is only sent when all retry checks failed
-    # and real server transitions to DOWN state)
+    # Logs every failed real server check in syslog.
+    # For MISC_CHECK, this force-enables no_checker_emails
     \fBchecker_log_all_failures \fR<BOOL>
 
     # Don't send smtp alerts for fault conditions


### PR DESCRIPTION
At least for MISC_CHECK, there is a special handling of checker_log_all_failures: It force-enables no_checker_emails.
At least for DNS_CHECK, there is not this force-enabling of no_checker_emails.

See check_misc.c:

    if (global_data->checker_log_all_failures || checker->log_all_failures)
    message_only = true;


and then:

    if (!message_only) {
    rs_was_alive = checker->rs->alive;
    update_svr_checker_state(script_success ? UP : DOWN, checker);
     
    if (checker->rs->smtp_alert &&
        (rs_was_alive != checker->rs->alive || !global_data->no_checker_emails)) {
    snprintf(message, sizeof(message), "=> MISC CHECK %s on service <=", script_exit_type);
    smtp_alert(SMTP_MSG_RS, checker, NULL, message);
    }
    }