### PR TITLE
Fix misc_check logging

### DIFF
--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -392,7 +392,7 @@ misc_check_child_thread(thread_ref_t thread)
 				if (global_data->checker_log_all_failures || checker->log_all_failures)
 					message_only = true;
 				else
-					script_exit_type = NULL;
+					script_exit_type = NULL; /* this disables all message handling */
 			} else {
 				checker->retry_it = 0;
 				misck_checker->last_exit_code = status;
@@ -426,33 +426,30 @@ misc_check_child_thread(thread_ref_t thread)
 				if (global_data->checker_log_all_failures || checker->log_all_failures)
 					message_only = true;
 				else
-					script_exit_type = NULL;
+					script_exit_type = NULL; /* this disables all message handling */
 			} else
 				checker->retry_it = 0;
 		}
 	}
 
-	if (script_exit_type) {
+	if (script_exit_type) { /* not the case if retry check will follow and log_all_failures unset */
 		char message[40];
 
 		if (!script_success) {
-			if (!checker->log_all_failures) {
-				if (checker->retry)
-					snprintf(message, sizeof(message), " after %u retries", checker->retry);
-			} else {
-				/*
-				 * retry is always the fixed value of config parameter retry
-				 * If retry > 0 then on the regular scheduled check fail retry_it is 1, on the first retry check fail retry_it is 2 and so on
-				 * but on the last retry check fail, retry_it is 0
-				 */
-				if (checker->retry)
-					if (checker->retry_it == 1) /* fail on regulary scheduled check */
-						snprintf(message, sizeof(message), ", will do %u %s", checker->retry, checker->retry > 1 ? "retries" : "retry");
-					else /* fail on retry check */
-						snprintf(message, sizeof(message), " on retry %u/%u", checker->retry_it ? checker->retry_it - 1 : checker->retry, checker->retry);
-				else
-					snprintf(message, sizeof(message), " with retry disabled");
-			}
+			/*
+			 * retry is always the fixed value of config parameter retry
+			 * If retry > 0 then on the regulary scheduled check fail retry_it is 1, on the first retry check fail retry_it is 2 and so on
+			 * but on the last retry check fail, retry_it is 0
+			 */
+			if (checker->retry) {
+				if (checker->retry_it == 1) /* failed regulary scheduled check */
+					snprintf(message, sizeof(message), ", will do %u %s", checker->retry, checker->retry == 1 ? "retry" : "retries");
+				else if (checker->retry_it > 1) /* failed retry check, but not the last */
+					snprintf(message, sizeof(message), " on retry %u/%u", checker->retry_it - 1, checker->retry);
+				else /* failed last retry check */
+					snprintf(message, sizeof(message), " after %u %s", checker->retry, checker->retry == 1 ? "retry" : "retries" );
+			} else /* retry 0 */
+				snprintf(message, sizeof(message), " with retry disabled");
 		} else
 			message[0] = '\0';
 


### PR DESCRIPTION
I saw there was a bug in line
https://github.com/acassen/keepalived/blob/141c341feefd6391e955ecf825b321d90d396f61/keepalived/check/check_misc.c#L439
because if `global_data->checker_log_all_failures` is true, `checker->log_all_failures` is still _false_, so there was again the effect that with checker_log_all_failures globally set, there was on every recheck logged "failed after x retries" (see #1676). This is fixed with this patch.

This also handles the case of 1 retry correctly, so there would not be logged "failed after 1 retries" anymore.

This makes also the logging identically in both cases of `checker_log_all_failures` being set or unset. The only difference is, that with `checker_log_all_failures` set, the checks before the last will be logged. But the last check (or the only check if retry=0) is logged the same.

I hope the code comments are acceptable. The code is complicated and not easy to understand, so I tried to comment a little.

I tested the different combinations, here the log output with this patch:

**checker_log_all_failures nowhere set**

retry=0
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed with retry disabled (exited with status 9).
```
retry=1
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed after 1 retry (exited with status 9).
```
retry=2
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed after 2 retries (exited with status 9).
```
retry=3
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed after 3 retries (exited with status 9).
```
**checker_log_all_failures globally set**
(not defined in the RS definitions)

retry=0
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed with retry disabled (exited with status 9).
```

retry=1
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed, will do 1 retry (exited with status 9).
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed after 1 retry (exited with status 9).
```

retry=2
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed, will do 2 retries (exited with status 9).
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed on retry 1/2 (exited with status 9).
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed after 2 retries (exited with status 9).
```

retry=3
```
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed, will do 3 retries (exited with status 9).
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed on retry 1/3 (exited with status 9).
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed on retry 2/3 (exited with status 9).
Misc check for [[10.7.2.223]:udp:53 VS [10.7.2.26]:udp:53] by [/usr/bin/dig] failed after 3 retries (exited with status 9).
```