### PR TITLE
support validate configuration before reload

### DIFF
--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -416,6 +416,37 @@ checker_log_all_failures_handler(const vector_t *strvec)
 
 	global_data->checker_log_all_failures = res;
 }
+
+static void
+test_config_before_reload_handler(const vector_t *strvec)
+{
+	int res = true;
+
+	if (vector_size(strvec) >= 2) {
+		res = check_true_false(strvec_slot(strvec,1));
+		if (res < 0) {
+			report_config_error(CONFIG_GENERAL_ERROR, "Invalid value for test_config_before_reload specified");
+			return;
+		}
+	}
+
+	global_data->test_config_before_reload = res;
+	if (!global_data->reload_check_log_path)
+		global_data->reload_check_log_path = STRDUP("/dev/null");
+}
+
+
+static void
+reload_check_log_path_handler(const vector_t *strvec)
+{
+	if (vector_size(strvec) < 2) {
+		report_config_error(CONFIG_GENERAL_ERROR, "default reload_check_log_path  /dev/null");
+		return;
+	}
+	FREE_CONST_PTR(global_data->reload_check_log_path);
+	global_data->reload_check_log_path = set_value(strvec);
+}
+
 #endif
 #ifdef _WITH_VRRP_
 static void
@@ -1993,6 +2024,8 @@ init_global_keywords(bool global_active)
 #ifdef _WITH_LVS_
 	install_keyword("smtp_alert_checker", &smtp_alert_checker_handler);
 	install_keyword("checker_log_all_failures", &checker_log_all_failures_handler);
+	install_keyword("test_config_before_reload",   &test_config_before_reload_handler);
+	install_keyword("reload_check_log_path",   &reload_check_log_path_handler);
 #endif
 #ifdef _WITH_VRRP_
 	install_keyword("dynamic_interfaces", &dynamic_interfaces_handler);

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -143,6 +143,8 @@ typedef struct _data {
 	struct lvs_syncd_config		lvs_syncd;
 	bool				lvs_flush;		/* flush any residual LVS config at startup */
 	lvs_flush_t			lvs_flush_onstop;	/* flush any LVS config at shutdown */
+	bool			    test_config_before_reload;  /* rollback necessary configuration items are missing in the reload process*/	
+	const char			*reload_check_log_path;
 #endif
 	int				max_auto_priority;
 	long				min_auto_priority_delay;

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -364,6 +364,14 @@ save_cmd_line_options(int argc, char * const *argv)
 	sav_argv = argv;
 }
 
+char **
+get_cmd_line_options(int * argc)
+{
+	*argc = sav_argc;
+	return sav_argv;
+}
+
+
 static const char *
 get_end(const char *str, size_t max_len)
 {

--- a/lib/scheduler.h
+++ b/lib/scheduler.h
@@ -224,6 +224,8 @@ extern bool do_script_debug;
 /* Prototypes. */
 extern void set_child_finder_name(char const * (*)(pid_t));
 extern void save_cmd_line_options(int, char * const *);
+extern char ** get_cmd_line_options(int * argc);
+
 extern void log_command_line(unsigned);
 #ifndef _ONE_PROCESS_DEBUG_
 extern unsigned calc_restart_delay(const timeval_t *, unsigned *, const char *);


### PR DESCRIPTION
According to the solution discussed in the previous PR(#1669), modify the function of rolling back the reload if the configuration item is incorrect

The specific modification contents are as follows:
1. Added configuration items test_config_before_reload and  reload_check_log_path.
test_config_before_reload on                //enable the function of checking the configuration file before reload
reload_check_log_path "/var/log/messages"   //Specifies the location for storing logs during configuration check. the default value is/dev/null

2. When test_config_before_reload is enabled, fork a new process.
The new process inherits the start parameter of the main process and adds the--config-test parameter to check whether the new configuration item is OK

3.After the new process is executed, check whether the validate is OK according to the exit code. if the new configuration is OK, continue to reload; otherwise, do not reload.