### PR TITLE
 Modify HTTP retry logs to make them consistent with other checkers

### DIFF
--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -1017,7 +1017,7 @@ epilog(thread_ref_t thread, register_checker_t method)
 		if (checker->is_up || !checker->has_run) {
 			if (checker->has_run && checker->retry)
 				log_message(LOG_INFO
-				   , "HTTP_CHECK on service %s failed after %u retry."
+				   , "HTTP_CHECK on service %s failed after %u retries."
 				   , FMT_CHK(checker)
 				   , checker->retry_it - 1);
 			else


### PR DESCRIPTION
When exceeding  the check failed threshold ,  HTTP logs is inconsistent with other checkers logs. modify the logs to make them consistent with other logs。
This  is helpful when parsing logs with scripts

Aug  3 15:03:32 openEuler Keepalived_healthcheckers[87646]: UDP_CHECK on service [22.22.52.199]:udp:53 failed after 1 **retries**.
Aug  3 15:04:00 openEuler Keepalived_healthcheckers[87646]: HTTP_CHECK on service [22.22.52.199]:tcp:443 failed after 3 **retry.**
Aug  3 15:06:12 openEuler Keepalived_healthcheckers[87646]: DNS_CHECK ([22.22.8.53]:udp:53) read timeout from socket after 1 **retries**
Aug  3 15:06:12 openEuler Keepalived_healthcheckers[87646]: TCP_CHECK on service [22.22.8.53]:tcp:5001 failed after 1 **retries**