### PR TITLE
Removing conflicting vrrp param documentaion

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -311,12 +311,12 @@ and
     # (default: 1)
     \fBvrrp_garp_master_refresh_repeat \fR2
 
-    # Delay in ms between gratuitous ARP messages sent on an interface
+    # Delay between gratuitous ARP messages sent on an interface
     # decimal, seconds (resolution usecs).
     # (default: 0)
     \fBvrrp_garp_interval \fR0.001
 
-    # Delay in ms between unsolicited NA messages sent on an interface
+    # Delay between unsolicited NA messages sent on an interface
     # decimal, seconds (resolution usecs).
     # (default: 0)
     \fBvrrp_gna_interval \fR0.000001


### PR DESCRIPTION
Config docs seem to indicate the value is both ms and seconds