### PR TITLE
Fix documentation of "ops" parameter

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -1807,7 +1807,7 @@ The syntax for virtual_server is :
     \fBmh-port\fR
     # Enable mh-fallback for mh scheduler  (-b mh-fallback in ipvsadm)
     \fBmh-fallback\fR
-    # Enable One-Packet-Scheduling for UDP (-O in ipvsadm)
+    # Enable One-Packet-Scheduling for UDP (-o in ipvsadm)
     \fBops\fR
 
     # Override default LVS forwarding method (default is NAT).


### PR DESCRIPTION
It's -o, not -O in ipvsadm, see
https://kernel.googlesource.com/pub/scm/utils/kernel/ipvsadm/ipvsadm/+/b18edce035ad01cd1828573275cbf221a3ac02c6/ipvsadm.8