### PR TITLE
parser: report_config_error when failing opening a file

### DIFF
--- a/doc/man/man5/keepalived.conf.5
+++ b/doc/man/man5/keepalived.conf.5
@@ -700,6 +700,9 @@ and
     # if the configuration is valid.
     \fBreload_check_config \fR[LOG_FILE]
 
+    # Treat each all globals config issues as config errors
+    \fBglob_strict \fR[LOG_FILE]
+
     # reload_time_file allows a reload of keepalived to be scheduled in the future. This is
     # particularly useful if there is a master keepalived and one or more backup keepalived
     # instances and the new configuration is incompatible with the previous configuration,

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -1986,6 +1986,12 @@ random_seed_handler(const vector_t *strvec)
 
 #ifndef _ONE_PROCESS_DEBUG_
 static void
+glob_strict_handler(__attribute__((unused)) const vector_t *strvec)
+{
+	glob_strict_set();
+}
+
+static void
 reload_check_config_handler(const vector_t *strvec)
 {
 	if (vector_size(strvec) >= 2) {
@@ -2223,5 +2229,6 @@ init_global_keywords(bool global_active)
 	install_keyword("reload_time_file", &reload_time_file_handler);
 	install_keyword("reload_repeat", &reload_repeat_handler);
 	install_keyword("reload_file", &reload_file_handler);
+	install_keyword("glob_strict", &glob_strict_handler);
 #endif
 }

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -142,6 +142,7 @@ bool do_parser_debug;
 #ifdef _DUMP_KEYWORDS_
 bool do_dump_keywords;
 #endif
+bool glob_strict = false;
 
 /* local vars */
 static vector_t *current_keywords;
@@ -1975,14 +1976,21 @@ open_conf_file(include_file_t *file)
 
 		if (file->globbuf.gl_pathv[i][strlen(file->globbuf.gl_pathv[i])-1] == '/') {
 			/* This is a directory - so skip */
+			if (glob_strict)
+				report_config_error(CONFIG_GENERAL_ERROR, "Configuration file '%s' is a directory - skipping"
+						, file->globbuf.gl_pathv[i]);
 			continue;
 		}
 
 		log_message(LOG_INFO, "Opening file '%s'.", file->globbuf.gl_pathv[i]);
 		stream = fopen(file->globbuf.gl_pathv[i], "r");
 		if (!stream) {
-			log_message(LOG_INFO, "Configuration file '%s' open problem (%s) - skipping"
-				       , file->globbuf.gl_pathv[i], strerror(errno));
+			if (!glob_strict)
+				log_message(LOG_INFO, "Configuration file '%s' open problem (%s) - skipping"
+					       , file->globbuf.gl_pathv[i], strerror(errno));
+			else
+				report_config_error(CONFIG_GENERAL_ERROR, "Configuration file '%s' open problem (%s) - skipping"
+						, file->globbuf.gl_pathv[i], strerror(errno));
 			continue;
 		}
 
@@ -1990,7 +1998,10 @@ open_conf_file(include_file_t *file)
 		if (fstat(fileno(stream), &stb) ||
 		    !S_ISREG(stb.st_mode) ||
 		    (stb.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
-			log_message(LOG_INFO, "Configuration file '%s' is not a regular non-executable file - skipping", file->globbuf.gl_pathv[i]);
+			if (!glob_strict)
+				log_message(LOG_INFO, "Configuration file '%s' is not a regular non-executable file - skipping", file->globbuf.gl_pathv[i]);
+			else
+				report_config_error(CONFIG_GENERAL_ERROR, "Configuration file '%s' is not a regular non-executable file - skipping", file->globbuf.gl_pathv[i]);
 			fclose(stream);
 			continue;
 		}
@@ -2020,8 +2031,12 @@ open_conf_file(include_file_t *file)
 
 			char *confpath = STRDUP(file->globbuf.gl_pathv[i]);
 			dirname(confpath);
-			if (chdir(confpath) < 0)
-				log_message(LOG_INFO, "chdir(%s) error (%s)", confpath, strerror(errno));
+			if (chdir(confpath) < 0) {
+				if (!glob_strict)
+					log_message(LOG_INFO, "chdir(%s) error (%s)", confpath, strerror(errno));
+				else
+					report_config_error(CONFIG_GENERAL_ERROR, "chdir(%s) error (%s)", confpath, strerror(errno));
+			}
 			FREE(confpath);
 		} else
 			file->curdir_fd = -1;
@@ -2049,16 +2064,26 @@ open_glob_file(const char *conf_file)
 						    , NULL, &file->globbuf);
 
 	if (res) {
-		if (res == GLOB_NOMATCH)
-			log_message(LOG_INFO, "No config files matched '%s'.", conf_file);
-		else
-			log_message(LOG_INFO, "Error reading config file(s): glob(\"%s\") returned %d, skipping.", conf_file, res);
+		if (res == GLOB_NOMATCH) {
+			if (!glob_strict)
+				log_message(LOG_INFO, "No config files matched '%s'.", conf_file);
+			else
+				report_config_error(CONFIG_GENERAL_ERROR, "No config files matched '%s'.", conf_file);
+		} else {
+			if (!glob_strict)
+				log_message(LOG_INFO, "Error reading config file(s): glob(\"%s\") returned %d, skipping.", conf_file, res);
+			else
+				report_config_error(CONFIG_GENERAL_ERROR, "Error reading config file(s): glob(\"%s\") returned %d, skipping.", conf_file, res);
+		}
 		FREE(file);
 		return false;
 	}
 
 	if (!open_conf_file(file)) {
-		log_message(LOG_INFO, "%s - no matching file", conf_file);
+		if (!glob_strict)
+			log_message(LOG_INFO, "%s - no matching file", conf_file);
+		else
+			report_config_error(CONFIG_GENERAL_ERROR, "%s - no matching file", conf_file);
 
 		globfree(&file->globbuf);
 		FREE(file);
@@ -2906,4 +2931,9 @@ set_config_fd(int fd)
 		rewind(conf_copy);
 	} else
 		log_message(LOG_INFO, "Unable to open config copy file (%d) - %m", errno);
+}
+
+void glob_strict_set(void)
+{
+	glob_strict = true;
 }

--- a/lib/parser.h
+++ b/lib/parser.h
@@ -144,5 +144,6 @@ extern void init_data(const char *, const vector_t * (*init_keywords) (void), bo
 extern void truncate_config_copy(void);
 extern int get_config_fd(void);
 extern void set_config_fd(int);
+void glob_strict_set(void);
 
 #endif


### PR DESCRIPTION
while using `reload_check_config`, it is useful to make sure to fail
when the config file or its includes are not possible to be open.

it will avoid a situation where a reload continues to happen while an
important config included cannot be open.