### PR TITLE
trackers: fix building with gcc

### DIFF
--- a/keepalived/trackers/track_file.c
+++ b/keepalived/trackers/track_file.c
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <inttypes.h>
 
 #include "track_file.h"
 #include "tracker.h"


### PR DESCRIPTION
Without including inttypes.h, compilation of 2.2 fails with such errors:
```
track_file.c:450:32: error: expected ')' before 'PRIi64'
```
Here was my build config:
```
Keepalived configuration
------------------------
Keepalived version       : 2.2.0
Compiler                 : gcc gcc (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2)
Preprocessor flags       : -D_GNU_SOURCE -I/usr/include/libnl3
Compiler flags           : -g -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -Wall -Wextra -Wunused -Wstrict-prototypes -Wabsolute-value -Waddress-of-packed-member -Walloca -Walloc-zero -Warray-bounds=2 -Wattribute-alias -Wbad-function-cast -Wcast-align -Wcast-qual -Wdate-time -Wdisabled-optimization -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Wfloat-conversion -Wfloat-equal -Wformat-overflow -Wformat-security -Wformat-signedness -Wformat-truncation -Wframe-larger-than=5120 -Wimplicit-fallthrough=3 -Winit-self -Winline -Wjump-misses-init -Wlogical-op -Wmissing-declarations -Wmissing-field-initializers -Wmissing-prototypes -Wnested-externs -Wnormalized -Wnull-dereference -Wold-style-definition -Woverlength-strings -Wpointer-arith -Wredundant-decls -Wshadow -Wshift-overflow=2 -Wstack-protector -Wstrict-overflow=4 -Wstrict-prototypes -Wstringop-overflow=2 -Wsuggest-attribute=cold -Wsuggest-attribute=const -Wsuggest-attribute=format -Wsuggest-attribute=malloc -Wsuggest-attribute=noreturn -Wsuggest-attribute=pure -Wsync-nand -Wtrampolines -Wundef -Wuninitialized -Wunknown-pragmas -Wunsuffixed-float-constants -Wunused-const-variable=2 -Wunused-macros -Wvariadic-macros -Wwrite-strings -fPIE -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -O2
Linker flags             : -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -pie -Wl,-z,relro -Wl,-z,now
Extra Lib                : -lm -lcrypto -lssl -lnl-3 -lnl-genl-3 -lpcre2-8
Use IPVS Framework       : Yes
IPVS use libnl           : Yes
IPVS syncd attributes    : Yes
IPVS 64 bit stats        : Yes
HTTP_GET regex support   : Yes
fwmark socket support    : Yes
Use VRRP Framework       : No
Use BFD Framework        : No
SNMP vrrp support        : No
SNMP checker support     : No
SNMP RFCv2 support       : No
SNMP RFCv3 support       : No
DBUS support             : No
SHA1 support             : Yes
Use JSON output          : No
libnl version            : 3
Use IPv4 devconf         : No
Use iptables             : No
Use nftables             : No
systemd integration      : No
init type                : systemd
Strict config checks     : No
Build genhash            : Yes
Build documentation      : No
```