### PR TITLE
Small improvements to the README

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -132,7 +132,7 @@ Installing from a git repo
 ==========================
 To install from a git repo, execute:
   1. Ensure you have autoconf and automake installed
-  2. git clone http://github.com/acassen/keepalived
+  2. git clone https://github.com/acassen/keepalived.git
   3. cd keepalived
   4. ./build_setup	# generate the autoconf and automake environment
   5. Follow the instructions below for Installation, omitting the first two steps.
@@ -211,8 +211,8 @@ To update the keepalived source code, put a new tarball in the image
 directory (the Dockerfile may need updating with a new version).
 
 Useful docker commands are:
-docker logs keepalvied 2>&1 | lessa	# view system logs of container
-docker exec it keepalived bash		# execute shell in container
+docker logs keepalvied 2>&1 | less	# view system logs of container
+docker exec -it keepalived bash		# execute shell in container
 docker rm -f keepalived			# Remove the container
 
 keepalived is unable to load the ip_tables, ip6_tables, xt_set and ip_vs
@@ -234,9 +234,9 @@ create a rule in the AWS security group. The rule should be "Custom Protocol"
 and value should be "112" (the VRRP protocol number). All ports should be opened.
 
 
-Running with SElinux
+Running with SELinux
 ====================
-If the system running keepalived has SElinux enabled in enforcing mode, keepalived
+If the system running keepalived has SELinux enabled in enforcing mode, keepalived
 may have difficulty running scripts, accessing configuration files, etc, especially
 if keepalived is being started by systemd.
 


### PR DESCRIPTION
* fixes a typo in `less` command
* adds missing dash before Docker' run `it` argument
* use HTTPS for Git clone operation
* spell SELinux as at https://selinuxproject.org/page/Main_Page