### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/doc/man/man1/Makefile.am
+++ b/doc/man/man1/Makefile.am
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2020-2020 Alexandre Cassen, <acassen@gmail.com>
 
-DATE=`date --date=\"\`git log -n 1 -- $@.in | grep Date: | sed -e \"s/  */ /g\" | cut -d' ' -f 4,3,6\`\" +\"%Y-%m-%d\"`
+DATE=`date -u --date=@\"\`git log -n 1 --format=%ct -- $@.in | grep . || echo $$SOURCE_DATE_EPOCH | grep . || date +%s\`\" +\"%Y-%m-%d\"`
 
 edit = echo "  EDIT     $@"; \
 	sed \

--- a/doc/man/man5/Makefile.am
+++ b/doc/man/man5/Makefile.am
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2020-2020 Alexandre Cassen, <acassen@gmail.com>
 
-DATE=`date --date=\"\`git log -n 1 -- $@.in | grep Date: | sed -e \"s/  */ /g\" | cut -d' ' -f 4,3,6\`\" +\"%Y-%m-%d\"`
+DATE=`date -u --date=@\"\`git log -n 1 --format=%ct -- $@.in | grep . || echo $$SOURCE_DATE_EPOCH | grep . || date +%s\`\" +\"%Y-%m-%d\"`
 
 edit = echo "  EDIT     $@"; \
 	sed \

--- a/doc/man/man8/Makefile.am
+++ b/doc/man/man8/Makefile.am
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
 
-DATE=`date --date=\"\`git log -n 1 -- $@.in | grep Date: | sed -e \"s/  */ /g\" | cut -d' ' -f 4,3,6\`\" +\"%Y-%m-%d\"`
+DATE=`date -u --date=@\"\`git log -n 1 --format=%ct -- $@.in | grep . || echo $$SOURCE_DATE_EPOCH | grep . || date +%s\`\" +\"%Y-%m-%d\"`
 
 edit = echo "  EDIT     $@"; \
 	sed \


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible when building from tarball.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call only works with GNU `date`, as before.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).