### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.10
-MAINTAINER Bertrand Gouny <bertrand.gouny@osixia.net>
+LABEL maintainer="Bertrand Gouny <bertrand.gouny@osixia.net>"
 
 # add keepalived sources to /tmp/keepalived-sources
 ADD . /tmp/keepalived-sources


### PR DESCRIPTION
Remove maintainer in favour of label as the maintainer instruction was deprecated by [Docker](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)