### PR TITLE
ipvs: Fix compiling when magic library not available

### DIFF
--- a/keepalived/include/check_data.h
+++ b/keepalived/include/check_data.h
@@ -35,6 +35,7 @@
 
 
 /* local includes */
+#include "logger.h"
 #include "ip_vs.h"
 #include "list_head.h"
 #include "vector.h"


### PR DESCRIPTION
This resolves issue #1885