### PR TITLE
vrrp: fix dont_track_primary on IPv6 when vmac disabled

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1127,7 +1127,8 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 							 vrrp->ifp) &&
 						 vrrp->family == ifa->ifa_family &&
 						 vrrp->saddr.ss_family != AF_UNSPEC &&
-						 (!vrrp->saddr_from_config || is_tracking_saddr)) {
+						 (!vrrp->saddr_from_config || is_tracking_saddr) &&
+						 !vrrp->dont_track_primary) {
 						down_instance(vrrp);
 						vrrp->saddr.ss_family = AF_UNSPEC;
 					}


### PR DESCRIPTION
Link local IPv6 deletion from the instance top interface causes
down_instance to be called.

Don't call down_instance if dont_track_primary is set on the instance.