### PR TITLE
vrrp: fix dont_track_primary on IPv6 when vmac disabled

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1127,7 +1127,10 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 							 vrrp->ifp) &&
 						 vrrp->family == ifa->ifa_family &&
 						 vrrp->saddr.ss_family != AF_UNSPEC &&
-						 (!vrrp->saddr_from_config || is_tracking_saddr)) {
+						 (!vrrp->saddr_from_config || is_tracking_saddr) &&
+						 (vrrp->family == AF_INET ||
+						  !vrrp->dont_track_primary ||
+						  IF_ISUP(ifp))) {
 						down_instance(vrrp);
 						vrrp->saddr.ss_family = AF_UNSPEC;
 					}


### PR DESCRIPTION
Link local IPv6 deletion from the instance top interface causes
down_instance to be called.

There are two cases where link local might be deleted:
 - link is set down. Linux kernel behaviour is to always remove
the link local IPv6 address from the interface (sysctl keep_addr_on_down
keeps IPv6 address except the link local). In that case,
dont_track_primary should allow to not put the instance into FAULT
state. The link local IPv6 address will be set back at link up.
 - IPv6 link local is removed from the interface whereas the link state
remains up. Even dont_track_primary is set, the instance must go to
FAULT state because no advertisement can't be sent.

This patch fixes the first case.

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>