### PR TITLE
build: unbreak calculation of relative path

### DIFF
--- a/keepalived/Makefile.am
+++ b/keepalived/Makefile.am
@@ -76,25 +76,6 @@ endif
 
 if WITH_IPVS
 install-exec-hook:
-	@( \
-	d=`echo $(bindir) | sed -e "s:^/::"`; \
-	s=`echo $(sbindir) | sed -e "s:^/::"`; \
-	\
-	while [ 1 ]; do \
-		d1=`echo $$d | sed -e "s:/.*::"`; \
-		s1=`echo $$s | sed -e "s:/.*::"`; \
-		if [ $$d1 != $$s1 ]; then \
-			break; \
-		fi; \
-		d=`echo $$d | sed -e "s:^[^/]*/::"`; \
-		s=`echo $$s | sed -e "s:^[^/]*/::"`; \
-		if [ -z $$d ]; then break; fi; \
-		if [ -z $$s ]; then break; fi; \
-	done; \
-	\
-	d=`echo /$$d/ | sed -e "s:/[^/.]*/:/../:g" -e "s:/[^/.]*/:/../:g" -e "s:^/::"`; \
-	\
-	$(MKDIR_P) $(DESTDIR)/$(bindir); \
-	$(LN_S) $$d$$s/keepalived $(DESTDIR)/$(bindir)/genhash; \
-	)
+	$(MKDIR_P) $(DESTDIR)/$(bindir)
+	$(LN_S) `realpath --relative-to="$(DESTDIR)/$(bindir)" "$(DESTDIR)/$(sbindir)/keepalived"` $(DESTDIR)/$(bindir)/genhash
 endif


### PR DESCRIPTION
Commit 81b5d68d08b2661f3256e0a673a4627417aaab85 changed genhash to be a
symbolic link to keepalived, but the code to calculate the relative path
is prone to errors, for example it can hang in infinite loop.
Replace the code with `realpath` from coreutils.

Fixes #1964