### PR TITLE
Fix time-of-check time-of-use 'bugs'

### DIFF
--- a/keepalived/bfd/bfd_scheduler.c
+++ b/keepalived/bfd/bfd_scheduler.c
@@ -940,13 +940,11 @@ bfd_open_fd_in(bfd_data_t *data)
 
 	if ((ret = getaddrinfo(NULL, BFD_CONTROL_PORT, &hints, &ai_in)))
 		log_message(LOG_ERR, "getaddrinfo() error %d (%s)", ret, gai_strerror(ret));
-	else if ((data->fd_in = socket(AF_INET6, ai_in->ai_socktype, ai_in->ai_protocol)) == -1) {
+	else if (ai_in && (data->fd_in = socket(AF_INET6, ai_in->ai_socktype, ai_in->ai_protocol)) == -1) {
 		if (errno == EAFNOSUPPORT) {
 			/* IPv6 is disabled on the system, so we need to try using IPv4 */
-			if (ai_in) {
-				freeaddrinfo(ai_in);
-				ai_in = NULL;
-			}
+			freeaddrinfo(ai_in);
+			ai_in = NULL;
 			hints.ai_family = AF_INET;
 
 			if ((ret = getaddrinfo(NULL, BFD_CONTROL_PORT, &hints, &ai_in)))

--- a/keepalived/vrrp/vrrp_firewall.c
+++ b/keepalived/vrrp/vrrp_firewall.c
@@ -87,9 +87,9 @@ check_iptables_nft(void)
 
 #ifdef ALLOW_IPTABLES_LEGACY
 		fp = popen("iptables-legacy -V", "r");
-		fclose(fp);
 
 		if (fp) {
+		    fclose(fp);
 			/* The iptables-legacy command exists, so can use iptables */
 			return;
 		}

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -2002,7 +2002,7 @@ process_threads(thread_master_t *m)
 		m->current_thread = thread;
 		thread_type = thread->type;
 
-		if (thread && thread->type == THREAD_CHILD_TIMEOUT) {
+		if (thread->type == THREAD_CHILD_TIMEOUT) {
 			/* We remove the thread from the child_pid queue here so that
 			 * if the termination arrives before we processed the timeout
 			 * we can still handle the termination. */


### PR DESCRIPTION
Hi,

This PR will fix three minor instances of "time-of-check vs time-of-use"-problems.

The problems are found with a tool detecting when pointers are checked against NULL after they have been dereferenced.

There are three instances found in this project:

---

### 1) [keepalived/bfd/bfd_scheduler.c](https://github.com/acassen/keepalived/blob/master/keepalived/bfd/bfd_scheduler.c#L941)

Problem: Superfluous/pointless check @ line 946 - if 'ai_in == NULL' it was already dereferenced on line 943. 

Suggestion: A change from the current form (see comment on line 946):

```C
941    if ((ret = getaddrinfo(NULL, BFD_CONTROL_PORT, &hints, &ai_in)))
942        log_message(LOG_ERR, "getaddrinfo() error %d (%s)", ret, gai_strerror(ret));
943    else if ((data->fd_in = socket(AF_INET6, ai_in->ai_socktype, ai_in->ai_protocol)) == -1) {
944        if (errno == EAFNOSUPPORT) {
945            /* IPv6 is disabled on the system, so we need to try using IPv4 */
946            if (ai_in) { // <-- check happens too late - ai_in was dereferenced on line 943 'ai_in->...'
947                freeaddrinfo(ai_in);
948                ai_in = NULL;
949            }
```

... into something like this:

```C
941    if ((ret = getaddrinfo(NULL, BFD_CONTROL_PORT, &hints, &ai_in)))
942        log_message(LOG_ERR, "getaddrinfo() error %d (%s)", ret, gai_strerror(ret));
943    else if (ai_in && (data->fd_in = socket(AF_INET6, ai_in->ai_socktype, ai_in->ai_protocol)) == -1) { // <-- check here instead
944        if (errno == EAFNOSUPPORT) {
945            /* IPv6 is disabled on the system, so we need to try using IPv4 */
946            freeaddrinfo(ai_in);
947            ai_in = NULL;
948            hints.ai_family = AF_INET;
949        
```

---

### 2) [keepalived/vrrp/vrrp_firewall.c](https://github.com/acassen/keepalived/blob/master/keepalived/vrrp/vrrp_firewall.c#L89)

Context: `popen(...)` may return NULL on failure, from man-page on popen(3):

  > popen(): on success, returns a pointer to an open stream that can be used to read or write to the pipe; 
  >          if the fork(2) or pipe(2) calls fail, or if the function cannot allocate memory, NULL is returned.

Problem: Line 90 calls 'fclose(fp)' without checking 'fp' against NULL. `fclose(NULL)` is undefined behavior.

Suggestion: move 'fclose(fp)' inside if-stmt @ line 92, changing code from 

```C
89        fp = popen("iptables-legacy -V", "r");
90        fclose(fp); // <-- calling 'fclose(fp)' without checking that 'fp != NULL'
91
92        if (fp) {
93            /* The iptables-legacy command exists, so can use iptables */
94            return;
95        }
```

... into something like this:

```C
89        fp = popen("iptables-legacy -V", "r");
90        
91        if (fp) {
92            /* The iptables-legacy command exists, so can use iptables */
93            fclose(fp); // <-- don't call 'fclose(fp)' before checking that 'fp != NULL'
94            return;
95        }
```

---

### 3) [lib/scheduler.c](https://github.com/acassen/keepalived/blob/master/lib/scheduler.c#L1999)

Problem: Superfluous/pointless check @ line 2005, because line 1999 already checks 'thread' against NULL (see comment on line 1999 below).

Suggestion: Remove NULL-check for 'thread' on line 2005. Changing the code from:

```C
1999        if (!(thread = thread_trim_head(thread_list))) // continue loop if 'thread == NULL'
2000            continue;
2001
2002        m->current_thread = thread;
2003        thread_type = thread->type;
2004
2005        if (thread && thread->type == THREAD_CHILD_TIMEOUT) { // 'thread' already checked against NULL at line 1999
2006            /* We remove the thread from the child_pid queue here so that
2007             * if the termination arrives before we processed the timeout
2008             * we can still handle the termination. */
2009            rb_erase(&thread->rb_data, &master->child_pid);
2010        }
```
... into something like this:
```C
1999        if (!(thread = thread_trim_head(thread_list)))
2000            continue;
2001
2002        m->current_thread = thread;
2003        thread_type = thread->type;
2004
2005        if (thread->type == THREAD_CHILD_TIMEOUT) {
2006            /* We remove the thread from the child_pid queue here so that
2007             * if the termination arrives before we processed the timeout
2008             * we can still handle the termination. */
2009            rb_erase(&thread->rb_data, &master->child_pid);
2010        }
```