### PR TITLE
vrrp: always notify FIFO script of VRRP states at reload

### DIFF
--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -340,6 +340,7 @@ typedef struct _vrrp_t {
 							 */
 	timeval_t		preempt_time;		/* Time after which preemption can happen */
 	int			state;			/* internal state (init/backup/master/fault) */
+	bool		state_same_at_reload;   /* State prior to reload */
 #ifdef _WITH_SNMP_VRRP_
 	int			configured_state;	/* the configured state of the instance */
 #endif
@@ -484,6 +485,7 @@ extern void shutdown_vrrp_instances(void);
 extern void clear_diff_vrrp(void);
 extern void clear_diff_script(void);
 extern void set_previous_sync_group_states(void);
+extern void set_previous_sync_instance_states(void);
 #ifdef _WITH_BFD_
 extern void clear_diff_bfd(void);
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -5030,6 +5030,22 @@ clear_diff_script(void)
 }
 
 void
+set_previous_sync_instance_states(void)
+{
+	vrrp_t *ovrrp, *nvrrp;
+
+	list_for_each_entry(nvrrp, &vrrp_data->vrrp, e_list) {
+		list_for_each_entry(ovrrp, &vrrp_data->vrrp, e_list) {
+			if (!strcmp(nvrrp->iname, ovrrp->iname)) {
+				if (nvrrp->state == ovrrp->state)
+					nvrrp->state_same_at_reload = true;
+				break;
+			}
+		}
+	}
+}
+
+void
 set_previous_sync_group_states(void)
 {
 	vrrp_sgroup_t *ogroup, *ngroup;

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -639,7 +639,9 @@ start_vrrp(data_t *prev_global_data)
 		clear_diff_vrrp();
 		vrrp_dispatcher_release(old_vrrp_data);
 
-		/* Set previous sync group states to suppress duplicate notifies */
+		/* Set previous sync group states to suppress duplicate notifies.
+      FIFO script is always notified at reload.
+		*/
 		set_previous_sync_group_states();
 	}
 

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -639,10 +639,11 @@ start_vrrp(data_t *prev_global_data)
 		clear_diff_vrrp();
 		vrrp_dispatcher_release(old_vrrp_data);
 
-		/* Set previous sync group states to suppress duplicate notifies.
+		/* Set previous sync states to suppress duplicate notifies.
       FIFO script is always notified at reload.
 		*/
 		set_previous_sync_group_states();
+		set_previous_sync_instance_states();
 	}
 
 #ifdef _WITH_DBUS_

--- a/keepalived/vrrp/vrrp_notify.c
+++ b/keepalived/vrrp/vrrp_notify.c
@@ -326,14 +326,17 @@ send_group_notifies(vrrp_sgroup_t *vgroup)
 	notify_script_t *gscript = get_ggscript(vgroup);
 
 	/* Launch the notify_* script */
-	if (script)
+	if (script && !vgroup->state_same_at_reload)
 		notify_exec(script);
 
 	/* Launch the generic notify script */
-	if (gscript)
+	if (gscript && !vgroup->state_same_at_reload)
 		notify_script_exec(gscript, "GROUP", vgroup->state, vgroup->gname, 0);
 
 	notify_group_fifo(vgroup);
+
+	if (vgroup->state_same_at_reload)
+		return;
 
 #ifdef _WITH_SNMP_VRRP_
 	vrrp_snmp_group_trap(vgroup);

--- a/keepalived/vrrp/vrrp_notify.c
+++ b/keepalived/vrrp/vrrp_notify.c
@@ -286,7 +286,7 @@ send_instance_notifies(vrrp_t *vrrp)
 	vrrp->notifies_sent = true;
 
 	/* Launch the notify_* script */
-	if (script) {
+	if (script && !vrrp->state_same_at_reload) {
 		if (vrrp->state == VRRP_STATE_STOP)
 			system_call_script(master, child_killed_thread, NULL, TIMER_HZ, script);
 		else
@@ -294,11 +294,14 @@ send_instance_notifies(vrrp_t *vrrp)
 	}
 
 	/* Launch the generic notify script */
-	if (gscript)
+	if (gscript && !vrrp->state_same_at_reload)
 		notify_script_exec(gscript, "INSTANCE", vrrp->state, vrrp->iname,
 				   vrrp->effective_priority);
 
 	notify_instance_fifo(vrrp);
+
+	if (vrrp->state_same_at_reload)
+		return;
 
 #ifdef _WITH_DBUS_
 	if (global_data->enable_dbus)

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -195,8 +195,7 @@ vrrp_init_state(list_head_t *l)
 	list_for_each_entry(vgroup, &vrrp_data->vrrp_sync_group, e_list) {
 		/* Init group if needed  */
 		if ((vgroup->state == VRRP_STATE_FAULT ||
-		     vgroup->state == VRRP_STATE_BACK) &&
-		     !vgroup->state_same_at_reload)
+		     vgroup->state == VRRP_STATE_BACK))
 			send_group_notifies(vgroup);
 		vgroup->state_same_at_reload = false;
 	}

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -277,11 +277,11 @@ vrrp_init_state(list_head_t *l)
 				vrrp->state = VRRP_STATE_FAULT;
 			}
 			if (vrrp_begin_state != vrrp->state) {
-				if (vrrp->state != VRRP_STATE_FAULT || vrrp->num_script_if_fault)
-					send_instance_notifies(vrrp);
 				vrrp->last_transition = timer_now();
 			}
 		}
+		send_instance_notifies(vrrp);
+		vrrp->state_same_at_reload = false;
 #ifdef _WITH_SNMP_RFC_
 		vrrp->stats->uptime = timer_now();
 #endif


### PR DESCRIPTION
Related to issue https://github.com/acassen/keepalived/issues/2012
Inspired by 6c8b51c8ea4836944ff1236e35490190ae9e541c

Configuration reload restarts the notify FIFO script.

If the FIFO script has instructions to (un)set things (e.g. iptables
filter rules) depending on a VRRP state. And if unset things is
requested at script stop, then, at script restart, the new script is
not notified of the VRRP states. Things that needed to be set are not.

This patch always notifies FIFO script of VRRP state at reload.
