### PR TITLE
vrrp: fix disabling vmac-xmit-base with VRRPv3 IPv6 use_vmac

### DIFF
--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -442,8 +442,6 @@ netlink_link_add_vmac(vrrp_t *vrrp, const interface_t *old_interface)
 	req.n.nlmsg_type = RTM_NEWLINK;
 	req.ifi.ifi_family = AF_UNSPEC;
 	req.ifi.ifi_index = (int)vrrp->ifp->ifindex;
-	req.ifi.ifi_change |= IFF_UP;
-	req.ifi.ifi_flags |= IFF_UP;
 
 	struct rtattr* spec;
 
@@ -458,9 +456,8 @@ netlink_link_add_vmac(vrrp_t *vrrp, const interface_t *old_interface)
 
 	if (netlink_talk(&nl_cmd, &req.n) < 0)
 		log_message(LOG_INFO, "(%s) Error setting ADDR_GEN_MODE to NONE on %s", vrrp->iname, vrrp->ifp->ifname);
-#else
-	netlink_link_up(vrrp);
 #endif
+	netlink_link_up(vrrp);
 
 	/* Mark it as UP ! */
 	__set_bit(VRRP_VMAC_UP_BIT, &vrrp->flags);


### PR DESCRIPTION
Fix for the issue #2026.

On VRRPv3 IPv6 with use_vmac mode, after disabling vmac-xmit-base, the
following error happens:

> Oct 29 11:33:10 ubuntu Keepalived_vrrp[1663]: (vrrp): send advert error 22 (Invalid argument)

No VRRP packets are emitted anymore.

Tested against the procedure of the #2015 issue. No regression on it.

Signed-off-by: Louis Scalbert <louis.scalbert@6wind.com>