### PR TITLE
Docs: adding security policy documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+Here at the Keepalived community security is very important to us.
+
+## Reporting a Vulnerability
+If you discover any issue regarding security, we'd appreciate a non-public disclosure of the information, so please disclose the information responsibly by sending an email to Alexandre Cassen <acassen@gmail.com> and not by creating a GitHub issue or start a dialog in the keepalived community at groups.io. 
+We will respond swiftly to fix verifiable security issues along with the disclosure being coordinated with vendors and other relevant security teams.


### PR DESCRIPTION
Adding a missing security policy documentation with a pretty standard community workflow.
Added Alexandre address as the contact for such incidents but perhaps Quentin should be that person instead. 
If more than one person should be notified, typically virtual email address is used or the text points to notify the maintainers listed in the MAINTAINERS file that typically resides in a repository. 