### PR TITLE
Apply a specific label to a pull request based on any paths changed in that pull request.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,98 @@
+repository:
+  - ./*
+
+github:
+  - .github/*
+  - .github/**/*
+
+bin:
+  - bin/*
+
+bin_install:
+  - bin_install/*
+
+documentation:
+  - doc/*
+  - doc/**/*
+  - doc/**/**/*
+  - doc/**/**/**/*
+
+man:
+   - doc/man/**/*
+
+man1:
+  - doc/man/man1/*
+
+man5:
+  - doc/man/man5/*
+
+man1:
+  - doc/man/man8/*
+
+samples:
+  - doc/samples/*
+
+source:
+  - doc/source/*
+  - doc/source/**/**
+
+docker:
+  - docker/*
+
+goodies:
+  - goodies/*
+
+keepalived:
+  - keepalived/*
+  - keepalived/**/*
+
+bfd:
+  - keepalived/bfd/*
+
+check:
+  - keepalived/check/*
+
+core:
+  - keepalived/core/*
+
+dbus:
+  - keepalived/dbus/*
+
+include:
+  - keepalived/include/*
+
+trackers:
+  - keepalived/trackers/*
+
+vrrp:
+  - keepalived/vrrp/*
+
+lib:
+  - lib/*
+
+m4:
+  - m4/*
+
+snap-tools:
+  - snap-tools/*
+
+snap:
+  - snap/*
+  - snap/**/*
+
+hooks:
+  - snap/hooks/*
+
+tests:
+  - test/*
+  - test/**/*
+
+ci:
+  - test/ci/*
+
+tools:
+  - tools/*
+  - tools/**/*
+
+jason_tracking:
+  - tools/json_tracking/*

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+
+on: pull_request_target
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/labeler@main
+              with:
+                  repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR will apply a specific label to a pull request based on any paths changed in that pull request which will enable label search on the repository in github. 

The current labeling scheme in this request is based on the existing hierarchy in the repository which is a good bases as a start but more comprehensive implementation of a labeling scheme requires more work and elevated privileges on the repository ( such as creating labels like bug, enhancment etc at issue creations ) for myself if I'm supposed to impement it ( which I dont mind doing, I just need to know how it should look like before hand ).

Also different action might need to be enabled one time to label existing/closed issues/pr's . 