### PR TITLE
dbus: fix policy to not be overly broad

### DIFF
--- a/keepalived/dbus/org.keepalived.Vrrp1.conf
+++ b/keepalived/dbus/org.keepalived.Vrrp1.conf
@@ -3,12 +3,15 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
 	<policy user="root">
-		<allow own="org.keepalived.Vrrp1"/>
-		<allow send_destination="org.keepalived.Vrrp1"/>
+		<allow own="org.keepalived.Vrrp1" />
+		<allow send_destination="org.keepalived.Vrrp1" />
 	</policy>
 	<policy context="default">
-		<allow send_interface="org.freedesktop.DBus.Introspectable" />
-		<allow send_interface="org.freedesktop.DBus.Peer" />
-		<allow send_interface="org.freedesktop.DBus.Properties" />
+		<allow send_destination="org.keepalived.Vrrp1"
+		       send_interface="org.freedesktop.DBus.Introspectable" />
+		<allow send_destination="org.keepalived.Vrrp1"
+		       send_interface="org.freedesktop.DBus.Peer" />
+		<allow send_destination="org.keepalived.Vrrp1"
+		       send_interface="org.freedesktop.DBus.Properties" />
 	</policy>
 </busconfig>


### PR DESCRIPTION
The DBus policy did not restrict the message destination, allowing any
user to inspect and manipulate any property.

Signed-off-by: Vincent Bernat <vincent@bernat.ch>