### PR TITLE
Various fixes

### DIFF
--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -387,6 +387,10 @@ start_bfd_child(void)
 
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
+	/* Check our parent hasn't already changed since the fork */
+	if (main_pid != getppid())
+		kill(getpid(), SIGTERM);
+
 	prog_type = PROG_TYPE_BFD;
 
 	/* Close the read end of the event notification pipes, and the track_process fd */

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -336,9 +336,6 @@ bfd_respawn_thread(thread_ref_t thread)
 static void
 register_bfd_thread_addresses(void)
 {
-	/* Remove anything we might have inherited from parent */
-	deregister_thread_addresses();
-
 	register_scheduler_addresses();
 	register_signal_thread_addresses();
 
@@ -401,6 +398,11 @@ start_bfd_child(void)
 #endif
 #ifdef _WITH_LVS_
 	close(bfd_checker_event_pipe[0]);
+#endif
+
+#ifdef THREAD_DUMP
+	/* Remove anything we might have inherited from parent */
+	deregister_thread_addresses();
 #endif
 
 	initialise_debug_options();

--- a/keepalived/check/check_bfd.c
+++ b/keepalived/check/check_bfd.c
@@ -327,6 +327,11 @@ bfd_check_thread(thread_ref_t thread)
 {
 	bfd_event_t evt;
 
+	if (thread->type == THREAD_READ_ERROR) {
+		thread_close_fd(thread);
+		return;
+	}
+
 	bfd_thread = thread_add_read(master, bfd_check_thread, NULL,
 				     thread->u.f.fd, TIMER_NEVER, 0);
 

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -617,9 +617,6 @@ check_respawn_thread(thread_ref_t thread)
 static void
 register_check_thread_addresses(void)
 {
-	/* Remove anything we might have inherited from parent */
-	deregister_thread_addresses();
-
 	register_scheduler_addresses();
 	register_signal_thread_addresses();
 	register_notify_addresses();
@@ -696,6 +693,11 @@ start_check_child(void)
 	prog_type = PROG_TYPE_CHECKER;
 
 	initialise_debug_options();
+
+#ifdef THREAD_DUMP
+	/* Remove anything we might have inherited from parent */
+	deregister_thread_addresses();
+#endif
 
 #ifdef _WITH_BFD_
 	/* Close the write end of the BFD checker event notification pipe and the track_process fd */

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -690,6 +690,10 @@ start_check_child(void)
 
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
+	/* Check our parent hasn't already changed since the fork */
+	if (main_pid != getppid())
+		kill(getpid(), SIGTERM);
+
 	prog_type = PROG_TYPE_CHECKER;
 
 	initialise_debug_options();

--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -529,6 +529,15 @@ start_keepalived(__attribute__((unused)) thread_ref_t thread)
 {
 	bool have_child = false;
 
+	/* Although we use prctl to set PDEATHSIG, there are windows when it
+	 * is not set, i.e. before it is first executed after a fork, and also
+	 * after set(e)[ug]id() calls before PDEATHSIG can be reinstated. */
+	main_pid = getpid();
+
+	/* We want to ensure that any children of child process don't miss the
+	 * termination of their immediate parent. */
+	prctl(PR_SET_CHILD_SUBREAPER, 1);
+
 #ifdef _WITH_BFD_
 	/* must be opened before vrrp and bfd start */
 	if (!open_bfd_pipes()) {

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -935,9 +935,6 @@ vrrp_respawn_thread(thread_ref_t thread)
 static void
 register_vrrp_thread_addresses(void)
 {
-	/* Remove anything we might have inherited from parent */
-	deregister_thread_addresses();
-
 	register_scheduler_addresses();
 	register_signal_thread_addresses();
 	register_notify_addresses();
@@ -1025,6 +1022,11 @@ start_vrrp_child(void)
 	prog_type = PROG_TYPE_VRRP;
 
 	initialise_debug_options();
+
+#ifdef THREAD_DUMP
+	/* Remove anything we might have inherited from parent */
+	deregister_thread_addresses();
+#endif
 
 #ifdef _WITH_BFD_
 	/* Close the write end of the BFD vrrp event notification pipe */

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -1014,6 +1014,10 @@ start_vrrp_child(void)
 
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
+	/* Check our parent hasn't already changed since the fork */
+	if (main_pid != getppid())
+		kill(getpid(), SIGTERM);
+
 #ifdef _WITH_PERF_
 	if (perf_run == PERF_ALL)
 		run_perf("vrrp", global_data->network_namespace, global_data->instance_name);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -822,6 +822,11 @@ vrrp_bfd_thread(thread_ref_t thread)
 {
 	bfd_event_t evt;
 
+	if (thread->type == THREAD_READ_ERROR) {
+		thread_close_fd(thread);
+		return;
+	}
+
 	bfd_thread = thread_add_read(master, vrrp_bfd_thread, NULL,
 				     thread->u.f.fd, TIMER_NEVER, 0);
 

--- a/lib/process.c
+++ b/lib/process.c
@@ -56,9 +56,9 @@ static bool process_locked_in_memory;
 static struct rlimit orig_fd_limit;
 
 /* rlimit values to set for child processes */
-bool rlimit_nofile_set;
+static bool rlimit_nofile_set;
 static struct rlimit core;
-bool rlimit_core_set;
+static bool rlimit_core_set;
 
 /* main_pid is used by child processes to ensure the main process
  * hasn't died during a window when PDEATHSIG is not set */

--- a/lib/process.c
+++ b/lib/process.c
@@ -60,6 +60,10 @@ bool rlimit_nofile_set;
 static struct rlimit core;
 bool rlimit_core_set;
 
+/* main_pid is used by child processes to ensure the main process
+ * hasn't died during a window when PDEATHSIG is not set */
+pid_t main_pid;
+
 static void
 set_process_dont_swap(size_t stack_reserve)
 {

--- a/lib/process.h
+++ b/lib/process.h
@@ -33,6 +33,7 @@
 #define PID_MAX_DIGITS		7
 
 extern long min_auto_priority_delay;
+extern pid_t main_pid;
 
 extern void set_process_priorities(int, int, long, int, int, int);
 extern void reset_process_priorities(void);


### PR DESCRIPTION
1. Handle unexpected close of BFD pipes
2. Thread debugging - deregister parent thread addresses earlier
3. Ensure PDEATHSIG does not become disabled
4. Add 'static' which was missing from a couple of variables.