### PR TITLE
doc: update pre-requisites installation

### DIFF
--- a/doc/source/installing_keepalived.rst
+++ b/doc/source/installing_keepalived.rst
@@ -42,8 +42,13 @@ Install Prerequisites on RHEL/CentOS/Fedora
 On RHEL, Centos, Fedora etc install the following prerequisites
 (on older systems replace dnf with yum)::
 
-    dnf install curl gcc autoconf automake openssl-devel libnl3-devel \
+    dnf install curl gcc autoconf make openssl-devel libnl3-devel \
         iptables-devel ipset-devel net-snmp-devel libnfnetlink-devel file-devel
+
+ipset-devel libnfnetlink-devel file-devel packages are available in PowerTools repository.
+If you need these packages::
+
+    dnf --enablerepo powertools install ipset-devel libnfnetlink-devel file-devel
 
 For DBUS support::
 


### PR DESCRIPTION
in rhel based OS prerequisites section, it says to install `automake`
but I was unable to build keepalived from source without installing `make` instead.

Also, `ipset-devel`, `libnfnetlink-devel` and `file-devel` packages require the repo
`PowerTools` to be enabled so I thought it was worth it to mention how to install them.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>