### PR TITLE
vrrp: Add no_virtual_ipaddress keyword

### DIFF
--- a/doc/man/man5/keepalived.conf.5.in
+++ b/doc/man/man5/keepalived.conf.5.in
@@ -556,6 +556,7 @@ possibly following any cleanup actions needed.
     #   Cannot clear lower_prio_no_advert
     #   Cannot set higher_prio_send_advert
     #   Cannot use vmac_xmit_base
+    #   Cannot have no VIPs with VRRPv3
     \fBvrrp_strict\fR
 
     # Send vrrp instance priority notifications on notify FIFOs.
@@ -1920,6 +1921,18 @@ The syntax for vrrp_instance is :
         <IPADDR>[/<MASK>] ...
         ...
     }
+
+    # Specifying no virtual IP addresses is generally a configuration error
+    # and VRRP version 3 explicitly states that the minimum number of addresses
+    # is 1. Consequently keepalived warns if no VIPs are configured.
+    # There are, however, circumstances when it is useful to have no VIPs, for
+    # example when cloud servers, e.g. AWS, where floating IP addresses are
+    # managed administratively, and are not configured on the cloud virtual
+    # server. Specifying no_virtual_ipaddress supresses warnings for no VIPs,
+    # and allows VRRPv3 to be used with no VIPs.
+    # WARNING - when using this with VRRPv3 it causes a protocol violation and
+    # may not work with other VRRP implementations.
+    \fBno_virtual_ipaddress\fR
 
     # Set the promote_secondaries flag on the interface to stop other
     # addresses in the same CIDR being removed when 1 of them is removed

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -64,6 +64,7 @@ enum vrrp_flags_bits {
 	VRRP_FLAG_CHECK_UNICAST_SRC,		/* It set, check the source address of a unicast advert */
 	VRRP_FLAG_PROMOTE_SECONDARIES,		/* Set promote_secondaries option on interface */
 	VRRP_FLAG_EVIP_OTHER_FAMILY,		/* There are eVIPs of the different address family from the vrrp family */
+	VRRP_FLAG_ALLOW_NO_VIPS,		/* Suppresses warnings re no VIPs */
 	VRRP_FLAG_NOPREEMPT,			/* true if higher prio does not preempt lower */
 #ifdef _HAVE_VRRP_VMAC_
 	VRRP_VMAC_BIT,

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -684,6 +684,8 @@ dump_vrrp(FILE *fp, const vrrp_t *vrrp)
 		conf_write(fp, "   VRRP interface tracking disabled");
 	if (__test_bit(VRRP_FLAG_SKIP_CHECK_ADV_ADDR, &vrrp->flags))
 		conf_write(fp, "   Skip checking advert IP addresses");
+	if (__test_bit(VRRP_FLAG_ALLOW_NO_VIPS, &vrrp->flags))
+		conf_write(fp, "   Suppress no VIPs warning");
 	if (vrrp->strict_mode)
 		conf_write(fp, "   Enforcing strict VRRP compliance");
 	conf_write(fp, "   Using src_ip = %s%s", vrrp->saddr.ss_family != AF_UNSPEC

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -1422,6 +1422,11 @@ vrrp_evip_handler(const vector_t *strvec)
 	alloc_value_block(alloc_vrrp_evip, strvec);
 }
 static void
+vrrp_no_vip_handler(__attribute__((unused)) const vector_t *strvec)
+{
+	__set_bit(VRRP_FLAG_ALLOW_NO_VIPS, &current_vrrp->flags);
+}
+static void
 vrrp_promote_secondaries_handler(__attribute__((unused)) const vector_t *strvec)
 {
 	__set_bit(VRRP_FLAG_PROMOTE_SECONDARIES, &current_vrrp->flags);
@@ -2095,6 +2100,7 @@ init_vrrp_keywords(bool active)
 	install_keyword("advert_int", &vrrp_adv_handler);
 	install_keyword("virtual_ipaddress", &vrrp_vip_handler);
 	install_keyword("virtual_ipaddress_excluded", &vrrp_evip_handler);
+	install_keyword("no_virtual_ipaddress", &vrrp_no_vip_handler);
 	install_keyword("promote_secondaries", &vrrp_promote_secondaries_handler);
 #ifdef _WITH_LINKBEAT_
 	install_keyword("linkbeat_use_polling", &vrrp_linkbeat_handler);


### PR DESCRIPTION
This keyword suppresses	warnings for no virtual ipaddresses configured
and allows none	to be configured when using VRRPv3.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>