### PR TITLE
check: use last entry if duplicate definition

### DIFF
--- a/keepalived/check/check_http.c
+++ b/keepalived/check/check_http.c
@@ -466,10 +466,7 @@ virtualhost_handler(const vector_t *strvec)
 		return;
 	}
 
-	if (!http_get_chk->virtualhost)
-		http_get_chk->virtualhost = set_value(strvec);
-	else
-		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate virtualhost %s - ignoring", strvec_slot(strvec, 1));
+	set_string(&http_get_chk->virtualhost, strvec, "virtualhost");
 }
 
 static void
@@ -588,10 +585,7 @@ url_virtualhost_handler(const vector_t *strvec)
 		return;
 	}
 
-	if (!current_url->virtualhost)
-		current_url->virtualhost = set_value(strvec);
-	else
-		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate url virtualhost %s - ignoring", strvec_slot(strvec, 1));
+	set_string(&current_url->virtualhost, strvec, "url virtualhost");
 }
 
 static void

--- a/keepalived/check/check_parser.c
+++ b/keepalived/check/check_parser.c
@@ -608,10 +608,7 @@ vs_virtualhost_handler(const vector_t *strvec)
 		return;
 	}
 
-	if (!current_vs->virtualhost)
-		current_vs->virtualhost = set_value(strvec);
-	else
-		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate vs virtualhost %s - ignoring", strvec_slot(strvec, 1));
+	set_string(&current_vs->virtualhost, strvec, "vs virtualhost");
 }
 
 #ifdef _WITH_SNMP_CHECKER_
@@ -624,10 +621,7 @@ vs_snmp_name_handler(const vector_t *strvec)
 		return;
 	}
 
-	if (!current_vs->snmp_name)
-		current_vs->snmp_name = set_value(strvec);
-	else
-		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate vs snmp_name %s - ignoring", strvec_slot(strvec, 1));
+	set_string(&current_vs->snmp_name, strvec, "vs snmp_name");
 }
 #endif
 
@@ -853,10 +847,7 @@ rs_virtualhost_handler(const vector_t *strvec)
 		return;
 	}
 
-	if (!current_rs->virtualhost)
-		current_rs->virtualhost = set_value(strvec);
-	else
-		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate rs virtualhost %s - ignoring", strvec_slot(strvec, 1));
+	set_string(&current_rs->virtualhost, strvec, "rs virtualhost");
 }
 
 #ifdef _WITH_SNMP_CHECKER_
@@ -868,10 +859,7 @@ rs_snmp_name_handler(const vector_t *strvec)
 		return;
 	}
 
-	if (!current_rs->snmp_name)
-		current_rs->snmp_name = set_value(strvec);
-	else
-		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate rs snmp_name %s - ignoring", strvec_slot(strvec, 1));
+	set_string(&current_rs->snmp_name, strvec, "rs snmp_name");
 }
 #endif
 

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -806,6 +806,16 @@ read_hex_str(const char *str, uint8_t **data, uint8_t **data_mask)
 }
 
 void
+set_string(const char **var, const vector_t *strvec, const char *param_name)
+{
+	if (*var) {
+		report_config_error(CONFIG_GENERAL_ERROR, "Duplicate %s - overwriting %s with %s", param_name, *var, strvec_slot(strvec, 1));
+		FREE_CONST_PTR(*var);
+	}
+	*var = set_value(strvec);
+}
+
+void
 set_random_seed(unsigned int seed)
 {
 	random_seed = seed;

--- a/lib/parser.h
+++ b/lib/parser.h
@@ -122,6 +122,7 @@ set_value_r(const vector_t *strvec)
 #endif
 
 /* Prototypes */
+extern void set_string(const char **, const vector_t *, const char *);
 extern void report_config_error(config_err_t, const char *format, ...)
 	__attribute__((format (printf, 2, 3)));
 extern void use_disk_copy_for_config(const char *);


### PR DESCRIPTION
Commits 8a3f145 - "fix mem leaks when virtualhost and snmp_name
are duplicate" and 86bbb2e - "fix mem leaks when virtualhost is
duplicate" changed the behaviour of virtualhost and snmp_name
configuration if there were duplicate definitions to use the
first defined entry, whereas previously the last defined entry
was used, albeit with a memory leak.

This commit retains the memory leak fixes, but reverts the
behaviour to use the last definition rather than the first.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>