### PR TITLE
Avoid terminating keepalived during a configuration test.

### DIFF
--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -391,7 +391,7 @@ start_bfd_child(void)
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
 	/* Check our parent hasn't already changed since the fork */
-	if (main_pid != getppid())
+	if (main_pid != 0 && main_pid != getppid())
 		kill(getpid(), SIGTERM);
 
 	prog_type = PROG_TYPE_BFD;

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -695,7 +695,7 @@ start_check_child(void)
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
 	/* Check our parent hasn't already changed since the fork */
-	if (main_pid != getppid())
+	if (main_pid != 0 && main_pid != getppid())
 		kill(getpid(), SIGTERM);
 
 	prog_type = PROG_TYPE_CHECKER;

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -1033,7 +1033,7 @@ start_vrrp_child(void)
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
 	/* Check our parent hasn't already changed since the fork */
-	if (main_pid != getppid())
+	if (main_id != 0 && main_pid != getppid())
 		kill(getpid(), SIGTERM);
 
 #ifdef _WITH_PERF_

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -1033,7 +1033,7 @@ start_vrrp_child(void)
 	prctl(PR_SET_PDEATHSIG, SIGTERM);
 
 	/* Check our parent hasn't already changed since the fork */
-	if (main_id != 0 && main_pid != getppid())
+	if (main_pid != 0 && main_pid != getppid())
 		kill(getpid(), SIGTERM);
 
 #ifdef _WITH_PERF_

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -756,8 +756,9 @@ check_script_secure(notify_script_t *script,
 		/* Restore parent death signal */
 		prctl(PR_SET_PDEATHSIG, sav_death_sig);
 
-		/* Check the parent didn't die in the window when PDEATHSIG was not set */
-		if (main_pid != getppid())
+		/* Check the parent didn't die in the window when PDEATHSIG was not set 
+		 * avoid the check during configuration testing */
+		if (main_pid != 0 && main_pid != getppid())
 			kill(getpid(), SIGTERM);
 	}
 


### PR DESCRIPTION
When a configuration is checked keepalived also checks script security and calls `check_script_secure()`.
The same function is also called during normal keepalived lifecycle. The function has a check that the main pid didn't die while we were checking other things (see 59271723ff8e311754878cb6f75ce4dbf18aa462 for details)
`main_pid` is set in `start_keepalived()` function called from `keepalived_main()`. In `keepalived_main()` we parse args, decide if we have to test configuration and do the check before calling `start_keepalived()`. So `main_pid` is not set to a proper value. 
At the same time, the problem `main_pid` solves is not really relevant at a configuration test stage. So the easiest fix, IMO, is to verify `main_pid` was set properly . If not - it's a configuration test and we can skip the check.

The problem only arises in `notify.c` for me. But the same check is placed in `check_daemon.c`, `vrrp_daemon.c` and `bfd_daemon.c`. I changed those as well just for good measure.