### PR TITLE
doc: Update description of enable_script_security

### DIFF
--- a/doc/man/man5/keepalived.conf.5.in
+++ b/doc/man/man5/keepalived.conf.5.in
@@ -687,7 +687,9 @@ possibly following any cleanup actions needed.
     \fBscript_user \fRusername [groupname]
 
     # Don't run scripts configured to be run as root if any part of the path
-    # is writable by a non-root user.
+    # is writable by a non-root user. Also, enforce the default script_user is
+    # keepalived_script, and don't default to the user under which keepalived
+    # is running (usually root).
     \fBenable_script_security\fR
 
     # Rather than using notify scripts, specifying a fifo allows more


### PR DESCRIPTION
It wasn't clear that enable_script_security stops defaulting to
running scripts as the user under which keepalived is running
(usually root), but defaults to keepalived_script in the absence
of any script user being specified.

Signed-off-by: Quentin Armitage <quentin@armitage.org.uk>