### PR TITLE
resolve segfault when modprobe ip_vs.ko error

### DIFF
--- a/keepalived/check/check_api.c
+++ b/keepalived/check/check_api.c
@@ -504,7 +504,8 @@ free_rs_checkers(const real_server_t *rs)
 void
 free_checkers_queue(void)
 {
-	free_checker_list(&checkers_queue);
+	if (checkers_queue.prev && checkers_queue.next)
+		free_checker_list(&checkers_queue);
 }
 
 /* register checkers to the global I/O scheduler */


### PR DESCRIPTION
In issue #2203,report two segfault,but only resolve one. In this commit, resolve another.