### PR TITLE
netlink: do not ignore vip as system owner

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -228,7 +228,12 @@ ignore_address_if_ours_or_link_local(struct ifaddrmsg *ifa, struct in_addr *addr
 		if (ifa->ifa_family == vrrp->family) {
 			list_for_each_entry(ip_addr, &vrrp->vip, e_list) {
 				if (addr_is_equal2(ifa, addr, ip_addr, ifp, vrrp))
-					return true;
+					/* When an instance is owning the
+					 * system IP, do not ignore. */
+					if (vrrp->base_priority == VRRP_PRIO_OWNER)
+						continue;
+					else
+						return true;
 			}
 		}
 


### PR DESCRIPTION
When an instance is configured with 255 priority and is waiting for an address to start,
do not ignore when the vip is added.

Signed-off-by: Loïc Sang <loic.sang@6wind.com>