### PR TITLE
netlink: do not ignore vip as system owner

### DIFF
--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -400,6 +400,22 @@ min_auto_priority_delay_handler(const vector_t *strvec)
 
 	global_data->min_auto_priority_delay = delay;
 }
+
+static void
+vrrp_system_owner_handler(const vector_t *strvec)
+{
+
+	if (!strcmp(strvec_slot(strvec, 1), "strict")) {
+		global_data->vrrp_system_owner = 2;
+	}
+	else if (!strcmp(strvec_slot(strvec, 1), "any")) {
+		global_data->vrrp_system_owner = 1;
+	}
+	else {
+		global_data->vrrp_system_owner = 0;
+	}
+}
+
 #ifdef _WITH_VRRP_
 static void
 smtp_alert_vrrp_handler(const vector_t *strvec)
@@ -2301,6 +2317,7 @@ init_global_keywords(bool global_active)
 	install_keyword("shutdown_script_timeout", &shutdown_script_timeout_handler);
 	install_keyword("max_auto_priority", &max_auto_priority_handler);
 	install_keyword("min_auto_priority_delay", &min_auto_priority_delay_handler);
+	install_keyword("vrrp_system_owner", &vrrp_system_owner_handler);
 #ifdef _WITH_VRRP_
 	install_keyword("smtp_alert_vrrp", &smtp_alert_vrrp_handler);
 #endif

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -227,8 +227,14 @@ ignore_address_if_ours_or_link_local(struct ifaddrmsg *ifa, struct in_addr *addr
 
 		if (ifa->ifa_family == vrrp->family) {
 			list_for_each_entry(ip_addr, &vrrp->vip, e_list) {
-				if (addr_is_equal2(ifa, addr, ip_addr, ifp, vrrp))
-					return true;
+				if (addr_is_equal2(ifa, addr, ip_addr, ifp, vrrp)) {
+					/* When an instance is owning the
+					 * system IP, do not ignore. */
+					if (vrrp->base_priority == VRRP_PRIO_OWNER)
+						continue;
+					else
+						return true;
+				}
 			}
 		}
 

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -232,8 +232,7 @@ ignore_address_if_ours_or_link_local(struct ifaddrmsg *ifa, struct in_addr *addr
 					 * system IP, do not ignore. */
 					if (vrrp->base_priority == VRRP_PRIO_OWNER)
 						continue;
-					else
-						return true;
+					return true;
 				}
 			}
 		}

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -116,6 +116,7 @@ typedef struct _data {
 	unsigned			startup_script_timeout;
 	notify_script_t			*shutdown_script;
 	unsigned			shutdown_script_timeout;
+	unsigned			vrrp_system_owner;
 #ifndef _ONE_PROCESS_DEBUG_
 	const char			*reload_check_config;	/* log file name for validating new configuration before reloading */
 	const char			*reload_time_file;

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -66,6 +66,9 @@ enum vrrp_flags_bits {
 	VRRP_FLAG_EVIP_OTHER_FAMILY,		/* There are eVIPs of the different address family from the vrrp family */
 	VRRP_FLAG_ALLOW_NO_VIPS,		/* Suppresses warnings re no VIPs */
 	VRRP_FLAG_NOPREEMPT,			/* true if higher prio does not preempt lower */
+	VRRP_FLAG_SYSTEM_OWNER_DFT,		/* system owner instance can transit with any IP address on physical interface */
+	VRRP_FLAG_SYSTEM_OWNER_ANY,		/* system owner instance can transit with any VIP on physical interface */
+	VRRP_FLAG_SYSTEM_OWNER_STRICT,		/* system owner instance can transit with all VIPs on physical interafce */
 #ifdef _HAVE_VRRP_VMAC_
 	VRRP_VMAC_BIT,
 	VRRP_VMAC_UP_BIT,

--- a/keepalived/include/vrrp_scheduler.h
+++ b/keepalived/include/vrrp_scheduler.h
@@ -70,6 +70,7 @@ extern void vrrp_gratuitous_arp_thread(thread_ref_t);
 extern void vrrp_lower_prio_gratuitous_arp_thread(thread_ref_t);
 extern void vrrp_arp_thread(thread_ref_t);
 extern void try_up_instance(vrrp_t *, bool);
+extern bool vrrp_system_owner_ready(vrrp_t *, interface_t *);
 #ifdef _WITH_DUMP_THREADS_
 extern void dump_threads(void);
 #endif

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -4250,17 +4250,22 @@ set_vrrp_src_addr(void)
 					vrrp->saddr.ss_family = AF_UNSPEC;
 				}
 			}
-			else if (vrrp->family == AF_INET)
-				inet_ip4tosockaddr(&VRRP_CONFIGURED_IFP(vrrp)->sin_addr, &vrrp->saddr);
+			else if (vrrp->family == AF_INET) {
+				if(vrrp->base_priority < VRRP_PRIO_OWNER || vrrp_system_owner_ready(vrrp, VRRP_CONFIGURED_IFP(vrrp)))
+					inet_ip4tosockaddr(&VRRP_CONFIGURED_IFP(vrrp)->sin_addr, &vrrp->saddr);
+			}
 			else if (vrrp->family == AF_INET6) {
+				if(vrrp->base_priority < VRRP_PRIO_OWNER ||
+					vrrp_system_owner_ready(vrrp, VRRP_CONFIGURED_IFP(vrrp))) {
 #ifdef _HAVE_VRRP_IPVLAN_
-				if (__test_bit(VRRP_IPVLAN_BIT, &vrrp->flags)) {
-					if (!IN6_IS_ADDR_UNSPECIFIED(&vrrp->ifp->sin6_addr))
-						inet_ip6tosockaddr(&vrrp->ifp->sin6_addr, &vrrp->saddr);
-				} else
+					if (__test_bit(VRRP_IPVLAN_BIT, &vrrp->flags)) {
+						if (!IN6_IS_ADDR_UNSPECIFIED(&vrrp->ifp->sin6_addr))
+							inet_ip6tosockaddr(&vrrp->ifp->sin6_addr, &vrrp->saddr);
+					} else
 #endif
-					if (!IN6_IS_ADDR_UNSPECIFIED(&VRRP_CONFIGURED_IFP(vrrp)->sin6_addr))
-						inet_ip6tosockaddr(&VRRP_CONFIGURED_IFP(vrrp)->sin6_addr, &vrrp->saddr);
+						if (!IN6_IS_ADDR_UNSPECIFIED(&VRRP_CONFIGURED_IFP(vrrp)->sin6_addr))
+							inet_ip6tosockaddr(&VRRP_CONFIGURED_IFP(vrrp)->sin6_addr, &vrrp->saddr);
+				}
 			}
 		}
 	}

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -1002,6 +1002,15 @@ vrrp_prio_handler(const vector_t *strvec)
 	}
 	else
 		current_vrrp->base_priority = (uint8_t)base_priority;
+
+	if (current_vrrp->base_priority == VRRP_PRIO_OWNER){
+		if (global_data->vrrp_system_owner == 2)
+			__set_bit(VRRP_FLAG_SYSTEM_OWNER_STRICT, &current_vrrp->flags);
+		else if (global_data->vrrp_system_owner == 1)
+			__set_bit(VRRP_FLAG_SYSTEM_OWNER_ANY, &current_vrrp->flags);
+		else
+			__set_bit(VRRP_FLAG_SYSTEM_OWNER_DFT, &current_vrrp->flags);
+	}
 }
 static void
 vrrp_adv_handler(const vector_t *strvec)


### PR DESCRIPTION
When a VRRP instance is waiting for an IP address on the interface to start, if the vip is added on the interface, keepalived ignores it and remains in FAULT state, even if the VRRP instance is the system owner (priority 255 and vip = system IP). However, when adding an IP address different than the vip, the instance can change the state.

This makes nonsense for an instance is configured as the system owner transit to FAULT state since the system has not yet the vip. When the vip is added to the system, keepalived ignores it and this instance remains in FAULT state, whereas an IP address different than the vip can change the state of this instance.

Thus, do not ignore if a vip is added to the system when a VRRP instance is configured with 255 priority.

Signed-off-by: Loïc Sang <loic.sang@6wind.com>