### PR TITLE
vrrp: Add optional new JSON format including track_process details

### DIFF
--- a/doc/man/man5/keepalived.conf.5.in
+++ b/doc/man/man5/keepalived.conf.5.in
@@ -925,6 +925,10 @@ possibly following any cleanup actions needed.
     # In order to alleviate this, enabling data_use_instance includes the
     # instance name and network namespace in the file name of the .data files.
     \fBdata_use_instance \fR[<BOOL>]
+
+    # json_version 2 puts the VRRP data in a named array and adds
+    # track_process details. Default is version 1.
+    \fBjson_version \fR{1|2}
 }
 .fi
 .SH Linkbeat interfaces

--- a/keepalived/core/global_data.c
+++ b/keepalived/core/global_data.c
@@ -43,6 +43,9 @@
 #endif
 #include "align.h"
 #include "pidfile.h"
+#ifdef _WITH_JSON_
+#include "global_json.h"
+#endif
 
 /* global vars */
 data_t *global_data = NULL;
@@ -221,6 +224,10 @@ alloc_global_data(void)
 	new->lvs_syncd.mcast_group.ss_family = AF_UNSPEC;
 #endif
 #endif
+#endif
+
+#ifdef _WITH_JSON_
+	new->json_version = JSON_VERSION_V1;
 #endif
 
 	return new;
@@ -814,4 +821,7 @@ dump_global_data(FILE *fp, data_t * data)
 		conf_write(fp, " current realtime priority = %u", val);
 	if ((val = get_cur_rlimit_rttime()))
 		conf_write(fp, " current realtime time limit = %u", val);
+#ifdef _WITH_JSON_
+	conf_write(fp, " json_version %u", global_data->json_version);
+#endif
 }

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -19,7 +19,7 @@
  *              as published by the Free Software Foundation; either version
  *              2 of the License, or (at your option) any later version.
  *
- * Copyright (C) 2001-2017 Alexandre Cassen, <acassen@gmail.com>
+ * Copyright (C) 2001-2023 Alexandre Cassen, <acassen@gmail.com>
  */
 
 #include "config.h"
@@ -65,6 +65,9 @@
 #endif
 #endif
 #include "namespaces.h"
+#ifdef _WITH_JSON_
+#include "global_json.h"
+#endif
 
 /* Defined in kernel source file include/linux/sched.h but
  * not currently (Linux v5.10.12) exposed to userspace.
@@ -2267,6 +2270,27 @@ data_use_instance_handler(const vector_t *strvec)
 
 	global_data->data_use_instance = res;
 }
+
+#ifdef _WITH_JSON_
+static void
+json_version_handler(const vector_t *strvec)
+{
+	unsigned version = true;
+
+	if (vector_size(strvec) < 2) {
+		report_config_error(CONFIG_GENERAL_ERROR, "%s requires version", strvec_slot(strvec, 1));
+		return;
+	}
+
+	if (!read_unsigned_strvec(strvec, 1, &version, JSON_VERSION_V1, JSON_VERSION_V2, true)) {
+		report_config_error(CONFIG_GENERAL_ERROR, "Invalid JSON version");
+		return;
+	}
+
+	global_data->json_version = version;
+}
+#endif
+
 void
 init_global_keywords(bool global_active)
 {
@@ -2473,4 +2497,7 @@ init_global_keywords(bool global_active)
 #endif
 	install_keyword("tmp_config_directory", &config_copy_directory_handler);
 	install_keyword("data_use_instance", &data_use_instance_handler);
+#ifdef _WITH_JSON_
+	install_keyword("json_version", &json_version_handler);
+#endif
 }

--- a/keepalived/include/global_data.h
+++ b/keepalived/include/global_data.h
@@ -280,6 +280,9 @@ typedef struct _data {
 	const char			*vmac_addr_prefix;
 #endif
 #endif
+#ifdef _WITH_JSON_
+	unsigned			json_version;
+#endif
 } data_t;
 
 /* Global vars exported */

--- a/keepalived/include/global_json.h
+++ b/keepalived/include/global_json.h
@@ -6,7 +6,7 @@
  *
  * Part:        Output running VRRP state information in JSON format
  *
- * Author:      Damien Clabaut, <Damien.Clabaut@corp.ovh.com>
+ * Author:      Quentin Armitage <quentin@armitage.org.uk>
  *
  *              This program is distributed in the hope that it will be useful,
  *              but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -18,16 +18,16 @@
  *              as published by the Free Software Foundation; either version
  *              2 of the License, or (at your option) any later version.
  *
- * Copyright (C) 2017 Damien Clabaut, <Damien.Clabaut@corp.ovh.com>
- * Copyright (C) 2017-2023 Alexandre Cassen, <acassen@gmail.com>
+ * Copyright (C) 2023 Quentin Armitage <quentin@armitage.org.uk>
+ * Copyright (C) 2023-2023 Alexandre Cassen <acassen@gmail.com>
  */
 
-#ifndef _VRRP_JSON_H
-#define _VRRP_JSON_H
+#ifndef _GLOBAL_JSON_H
+#define _GLOBAL_JSON_H
 
-#include "global_json.h"
+/* https://jsonlint.com/ is useful to check validity of JSON output */
 
-/* Prototypes */
-extern void vrrp_print_json(void);
+#define JSON_VERSION_V1	1
+#define JSON_VERSION_V2	2
 
 #endif

--- a/keepalived/vrrp/vrrp_json.c
+++ b/keepalived/vrrp/vrrp_json.c
@@ -38,6 +38,7 @@
 #include "logger.h"
 #include "timer.h"
 #include "utils.h"
+#include "global_data.h"
 #include "json_writer.h"
 
 static inline double
@@ -263,6 +264,57 @@ vrrp_json_stats_dump(json_writer_t *wr, vrrp_t *vrrp)
 	return 0;
 }
 
+#ifdef _WITH_TRACK_PROCESS_
+static int
+vrrp_json_vprocess_dump(json_writer_t *wr, list_head_t *e)
+{
+	vrrp_tracked_process_t *vprocess = list_entry(e, vrrp_tracked_process_t, e_list);
+	char *params, *p;
+
+	jsonw_start_object(wr);
+
+	jsonw_string_field(wr, "process", vprocess->pname);
+	if (vprocess->process_params) {
+		params = MALLOC(vprocess->process_params_len);
+		memcpy(params, vprocess->process_params, vprocess->process_params_len);
+		p = params;
+		for (p = strchr(params, '\0'); p < params + vprocess->process_params_len - 1; p = strchr(params + 1, '\0'))
+			*p = ' ';
+		jsonw_string_field(wr, "parameters", params);
+		FREE(params);
+	}
+	jsonw_string_field(wr, "param match",
+		vprocess->param_match == PARAM_MATCH_NONE ? "none" :
+		vprocess->param_match == PARAM_MATCH_EXACT ? "exact" :
+		vprocess->param_match == PARAM_MATCH_PARTIAL ? "partial" :
+		vprocess->param_match == PARAM_MATCH_INITIAL ? "initial" :
+		"unknown");
+	jsonw_uint_field(wr, "min processes", vprocess->quorum);
+	if (vprocess->quorum_max < UINT_MAX)
+		jsonw_uint_field(wr, "max processes", vprocess->quorum_max);
+	jsonw_uint_field(wr, "current processes", vprocess->num_cur_proc);
+	jsonw_bool_field(wr, "have quorum", vprocess->have_quorum);
+	jsonw_int_field(wr, "weight", vprocess->weight_reverse ? -(int)vprocess->weight : vprocess->weight);
+	jsonw_float_field(wr, "terminate delay", (double)vprocess->terminate_delay / TIMER_HZ);
+	jsonw_float_field(wr, "fork delay", (double)vprocess->fork_delay / TIMER_HZ);
+	jsonw_bool_field(wr, "fork delay timer running", vprocess->fork_timer_thread);
+	jsonw_bool_field(wr, "terminate delay timer running", vprocess->terminate_timer_thread);
+	jsonw_bool_field(wr, "full command", vprocess->full_command);
+
+	jsonw_end_object(wr);
+
+	return 0;
+}
+
+static int
+vrrp_json_vprocesses_dump(json_writer_t *wr)
+{
+	vrrp_json_array_dump(wr, "track_process", &vrrp_data->vrrp_track_processes, vrrp_json_vprocess_dump);
+
+	return 0;
+}
+#endif
+
 /*
  *	Split dump function for future purpose
  *	this offer generic integration for mapping
@@ -275,6 +327,12 @@ vrrp_json_dump(FILE *fp)
 	vrrp_t *vrrp;
 
 	wr = jsonw_new(fp);
+
+	if (global_data->json_version == JSON_VERSION_V2) {
+		jsonw_start_object(wr);
+		jsonw_name(wr, "vrrp");
+	}
+
 	jsonw_start_array(wr);
 
 	list_for_each_entry(vrrp, &vrrp_data->vrrp, e_list) {
@@ -285,6 +343,16 @@ vrrp_json_dump(FILE *fp)
 	}
 
 	jsonw_end_array(wr);
+
+	if (global_data->json_version == JSON_VERSION_V2) {
+#ifdef _WITH_TRACK_PROCESS_
+		if (!list_empty(&vrrp_data->vrrp_track_processes))
+			vrrp_json_vprocesses_dump(wr);
+#endif
+
+		jsonw_end_object(wr);
+	}
+
 	jsonw_destroy(&wr);
 	return 0;
 }


### PR DESCRIPTION
The original JSON format did not allow for adding additional object types other than the original vrrp instances. This commit adds a json_version 2, which puts the vrrp instances in a named array and adds an array of the track_processes.