### PR TITLE
Update vrrp_json.c

### DIFF
--- a/keepalived/vrrp/vrrp_json.c
+++ b/keepalived/vrrp/vrrp_json.c
@@ -283,23 +283,23 @@ vrrp_json_vprocess_dump(json_writer_t *wr, list_head_t *e)
 		jsonw_string_field(wr, "parameters", params);
 		FREE(params);
 	}
-	jsonw_string_field(wr, "param match",
+	jsonw_string_field(wr, "param_match",
 		vprocess->param_match == PARAM_MATCH_NONE ? "none" :
 		vprocess->param_match == PARAM_MATCH_EXACT ? "exact" :
 		vprocess->param_match == PARAM_MATCH_PARTIAL ? "partial" :
 		vprocess->param_match == PARAM_MATCH_INITIAL ? "initial" :
 		"unknown");
-	jsonw_uint_field(wr, "min processes", vprocess->quorum);
+	jsonw_uint_field(wr, "min_processes", vprocess->quorum);
 	if (vprocess->quorum_max < UINT_MAX)
-		jsonw_uint_field(wr, "max processes", vprocess->quorum_max);
-	jsonw_uint_field(wr, "current processes", vprocess->num_cur_proc);
-	jsonw_bool_field(wr, "have quorum", vprocess->have_quorum);
+		jsonw_uint_field(wr, "max_processes", vprocess->quorum_max);
+	jsonw_uint_field(wr, "current_processes", vprocess->num_cur_proc);
+	jsonw_bool_field(wr, "have_quorum", vprocess->have_quorum);
 	jsonw_int_field(wr, "weight", vprocess->weight_reverse ? -(int)vprocess->weight : vprocess->weight);
-	jsonw_float_field(wr, "terminate delay", (double)vprocess->terminate_delay / TIMER_HZ);
-	jsonw_float_field(wr, "fork delay", (double)vprocess->fork_delay / TIMER_HZ);
-	jsonw_bool_field(wr, "fork delay timer running", vprocess->fork_timer_thread);
-	jsonw_bool_field(wr, "terminate delay timer running", vprocess->terminate_timer_thread);
-	jsonw_bool_field(wr, "full command", vprocess->full_command);
+	jsonw_float_field(wr, "terminate_delay", (double)vprocess->terminate_delay / TIMER_HZ);
+	jsonw_float_field(wr, "fork_delay", (double)vprocess->fork_delay / TIMER_HZ);
+	jsonw_bool_field(wr, "fork_delay_timer_running", vprocess->fork_timer_thread);
+	jsonw_bool_field(wr, "terminate_delay_timer_running", vprocess->terminate_timer_thread);
+	jsonw_bool_field(wr, "full_command", vprocess->full_command);
 
 	jsonw_end_object(wr);
 


### PR DESCRIPTION
Good morning, related to commit: #2248, changing white spaces for underscores in ```vrrp_json_vprocess_dump```.

Minimal Keepalived configuration:

```
global_defs {
        router_id R01

        vrrp_version 3

        vrrp_no_swap

        vrrp_strict

        json_version 2
}

vrrp_track_process asterisk {
        process "asterisk"
}

vrrp_track_process gunicorn {
        process "gunicorn"
}

vrrp_instance VI_1 {
        interface eth0
        virtual_router_id 99
        nopreempt
        state BACKUP
        priority 233
        advert_int 1

        accept

        virtual_ipaddress {
                192.168.1.250 dev eth0
        }

        track_process {
                asterisk
                gunicorn
        }

}
```

JSON output:

```
[...]
  "track_process": [
    {
      "process": "asterisk",
      "param_match": "none",
      "min_processes": 1,
      "current_processes": 1,
      "have_quorum": true,
      "weight": 0,
      "terminate_delay": 0,
      "fork_delay": 0,
      "fork_delay_timer_running": false,
      "terminate_delay_timer_running": false,
      "full_command": false
    },
    {
      "process": "gunicorn",
      "param_match": "none",
      "min_processes": 1,
      "current_processes": 3,
      "have_quorum": true,
      "weight": 0,
      "terminate_delay": 0,
      "fork_delay": 0,
      "fork_delay_timer_running": false,
      "terminate_delay_timer_running": false,
      "full_command": false
    }
  ]
[...]
````

Regards

