### PR TITLE
vrrp: work around missing promiscuous netlink notifications

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1853,6 +1853,8 @@ netlink_if_link_populate(interface_t *ifp, struct rtattr *tb[], struct ifinfomsg
 	ifp->mtu = *PTR_CAST(uint32_t, RTA_DATA(tb[IFLA_MTU]));
 	ifp->hw_type = ifi->ifi_type;
 
+	ifp->group = *(uint32_t *)RTA_DATA(tb[IFLA_GROUP]);
+
 	if (!netlink_if_get_ll_addr(ifp, tb, IFLA_ADDRESS, name))
 		return false;
 	if (!netlink_if_get_ll_addr(ifp, tb, IFLA_BROADCAST, name))

--- a/keepalived/include/vrrp_if.h
+++ b/keepalived/include/vrrp_if.h
@@ -139,6 +139,7 @@ typedef struct _interface {
 	unsigned		up_debounce_timer;
 	unsigned		down_debounce_timer;
 	uint32_t		mtu;			/* MTU for this interface_t */
+	uint32_t		group;			/* GROUP for this interface_t */
 	unsigned short		hw_type;		/* Type of hardware address */
 	u_char			hw_addr[MAX_ADDR_LEN];	/* MAC address */
 	u_char			hw_addr_bcast[MAX_ADDR_LEN]; /* broadcast address */


### PR DESCRIPTION
If the base interface does not implement IFF_UNICAST_FLT, for example
it is a bridge interface, no Netlink notification is sent by the kernel
when promiscuity is set on the base interface.

The promiscuous state of the base interface is correct in kernel but it
is in incorrect in daemons that listen to the interface netlink messages
(eg. DPDK).

The issue is still there in kernel 5.4.0

Force a notification by re-setting IFLA_GROUP for the base interface.