### PR TITLE
vrrp: fix ipv6 vrrp in fault state because no ipv4 address

### DIFF
--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -1115,16 +1115,14 @@ alloc_vrrp_vip(const vector_t *strvec)
 	if (!(new_ipaddr = alloc_ipaddress(strvec, false)))
 		return;
 
-	if (last_ipaddr) {
-		address_family = IP_FAMILY(new_ipaddr);
+	address_family = IP_FAMILY(new_ipaddr);
 
-		if (current_vrrp->family == AF_UNSPEC)
-			current_vrrp->family = address_family;
-		else if (address_family != current_vrrp->family) {
-			report_config_error(CONFIG_GENERAL_ERROR, "(%s): address family must match VRRP instance [%s] - ignoring", current_vrrp->iname, strvec_slot(strvec, 0));
-			free_ipaddress(new_ipaddr);
-			return;
-		}
+	if (current_vrrp->family == AF_UNSPEC)
+		current_vrrp->family = address_family;
+	else if (address_family != current_vrrp->family) {
+		report_config_error(CONFIG_GENERAL_ERROR, "(%s): address family must match VRRP instance [%s] - ignoring", current_vrrp->iname, strvec_slot(strvec, 0));
+		free_ipaddress(new_ipaddr);
+		return;
 	}
 
 	list_add_tail(&new_ipaddr->e_list, &current_vrrp->vip);


### PR DESCRIPTION
Setting an IPv6 VRRP virtual address on an interface that has no IPv4 address results in a persistent FAULT state:

> Mar 21 11:23:25 ubuntu2204 Keepalived_vrrp[95135]: (vrrp) entering FAULT state (no IPv4 address for interface)

Virtual addresses are not correctly parsed in alloc_vrrp_vip(). vrrp_complete_instance() considers that the IPv4 address family is set by default if no virtual addresses are detected.

>         /* Default to IPv4. This can only happen if no VIPs are specified. */
>         if (vrrp->family == AF_UNSPEC)
>                 vrrp->family = AF_INET;

Fix the virtual address parsing.

Fixes: 516032ec39 ("config parser: Fix segfault caused by extra '}' and other parser fixes")