### PR TITLE
vrrp: restore the vmac ipv6 link-local after flapping

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1599,10 +1599,10 @@ process_interface_flags_change(interface_t *ifp, unsigned ifi_flags)
 		process_if_status_change(ifp);
 	}
 
-	if (!now_up)
-		interface_down(ifp);
-	else
+	if (now_up)
 		interface_up(ifp);
+	else
+		interface_down(ifp);
 }
 
 static void

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -240,6 +240,7 @@ set_link_local_address(const vrrp_t *vrrp)
 	 * This is so that VRRP advertisements will be sent from a non-VIP address, but
 	 * using the VRRP MAC address */
 	struct in6_addr addr;
+	char addr_str[INET6_ADDRSTRLEN];
 
 	if (vrrp->saddr.ss_family == AF_INET6)
 		addr = PTR_CAST_CONST(struct sockaddr_in6, &vrrp->saddr)->sin6_addr;
@@ -247,6 +248,11 @@ set_link_local_address(const vrrp_t *vrrp)
 		addr = vrrp->configured_ifp->sin6_addr;
 	else
 		make_link_local_address(&addr, vrrp->configured_ifp->base_ifp->hw_addr);
+
+	inet_ntop(AF_INET6, &addr, addr_str, sizeof(addr_str));
+
+	log_message(LOG_INFO, "Adding link local address %s for %s, interface %u", addr_str,
+			vrrp->iname, vrrp->ifp->ifindex);
 
 	return add_link_local_address(vrrp->ifp, &addr);
 }


### PR DESCRIPTION
The user is not supposed to shutdown a vmac interface created by
keepalived. However, it can mistakenly happen. When the link is
re-established, the link-local has disappear (the kernel removes all
IPv6 addresses on link down except if keep_addr_on_down sysctl is on)
and sending VRRP packet is no nore possible.

Restore the IPv6 Link-Local after a VMAC interface flapping.

Note that the IPv6 Virtual Addresses are also removed on link down which
is the desired behavior. Enabling keep_addr_on_down sysctl would keep
the link-local without this patch but would break this behavior.