### PR TITLE
core: Add IRWXU etc for umask and update documentation

### DIFF
--- a/doc/man/man5/keepalived.conf.5.in
+++ b/doc/man/man5/keepalived.conf.5.in
@@ -803,7 +803,8 @@ possibly following any cleanup actions needed.
 
     # The umask to use for creating files. The number can be specified in hex, octal
     #   or decimal. BITS are I{R|W|X}{USR|GRP|OTH}, e.g. IRGRP, separated by '|'s.
-    #   The default umask is IWGRP | IWOTH. This option cannot override the
+    #   IRWX{U|G|O} can also be specified.
+    #   The default umask is IXUSR | IRWXG | IRWXO. This option cannot override the
     #   command-line option.
     \fBumask \fR[NUMBER|BITS]
 

--- a/keepalived/core/global_parser.c
+++ b/keepalived/core/global_parser.c
@@ -2043,12 +2043,15 @@ umask_handler(const vector_t *strvec)
 				if      (!strncmp(p, "IRUSR", 5)) umask_bits |= S_IRUSR;
 				else if (!strncmp(p, "IWUSR", 5)) umask_bits |= S_IWUSR;
 				else if (!strncmp(p, "IXUSR", 5)) umask_bits |= S_IXUSR;
+				else if (!strncmp(p, "IRWXU", 5)) umask_bits |= S_IRWXU;
 				else if (!strncmp(p, "IRGRP", 5)) umask_bits |= S_IRGRP;
 				else if (!strncmp(p, "IWGRP", 5)) umask_bits |= S_IWGRP;
 				else if (!strncmp(p, "IXGRP", 5)) umask_bits |= S_IXGRP;
+				else if (!strncmp(p, "IRWXG", 5)) umask_bits |= S_IRWXG;
 				else if (!strncmp(p, "IROTH", 5)) umask_bits |= S_IROTH;
 				else if (!strncmp(p, "IWOTH", 5)) umask_bits |= S_IWOTH;
 				else if (!strncmp(p, "IXOTH", 5)) umask_bits |= S_IXOTH;
+				else if (!strncmp(p, "IRWXO", 5)) umask_bits |= S_IRWXO;
 				else {
 					report_config_error(CONFIG_GENERAL_ERROR, "Unknown umask bit %s", p);
 					return;


### PR DESCRIPTION
keepalived.conf(5) man page incorrectly specified that the default umask was IWGRP | IWOTH, whereas it is IXUSR | IRWXG | IRWXO.