### PR TITLE
vrrp: Fix checking for unicast if no interface specified

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2366,7 +2366,7 @@ chk_min_cfg(vrrp_t *vrrp)
 		report_config_error(CONFIG_GENERAL_ERROR, "(%s) the virtual router id must be set", vrrp->iname);
 		return false;
 	}
-	if (!vrrp->ifp && !__test_bit(VRRP_FLAG_UNICAST, &vrrp->flags)) {
+	if (!vrrp->ifp && !__test_bit(VRRP_FLAG_UNICAST_CONFIGURED, &vrrp->flags)) {
 		report_config_error(CONFIG_GENERAL_ERROR, "(%s) Unknown interface!", vrrp->iname);
 		return false;
 	}


### PR DESCRIPTION
Fixes: a534e94 vrrp: Use vrrp_t flags for checking if unicast is in use Resolves issue #2270