### PR TITLE
vrrp: do not replace the ipv6 link-local by the same address

### DIFF
--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -125,6 +125,10 @@ change_link_local_address(interface_t *ifp, struct in6_addr *old_addr, struct in
 {
 	ip_address_t ipaddress;
 
+	/* There is no point in replacing the address with the same address */
+	if (inaddr_equal(AF_INET6, old_addr, new_addr))
+		return true;
+
 	memset(&ipaddress, 0, sizeof(ipaddress));
 
 	/* Delete the old address */


### PR DESCRIPTION
Do not replace the IPv6 Link-Local address by the same address.