### PR TITLE
vrrp: fix persistent FAULT state with use_vmac on a down base interface

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1027,22 +1027,25 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 							 !__test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->flags) &&
 							 ifa->ifa_family == AF_INET6 &&
 							 vrrp->ifp->is_ours) {
-								inet_ip6tosockaddr(addr.in6, &vrrp->saddr);
+								if (vrrp->saddr.ss_family == AF_UNSPEC) {
+									inet_ip6tosockaddr(addr.in6, &vrrp->saddr);
+									if (
 #if 0
-								if (IN6_IS_ADDR_UNSPECIFIED(&vrrp->ifp->sin6_addr)) {
-									/* This should never happen with the current code since we always
-									 * create a link local address on the VMAC interface.
-									 * However, if in future it is decided not to automatically create
-									 * a link local address on the VMAC interface if the parent interface
-									 * does not have one, then we will need the following code
-									 */
-									if (add_link_local_address(vrrp->ifp, addr.in6) &&
+										/* This should never happen with the current code since we always
+										 * create a link local address on the VMAC interface.
+										 * However, if in future it is decided not to automatically create
+										 * a link local address on the VMAC interface if the parent interface
+										 * does not have one, then we will need the following code
+										 */
+									    add_link_local_address(vrrp->ifp, addr.in6) &&
+#endif
 									    vrrp->num_script_if_fault &&
 									    (!__test_bit(VRRP_FLAG_SADDR_FROM_CONFIG, &vrrp->flags) || is_tracking_saddr))
 										try_up_instance(vrrp, false);
-								} else
-#endif
+								} else {
+									inet_ip6tosockaddr(addr.in6, &vrrp->saddr);
 									reset_link_local_address(&vrrp->ifp->sin6_addr, vrrp);
+								}
 						}
 #endif
 					}


### PR DESCRIPTION
If the base interface of VMAC is down at startup, the VRRP instance will remain on FAULT state even if the base interface is set up.

Since the base interface is down, the VMAC operational state is also down and there is no operational IPv6 address. keepalived increments vrrp->num_script_if_fault. When the interface comes up, the link-local IPv6 address is set but vrrp->num_script_if_fault is not decremented. keepalived considers that there is still a remaining fault and keeps the VRRP instance in FAULT state.

Increment vrrp->num_script_if_fault when an IPv6 appears on the VMAC.

Fixes: 4c7a94a409 ("vrrp: Make VMAC IPv6 link local address mirror parent interface")