### PR TITLE
dbus: fix type of Name property in Interface

### DIFF
--- a/keepalived/dbus/org.keepalived.Vrrp1.Instance.xml
+++ b/keepalived/dbus/org.keepalived.Vrrp1.Instance.xml
@@ -25,7 +25,7 @@
 	<signal name='VrrpStatusChange'>
 	  <arg type='u' name='status' />
 	</signal>
-	<property type='s' name='Name' access='read' />
+	<property type='(s)' name='Name' access='read' />
 	<property type='(us)' name='State' access='read' />
   </interface>
 </node>


### PR DESCRIPTION
The type of the `Name` property of `org.keepalived.Vrrp1.Interface` seems to be incorrect.

In the code (https://github.com/acassen/keepalived/blob/333e086155507eb7ee30378cc9ff88d48af2d338/keepalived/vrrp/vrrp_dbus.c#L843), the property is a `(s)`, however, the XML interface file states that the type is `s`.

It causes problems when using the interface.