### PR TITLE
json-updates

### DIFF
--- a/keepalived/include/vrrp_ipaddress.h
+++ b/keepalived/include/vrrp_ipaddress.h
@@ -96,6 +96,8 @@ typedef struct _ip_address {
 
 #define	IPADDRESSTOS_BUF_LEN	(INET6_ADDRSTRLEN + 4)     /* allow for subnet */
 
+#define INFINITY_LIFE_TIME      0xFFFFFFFF
+
 /* Forward reference */
 struct ipt_handle;
 
@@ -118,3 +120,4 @@ extern void clear_diff_static_addresses(void);
 extern void reinstate_static_address(ip_address_t *);
 
 #endif
+

--- a/keepalived/vrrp/vrrp_ipaddress.c
+++ b/keepalived/vrrp/vrrp_ipaddress.c
@@ -43,9 +43,6 @@
 #include "vrrp_firewall.h"
 #endif
 
-
-#define INFINITY_LIFE_TIME      0xFFFFFFFF
-
 const char *
 ipaddresstos(char *buf, const ip_address_t *ip_addr)
 {
@@ -836,3 +833,4 @@ void reinstate_static_address(ip_address_t *ip_addr)
 	format_ipaddress(ip_addr, buf, sizeof(buf));
 	log_message(LOG_INFO, "Restoring deleted static address %s", buf);
 }
+

--- a/keepalived/vrrp/vrrp_json.c
+++ b/keepalived/vrrp/vrrp_json.c
@@ -39,6 +39,7 @@
 #include "timer.h"
 #include "utils.h"
 #include "global_data.h"
+#include "rttables.h"
 #include "json_writer.h"
 
 static inline double
@@ -59,13 +60,68 @@ vrrp_json_script_dump(json_writer_t *wr, const char *prop, notify_script_t *scri
 }
 
 static int
+vrrp_json_ip_peer_dump(json_writer_t *wr, ip_address_t *ipaddr)
+{
+	char peer[INET6_ADDRSTRLEN + 4];
+
+	inet_ntop(ipaddr->ifa.ifa_family, &ipaddr->peer, peer, sizeof(peer));
+	jsonw_string_field(wr, "peer", peer);
+	jsonw_uint_field(wr, "peer_prefixlen", ipaddr->ifa.ifa_prefixlen);
+
+	return 0;
+}
+
+static int
 vrrp_json_ip_dump(json_writer_t *wr, list_head_t *e)
 {
 	ip_address_t *ipaddr = list_entry(e, ip_address_t, e_list);
-	char buf[256];
 
-	format_ipaddress(ipaddr, buf, sizeof(buf));
-	jsonw_string(wr, buf);
+	if (ipaddr->ifa.ifa_family == AF_UNSPEC)
+		return -1;
+
+	jsonw_start_object(wr);
+
+	jsonw_string_field(wr, "ip", ipaddresstos(NULL, ipaddr));
+	if (!IP_IS6(ipaddr) && ipaddr->u.sin.sin_brd.s_addr)
+		jsonw_string_field(wr, "brd", inet_ntop2(ipaddr->u.sin.sin_brd.s_addr));
+	jsonw_string_field(wr, "dev", IF_NAME(ipaddr->ifp));
+#ifdef _HAVE_VRRP_VMAC_
+	jsonw_string_field(wr, "base_ifp",(ipaddr->ifp != ipaddr->ifp->base_ifp) ? ipaddr->ifp->base_ifp->ifname : "none");
+	jsonw_bool_field(wr, "use_vmac", (ipaddr->use_vmac) ? true : false);
+#endif
+	jsonw_string_field(wr, "scope", get_rttables_scope(ipaddr->ifa.ifa_scope));
+	jsonw_string_field(wr, "label", (ipaddr->label) ? ipaddr->label : "");
+	vrrp_json_ip_peer_dump(wr, ipaddr);
+	jsonw_bool_field(wr, "home", (ipaddr->flags & IFA_F_HOMEADDRESS) ? true : false);
+	jsonw_bool_field(wr, "no_dad", (ipaddr->flagmask & IFA_F_NODAD) ? true : false);
+#ifdef IFA_F_MANAGETEMPADDR
+	jsonw_bool_field(wr, "mng_tmp_addr", (ipaddr->flags & IFA_F_MANAGETEMPADDR) ? true : false);
+#endif
+#ifdef IFA_F_NOPREFIXROUTE
+	jsonw_bool_field(wr, "no_prefix_route", (ipaddr->flags & IFA_F_NOPREFIXROUTE) ? true : false);
+#endif
+#ifdef IFA_F_MCAUTOJOIN
+	jsonw_bool_field(wr, "auto_join", (ipaddr->flags & IFA_F_MCAUTOJOIN) ? true : false);
+#endif
+	jsonw_bool_field(wr, "dont_track", (ipaddr->dont_track) ? true : false);
+	jsonw_bool_field(wr, "track_group", (ipaddr->track_group) ? true : false);
+	if (IP_IS6(ipaddr)) {
+		if (ipaddr->preferred_lft == 0)
+			jsonw_string_field(wr, "preferred_lft", "deprecated");
+		else if (ipaddr->preferred_lft == INFINITY_LIFE_TIME)
+			jsonw_string_field(wr, "preferred_lft", "forever");
+		else
+			jsonw_uint_field(wr, "preferred_lft", ipaddr->preferred_lft);
+	}
+	jsonw_bool_field(wr, "set", (ipaddr->set) ? true : false);
+#ifdef _WITH_IPTABLES_
+	jsonw_bool_field(wr, "iptable_set", (ipaddr->iptable_rule_set) ? true : false);
+#endif
+#ifdef _WITH_NFTABLES_
+	jsonw_bool_field(wr, "nftable_set", (ipaddr->nftable_rule_set) ? true : false);
+#endif
+
+	jsonw_end_object(wr);
 	return 0;
 }
 
@@ -107,7 +163,7 @@ vrrp_json_track_script_dump(json_writer_t *wr, list_head_t *e)
 	tracked_sc_t *tsc = list_entry(e, tracked_sc_t, e_list);
 	vrrp_script_t *vscript = tsc->scr;
 
-	jsonw_string(wr, cmd_str(&vscript->script));
+	jsonw_string(wr, vscript->sname);
 	return 0;
 }
 
@@ -264,6 +320,54 @@ vrrp_json_stats_dump(json_writer_t *wr, vrrp_t *vrrp)
 	return 0;
 }
 
+static int
+vrrp_json_vscript_dump(json_writer_t *wr, list_head_t *e)
+{
+	vrrp_script_t *vscript = list_entry(e, vrrp_script_t, e_list);
+
+	jsonw_start_object(wr);
+
+	jsonw_string_field(wr, "script_name", vscript->sname);
+	jsonw_string_field(wr, "script", cmd_str(&vscript->script));
+	jsonw_uint_field(wr, "interval", vscript->interval / TIMER_HZ);
+	jsonw_uint_field(wr, "timeout", vscript->timeout / TIMER_HZ);
+	jsonw_int_field(wr, "weight", vscript->weight);
+	jsonw_bool_field(wr, "reverse", vscript->weight_reverse);
+	jsonw_int_field(wr, "rise", vscript->rise);
+	jsonw_int_field(wr, "fall", vscript->fall);
+	jsonw_uint_field(wr, "uid", vscript->script.uid);
+	jsonw_uint_field(wr, "gid", vscript->script.gid);
+	jsonw_string_field(wr, "init_state",
+		vscript->init_state == SCRIPT_INIT_STATE_INIT ? "init":
+		vscript->init_state == SCRIPT_INIT_STATE_FAILED ? "failed" :
+		vscript->init_state == SCRIPT_INIT_STATE_INIT_RELOAD ? "reload" :
+		"unknown"
+	);
+	jsonw_int_field(wr, "status",
+		vscript->result >= vscript->rise ? 1 :
+		0
+	);
+	jsonw_string_field(wr, "state",
+		vscript->state == SCRIPT_STATE_IDLE ? "idle" :
+		vscript->state == SCRIPT_STATE_RUNNING ? "running" :
+		vscript->state == SCRIPT_STATE_REQUESTING_TERMINATION ? "requesting_termination" :
+		vscript->state == SCRIPT_STATE_FORCING_TERMINATION ? "forcing_termination" :
+		"unknown"
+	);
+
+	jsonw_end_object(wr);
+
+	return 0;
+}
+
+static int
+vrrp_json_vscripts_dump(json_writer_t *wr)
+{
+	vrrp_json_array_dump(wr, "track_script", &vrrp_data->vrrp_script, vrrp_json_vscript_dump);
+
+	return 0;
+}
+
 #ifdef _WITH_TRACK_PROCESS_
 static int
 vrrp_json_vprocess_dump(json_writer_t *wr, list_head_t *e)
@@ -345,6 +449,8 @@ vrrp_json_dump(FILE *fp)
 	jsonw_end_array(wr);
 
 	if (global_data->json_version == JSON_VERSION_V2) {
+		if (!list_empty(&vrrp_data->vrrp_script))
+			vrrp_json_vscripts_dump(wr);
 #ifdef _WITH_TRACK_PROCESS_
 		if (!list_empty(&vrrp_data->vrrp_track_processes))
 			vrrp_json_vprocesses_dump(wr);


### PR DESCRIPTION
A little first update over JSON modules to start discussing it and get some feedback on current and future work.

**Update motivation**: JSON output is incomplete in some modules or even is missing for others (BFD for example).

In ```vrrp_json.c``` I applied the following updates:

1. Added ```track_script``` details.
2. ```vips``` property is now an object.

Result (after some reviews I chose to display all ```vips``` properties):

```
{
  "vrrp": [
    {
      "data": {
        "iname": "VI_1",
        "dont_track_primary": 0,
        "skip_check_adv_addr": 0,
        "strict_mode": 1,
        "vmac_ifname": "",
        "ifp_ifname": "eth0",
        "master_priority": 0,
        "last_transition": 1680943642.428485,
        "garp_delay": 5,
        "garp_refresh": 0,
        "garp_rep": 5,
        "garp_refresh_rep": 1,
        "garp_lower_prio_delay": 0,
        "garp_lower_prio_rep": 0,
        "lower_prio_no_advert": 1,
        "higher_prio_send_advert": 0,
        "vrid": 99,
        "base_priority": 233,
        "effective_priority": 233,
        "vipset": false,
        "promote_secondaries": false,
        "adver_int": 1,
        "master_adver_int": 1,
        "accept": 1,
        "nopreempt": true,
        "preempt_delay": 0,
        "state": 3,
        "wantstate": 1,
        "version": 3,
        "smtp_alert": false,
        "notify_deleted": false,
        "vips": [
          {
            "ip": "10.1.0.9",
            "dev": "eth0",
            "base_ifp": "none",
            "use_vmac": false,
            "scope": "global",
            "label": "",
            "peer": "0.0.0.0",
            "peer_prefixlen": 32,
            "home": false,
            "no_dad": false,
            "mng_tmp_addr": false,
            "no_prefix_route": false,
            "auto_join": false,
            "dont_track": false,
            "track_group": false,
            "set": false,
            "iptable_set": false
          },
          {
            "ip": "10.1.0.8",
            "dev": "eth0",
            "base_ifp": "none",
            "use_vmac": false,
            "scope": "global",
            "label": "",
            "peer": "0.0.0.0",
            "peer_prefixlen": 32,
            "home": false,
            "no_dad": false,
            "mng_tmp_addr": false,
            "no_prefix_route": false,
            "auto_join": false,
            "dont_track": false,
            "track_group": false,
            "set": false,
            "iptable_set": false
          }
        ],
        "track_script": [
          "sip_invite_control"
        ]
      },
      "stats": {
        "advert_rcvd": 0,
        "advert_sent": 0,
        "become_master": 0,
        "release_master": 0,
        "packet_len_err": 0,
        "advert_interval_err": 0,
        "ip_ttl_err": 0,
        "invalid_type_rcvd": 0,
        "addr_list_err": 0,
        "invalid_authtype": 0,
        "pri_zero_rcvd": 0,
        "pri_zero_sent": 0
      }
    },
    {
      "data": {
        "iname": "VI_2",
        "dont_track_primary": 0,
        "skip_check_adv_addr": 0,
        "strict_mode": 1,
        "vmac_ifname": "vrrp.100",
        "ifp_ifname": "vrrp.100",
        "master_priority": 0,
        "last_transition": 1680943642.3693,
        "garp_delay": 5,
        "garp_refresh": 0,
        "garp_rep": 5,
        "garp_refresh_rep": 1,
        "garp_lower_prio_delay": 0,
        "garp_lower_prio_rep": 0,
        "lower_prio_no_advert": 1,
        "higher_prio_send_advert": 0,
        "vrid": 100,
        "base_priority": 234,
        "effective_priority": 234,
        "vipset": false,
        "promote_secondaries": false,
        "adver_int": 1,
        "master_adver_int": 1,
        "accept": 1,
        "nopreempt": true,
        "preempt_delay": 0,
        "state": 3,
        "wantstate": 3,
        "version": 3,
        "smtp_alert": false,
        "notify_deleted": false,
        "vips": [
          {
            "ip": "10.1.0.7",
            "dev": "vrrp.100",
            "base_ifp": "eth0",
            "use_vmac": false,
            "scope": "global",
            "label": "",
            "peer": "0.0.0.0",
            "peer_prefixlen": 32,
            "home": false,
            "no_dad": false,
            "mng_tmp_addr": false,
            "no_prefix_route": false,
            "auto_join": false,
            "dont_track": false,
            "track_group": false,
            "set": false,
            "iptable_set": false
          }
        ]
      },
      "stats": {
        "advert_rcvd": 0,
        "advert_sent": 0,
        "become_master": 0,
        "release_master": 0,
        "packet_len_err": 0,
        "advert_interval_err": 0,
        "ip_ttl_err": 0,
        "invalid_type_rcvd": 0,
        "addr_list_err": 0,
        "invalid_authtype": 0,
        "pri_zero_rcvd": 0,
        "pri_zero_sent": 0
      }
    }
  ],
  "track_script": [
    {
      "script_name": "sip_invite_control",
      "script": "'/opt/test.sh'",
      "interval": 50,
      "timeout": 0,
      "weight": 0,
      "reverse": false,
      "rise": 1,
      "fall": 1,
      "uid": 116,
      "gid": 125,
      "init_state": "init",
      "status": 0,
      "state": "running"
    }
  ]
}
```

----

I'm also working on ```bfd_json.c```.

An incomplete example:

```
{
  "bfd": [
    {
      "iname": "bfd_1",
      "neighbor_ip": "10.1.0.1",
      "src_ip": "10.1.0.14",
      "required_min_rx_interval": 20000,
      "required_min_tx_interval": 50000,
      "desired_idle_tx_interval": 1000000,
      "detection_multiplier": 5,
      "max_hops": 2,
      "passive": false,
      "send_event_to_vrrp_process": false,
      "send_event_to_checker_process": true,
      "fd_out": 9,
      "send_error": false,
      "local": {
        "state": "Down",
        "discriminator": 1288400932,
        "diag": "AdminDown",
        "demand": 0,
        "tx_intv": 1000000,
        "detect_time": 0
      },
      "remote": {
        "state": "Down",
        "discriminator": 0,
        "diag": "AdminDown",
        "min_tx_intv": 0,
        "min_rx_intv": 0,
        "demand": 0,
        "detect_multiplier": 0,
        "tx_intv": 0,
        "detect_time": 0
      },
      "last_seen": "never"
    },
    {
      "iname": "bfd_2",
      "neighbor_ip": "10.1.0.2",
      "src_ip": "10.1.0.14",
      "required_min_rx_interval": 20000,
      "required_min_tx_interval": 50000,
      "desired_idle_tx_interval": 1000000,
      "detection_multiplier": 5,
      "max_hops": 2,
      "passive": false,
      "send_event_to_vrrp_process": false,
      "send_event_to_checker_process": true,
      "fd_out": 11,
      "send_error": false,
      "local": {
        "state": "Down",
        "discriminator": 2355688454,
        "diag": "AdminDown",
        "demand": 0,
        "tx_intv": 1000000,
        "detect_time": 0
      },
      "remote": {
        "state": "Down",
        "discriminator": 0,
        "diag": "AdminDown",
        "min_tx_intv": 0,
        "min_rx_intv": 0,
        "demand": 0,
        "detect_multiplier": 0,
        "tx_intv": 0,
        "detect_time": 0
      },
      "last_seen": "never"
    }
  ]
}

```

----

Why I mencioned ```bfd_json.c``` (which does not exists) on ```vrrp_json.c``` updates?

When you run: ```kill -s $(keepalived --signum=DATA) $(cat /run/keepalived/keepalived.pid)``` - for vrrp_data - or ```kill -s $(keepalived --signum=DATA) $(cat /run/keepalived/keepalived.pid)``` - for bfd_data - you will get the same output structure, where ```< Global definitions >``` acts as 'header':

```
------< Global definitions >------
[...]
------< VRRP Topology >------ || ------< BFD Topology >------
```

In a JSON oriented output we may want to print out the ```< Global definitions >``` area in a separated file.