### PR TITLE
vrrp: fix compilation error when VRRP_VMAC is disabled

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1176,10 +1176,12 @@ netlink_if_address_filter(__attribute__((unused)) struct sockaddr_nl *snl, struc
 							 vrrp->ifp) &&
 						 vrrp->family == ifa->ifa_family &&
 						 vrrp->saddr.ss_family != AF_UNSPEC &&
+#ifdef _HAVE_VRRP_VMAC_
 						 (vrrp->family != AF_INET6 ||	/* For an IPv6 VMAC if down removes the link local address */
 						  !__test_bit(VRRP_VMAC_BIT, &vrrp->flags) ||
 						  __test_bit(VRRP_VMAC_XMITBASE_BIT, &vrrp->flags) ||
 						  IF_ISUP(ifp)) &&
+#endif
 						 (!__test_bit(VRRP_FLAG_SADDR_FROM_CONFIG, &vrrp->flags) || is_tracking_saddr)) {
 						down_instance(vrrp);
 						vrrp->saddr.ss_family = AF_UNSPEC;


### PR DESCRIPTION
solve #2294 
if VRRP_VMAC is not enabled, VRRP_VMAC_BIT AND VRRP_VMAC_XMITBASE_BIT are invalid. However, VRRP_VMAC_BIT AND VRRP_VMAC_XMITBASE_BIT are used without checking _HAVE_VRRP_VMAC_ in netlink_if_address_filter().

fixes: 74b203b ("vrrp:restore the vmac ipv6 link_local after flapping")
