### PR TITLE
vrrp: Set sysctl arp_ignore to 1 on IPv6 VMACs

### DIFF
--- a/keepalived/include/vrrp_if_config.h
+++ b/keepalived/include/vrrp_if_config.h
@@ -34,7 +34,7 @@ extern void set_promote_secondaries(interface_t*);
 extern void reset_promote_secondaries(interface_t*);
 #ifdef _HAVE_VRRP_VMAC_
 extern void restore_rp_filter(void);
-extern void set_interface_parameters(const interface_t*, interface_t*);
+extern void set_interface_parameters(const interface_t*, interface_t*, sa_family_t);
 extern void reset_interface_parameters(interface_t*);
 extern void link_set_ipv6(const interface_t*, bool);
 #endif

--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -435,10 +435,9 @@ netlink_link_add_vmac(vrrp_t *vrrp, const interface_t *old_interface)
 	if (!ifp->ifindex)
 		return false;
 
-	if (vrrp->family == AF_INET && create_interface) {
+	if (create_interface) {
 		/* Set the necessary kernel parameters to make macvlans work for us */
-// If this saves current base_ifp's settings, we need to be careful if multiple VMACs on same i/f
-		set_interface_parameters(ifp, ifp->base_ifp);
+		set_interface_parameters(ifp, ifp->base_ifp, vrrp->family);
 	}
 
 #ifdef _WITH_FIREWALL_


### PR DESCRIPTION
Setting arp_ignore to 1 ensures that the VMAC interface does not respond to ARP requests for IPv4 addresses not configured on the VMAC.