### PR TITLE
ipvs: add/remove sorry server of group server when reload

### DIFF
--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -337,9 +337,10 @@ misc_check_child_thread(thread_ref_t thread)
 					/* The process does not exist, and we should
 					 * have reaped its exit status, otherwise it
 					 * would exist as a zombie process. */
-					log_message(LOG_INFO, "Misc script %s child (PID %d) lost", misck_checker->script.args[0], pid);
+					log_message(LOG_INFO, "Misc script %s child (PID %d) lost, register checker again", misck_checker->script.args[0], pid);
 					misck_checker->state = SCRIPT_STATE_IDLE;
 					timeout = 0;
+					goto recheck;
 				} else {
 					log_message(LOG_INFO, "kill -%d of process %s(%d) with new state %u failed with errno %d", sig_num, misck_checker->script.args[0], pid, misck_checker->state, errno);
 					timeout = 1000;
@@ -488,6 +489,7 @@ misc_check_child_thread(thread_ref_t thread)
 		}
 	}
 
+recheck:
 	/* Register next timer checker */
 	next_time = timer_add_long(misck_checker->last_ran, checker->retry_it ? checker->delay_before_retry : checker->delay_loop);
 	next_time = timer_sub_now(next_time);

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -687,6 +687,19 @@ ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 			ipvs_set_vsge_alive_state(IP_VS_SO_SET_ADDDEST, vsge, vs);
 		}
 	}
+
+	if (vs->s_svr && vs->s_svr->alive && vs->s_svr->reloaded && vs->s_svr->set) {
+		ipvs_set_drule(IP_VS_SO_SET_ADDDEST, &drule, vs->s_svr);
+
+		if (vs->s_svr->forwarding_method != IP_VS_CONN_F_MASQ)
+			drule.user.port = inet_sockaddrport(&vsge->addr);
+		else
+			drule.user.port = inet_sockaddrport(&vs->s_svr->addr);
+
+		ipvs_group_range_cmd(IP_VS_SO_SET_ADDDEST, &srule, &drule, vsge);
+
+		ipvs_set_vsge_alive_state(IP_VS_SO_SET_ADDDEST, vsge, vs);
+	}
 }
 
 /* Remove a specific vs group entry */
@@ -748,6 +761,20 @@ ipvs_group_remove_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge
 
 			ipvs_set_vsge_alive_state(IP_VS_SO_SET_DELDEST, vsge, vs);
 		}
+	}
+
+	if (vs->s_svr && vs->s_svr->alive && vs->s_svr->set) {
+		if (global_data->lvs_flush_on_stop == LVS_NO_FLUSH) {
+			ipvs_set_drule(IP_VS_SO_SET_ADDDEST, &drule, vs->s_svr);
+
+			if (vs->s_svr->forwarding_method != IP_VS_CONN_F_MASQ)
+				drule.user.port = inet_sockaddrport(&vsge->addr);
+			else
+				drule.user.port = inet_sockaddrport(&vs->s_svr->addr);
+
+			ipvs_group_range_cmd(IP_VS_SO_SET_DELDEST, &srule, &drule, vsge);
+		}
+		ipvs_set_vsge_alive_state(IP_VS_SO_SET_DELDEST, vsge, vs);
 	}
 
 	/* Remove VS entry if this is the last VS using it */


### PR DESCRIPTION
issue: when using virtual server groups, if all rs down and sorry server up, at this time remove/add vs entry in configure file and then do reload, vs entry can not be removed.

fix: add/remove sorry server same as normal rs when reload server groups