### PR TITLE
vrrp: For use_vmac and use_ipvlan, copy the group from the base interface

### DIFF
--- a/keepalived/vrrp/vrrp_vmac.c
+++ b/keepalived/vrrp/vrrp_vmac.c
@@ -277,6 +277,7 @@ netlink_link_add_vmac(vrrp_t *vrrp, const interface_t *old_interface)
 	struct rtattr *linkinfo;
 	struct rtattr *data;
 	interface_t *ifp;
+	uint32_t group;
 	bool create_interface = true;
 	struct {
 		struct nlmsghdr n;
@@ -386,6 +387,14 @@ netlink_link_add_vmac(vrrp_t *vrrp, const interface_t *old_interface)
 			addattr32(&req.n, sizeof(req), IFLA_LINK, vrrp->configured_ifp->ifindex);
 			addattr_l(&req.n, sizeof(req), IFLA_IFNAME, vrrp->vmac_ifname, strlen(vrrp->vmac_ifname));
 		}
+
+		/*
+		 * Copy the group from the base interface to allow firewall rules
+		 * (iptables devgroup or nftables iifgroup, oifgroup) to continue
+		 * working regardless of the use_vmac setting.
+		 */
+		group = vrrp->configured_ifp->base_ifp->group;
+		addattr_l(&req.n, sizeof(req), IFLA_GROUP, &group, sizeof(group));
 		addattr_l(&req.n, sizeof(req), IFLA_ADDRESS, if_ll_addr, ETH_ALEN);
 
 #ifdef _HAVE_VRF_


### PR DESCRIPTION
It is useful in many instances to set up firewall rules based on interface groups so that sets of interfaces may be aggregated by group and matched with a single rule rather than by listing them all.

Prior to this change, when use_vmac or use_ipvlan is used, new interfaces are created with the default group, which breaks this ability.

Further complicating the issue is that nftables resolves interface names to ifindex at load time. This is problematic with keepalived's interface creation, which usually comes after the firewall loading, forcing the use of iifname, oifname instead (similar to iptables -i, -o).

By copying the group value, such firewall rules can continue to work regardless of the use_vmac or use_ipvlan settings, since packets may now arrive on, or be routed out from, the new interfaces.

I've tested that this works with use_vmac, but I'm not sure about use_ipvlan or cross-namespace cases. There is already a function for setting interface groups, netlink_link_group(), but it was introduced to work around a netlink issue by setting it to the current value, and it creates a whole new request, which is unnecessary here.

I've thought about other ways to make firewall rules that play more nicely with the use_vmac interfaces, but so far the best I've come up with is interface groups and iifname, oifname for all of the other cases. Eventually, maybe it would make sense for the kernel to update nft findexes dynamically whenever an interface name appears, rather than doing it only at load time.