### PR TITLE
Fix lack macro for find_rttables_group()

### DIFF
--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -571,6 +571,7 @@ vrrp_vmac_handler(const vector_t *strvec)
 			continue;
 		}
 
+#if HAVE_DECL_FRA_SUPPRESS_IFGROUP
 		if (!strcmp(strvec_slot(strvec, i), "group")) {
 			uint32_t group;
 			if (!find_rttables_group(strvec_slot(strvec, ++i), &group)) {
@@ -581,6 +582,7 @@ vrrp_vmac_handler(const vector_t *strvec)
 			current_vrrp->vmac_group = group;
 			continue;
 		}
+#endif
 
 		if (!strcmp(strvec_slot(strvec, i), "name")) {
 			/* Skip over "name" */
@@ -695,6 +697,7 @@ vrrp_ipvlan_handler(const vector_t *strvec)
 			continue;
 		}
 
+#if HAVE_DECL_FRA_SUPPRESS_IFGROUP
 		if (!strcmp(strvec_slot(strvec, i), "group")) {
 			uint32_t group;
 			if (!find_rttables_group(strvec_slot(strvec, ++i), &group)) {
@@ -705,6 +708,7 @@ vrrp_ipvlan_handler(const vector_t *strvec)
 			current_vrrp->vmac_group = group;
 			continue;
 		}
+#endif
 
 		if (!strcmp(strvec_slot(strvec, i), "name")) {
 			i++;

--- a/lib/rttables.c
+++ b/lib/rttables.c
@@ -322,11 +322,13 @@ find_rttables_dsfield(const char *name, uint8_t *id)
 	return ret;
 }
 
+#if HAVE_DECL_FRA_SUPPRESS_IFGROUP && defined _WITH_SNMP_VRRP_
 bool
 find_rttables_group(const char *name, uint32_t *id)
 {
 	return find_entry(name, id, &rt_groups, RT_GROUPS_FILE, NULL, INT32_MAX);
 }
+#endif
 
 bool
 find_rttables_realms(const char *name, uint32_t *id)

--- a/lib/rttables.h
+++ b/lib/rttables.h
@@ -31,7 +31,9 @@ extern void clear_rt_names(void);
 extern bool find_rttables_table(const char *, uint32_t *);
 extern bool find_rttables_dsfield(const char *, uint8_t *);
 extern bool find_rttables_realms(const char *, uint32_t *);
+#if HAVE_DECL_FRA_SUPPRESS_IFGROUP && defined _WITH_SNMP_VRRP_
 extern bool find_rttables_group(const char *, uint32_t *);
+#endif
 extern bool find_rttables_proto(const char *, uint8_t *);
 extern bool find_rttables_rtntype(const char *, uint8_t *);
 extern bool find_rttables_scope(const char *, uint8_t *);


### PR DESCRIPTION
lack macro HAVE_DECL_FRA_SUPPRESS_IFGROUP,
which is similar with get_rttables_group().

This fix build error when macro HAVE_DECL_FRA_SUPPRESS_IFGROUP=0  (on centos 7  kernel 3.10.0)
```
rttables.c:328:31: error: use of undeclared identifier 'rt_groups'
  328 |         return find_entry(name, id, &rt_groups, RT_GROUPS_FILE, NULL, INT32_MAX);
      |                                      ^
rttables.c:328:42: error: use of undeclared identifier 'RT_GROUPS_FILE'
  328 |         return find_entry(name, id, &rt_groups, RT_GROUPS_FILE, NULL, INT32_MAX);
```