### PR TITLE
vrrp: fix commit "fix lack macro for find_rttables_group()"

### DIFF
--- a/lib/rttables.c
+++ b/lib/rttables.c
@@ -322,7 +322,7 @@ find_rttables_dsfield(const char *name, uint8_t *id)
 	return ret;
 }
 
-#if HAVE_DECL_FRA_SUPPRESS_IFGROUP && defined _WITH_SNMP_VRRP_
+#if HAVE_DECL_FRA_SUPPRESS_IFGROUP
 bool
 find_rttables_group(const char *name, uint32_t *id)
 {

--- a/lib/rttables.h
+++ b/lib/rttables.h
@@ -31,7 +31,7 @@ extern void clear_rt_names(void);
 extern bool find_rttables_table(const char *, uint32_t *);
 extern bool find_rttables_dsfield(const char *, uint8_t *);
 extern bool find_rttables_realms(const char *, uint32_t *);
-#if HAVE_DECL_FRA_SUPPRESS_IFGROUP && defined _WITH_SNMP_VRRP_
+#if HAVE_DECL_FRA_SUPPRESS_IFGROUP
 extern bool find_rttables_group(const char *, uint32_t *);
 #endif
 extern bool find_rttables_proto(const char *, uint8_t *);


### PR DESCRIPTION
Commit "fix lack macro for find_rttabpes_group()" - db4b11d didn't work if building without SNMP support. This is now resolved by this patch.