### PR TITLE
vrrp: correct some parameter/return types

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1317,7 +1317,7 @@ AC_CHECK_DECLS([IPV6_MULTICAST_ALL],
   [
     add_system_opt([IPV6_MULTICAST_ALL])
 
-    # We can't include <linux/in6.h> before <netinet/in.h> otherwise there a a lot of
+    # We can't include <linux/in6.h> before <netinet/in.h> otherwise there are a lot of
     #   duplicate definitions. If we include them the other way around and <netinet/in.h>
     #   doesn't define IPV6_MULTICAST_ALL, then we don't get the definition from
     #   <linux/in6.h> due to the UAPI guards to stop compile errors.

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3792,7 +3792,7 @@ vrrp_complete_instance(vrrp_t * vrrp)
 							memcpy(addr_vrrp.ll_addr, vrrp->ll_addr, sizeof(vrrp->ll_addr));
 						}
 
-						netlink_link_add_vmac(&addr_vrrp, false);
+						netlink_link_add_vmac(&addr_vrrp, NULL);
 					} else {
 						ifp->is_ours = true;
 						ifp->if_type = IF_TYPE_MACVLAN;

--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -1500,7 +1500,7 @@ setup_interface(vrrp_t *vrrp)
 	if (!vrrp->ifp->ifindex) {
 		/* coverity[var_deref_model] - vrrp->configured_ifp is not NULL for VMAC */
 		if (__test_bit(VRRP_VMAC_BIT, &vrrp->flags) &&
-		    !netlink_link_add_vmac(vrrp, false))
+		    !netlink_link_add_vmac(vrrp, NULL))
 			return;
 #ifdef _HAVE_VRRP_IPVLAN_
 		/* coverity[var_deref_model] - vrrp->configured_ifp is not NULL for IPVLAN */

--- a/lib/parser.c
+++ b/lib/parser.c
@@ -2066,7 +2066,7 @@ check_definition(const char *buf)
 	char *str;
 
 	if (buf[0] != '$')
-		return false;
+		return NULL;
 
 	if (!isalpha(buf[1]) && buf[1] != '_')
 		return NULL;


### PR DESCRIPTION
GCC 13 now reports an error when "false" is used instead of "NULL". This commit now resolves the three instances of the wrong use identified.