### PR TITLE
all: fix clean_path()

### DIFF
--- a/lib/notify.c
+++ b/lib/notify.c
@@ -712,7 +712,7 @@ clean_path(const char *old_argv)
 
 	slash = strchr(ip, '/');
 	if (!slash)
-		strcpy(op, slash);
+		strcpy(op, ip);
 	else if (slash > ip) {
 		strncpy(op, ip, slash - ip);
 		op += slash - ip;


### PR DESCRIPTION
GCC 13 identified a bug in clean_path where the source of a strcpy() was always NULL.