### PR TITLE
core: initialise script structure in start_validate_reload_conf_child()

### DIFF
--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -994,7 +994,7 @@ reload_check_child_thread(thread_ref_t thread)
 static void
 start_validate_reload_conf_child(void)
 {
-	notify_script_t script;
+	notify_script_t script = { .path = NULL };
 	int i;
 	int ret;
 	int argc;

--- a/lib/notify.c
+++ b/lib/notify.c
@@ -214,7 +214,7 @@ system_call_script(thread_master_t *m, thread_func_t func, void * arg, unsigned 
 		execve(script->path ? script->path : script->args[0], args.execve_args, environ);
 
 		/* error */
-		log_message(LOG_ALERT, "Error exec-ing command '%s', error %d: %m", script->args[0], errno);
+		log_message(LOG_ALERT, "Error exec-ing command '%s', error %d: %m", script->path ? script->path : script->args[0], errno);
 	} else {
 		retval = system(str = cmd_str(script));
 


### PR DESCRIPTION
Due to the path field not being set to NULL, it was attempting to exec a random string when reload_check_config was configured.