### PR TITLE
ipvs: Fix stats handling when only have 32 bit stats

### DIFF
--- a/doc/man/man5/keepalived.conf.5.in
+++ b/doc/man/man5/keepalived.conf.5.in
@@ -681,8 +681,8 @@ possibly following any cleanup actions needed.
     # When SNMP requests are made, the checker process only updates the
     # virtual and real server stats from the kernel if the last time the
     # stats for that virtual server were read was more than this configured
-    # interval. The default interval is 5 seconds, and the valid range is
-    # 1 milli-second to 30 seconds.
+    # interval (in seconds). The default interval is 5 seconds, and the
+    # valid range is 0.001 (1 milli-second) to 30 seconds.
     \fBsnmp_vs_stats_update_interval\fR <TIMER>
 
     # Like snmp_vs_stats_update_interval but for real servers. Stats for

--- a/keepalived/check/libipvs.c
+++ b/keepalived/check/libipvs.c
@@ -961,7 +961,7 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg)
 	} else if (svc_attrs[IPVS_SVC_ATTR_STATS])
 #endif
 	{
-		if (ipvs_parse_stats64(&(get->user.entrytable[0].ip_vs_stats),
+		if (ipvs_parse_stats(&(get->user.entrytable[0].ip_vs_stats),
 				     svc_attrs[IPVS_SVC_ATTR_STATS]) != 0)
 			return -1;
 	}
@@ -969,12 +969,6 @@ static int ipvs_services_parse_cb(struct nl_msg *msg, void *arg)
 	get->user.entrytable[0].user.num_dests = 0;
 
 	get->user.num_services++;
-
-#if 0
-	get = REALLOC(get, sizeof(*get)
-	      + sizeof(ipvs_service_entry_t) * (get->user.num_services + 1));
-	*getp = get;
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
This resolves commit 930f3b72 "ipvs: Don't duplicate storage of 32 bit SNMP stats"