### PR TITLE
vrrp: remove logging on status output

### DIFF
--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -758,8 +758,6 @@ sigusr2_vrrp(__attribute__((unused)) void *v, int sig)
 static void
 sigjson_vrrp(__attribute__((unused)) void *v, __attribute__((unused)) int sig)
 {
-	log_message(LOG_INFO, "Printing VRRP as json for process(%d) on signal",
-		getpid());
 	thread_add_event(master, print_vrrp_json, NULL, 0);
 }
 #endif


### PR DESCRIPTION
I am the [maintainer](https://github.com/openwrt/packages/blob/master/net/keepalived/Makefile#L22) of the keepalived packages in OpenWrt.
There is also a [LuCI](https://github.com/openwrt/luci/tree/master/applications/luci-app-keepalived) frontend that queries the status of keepalived.

To get the status of keepalived, the json signal handling is used.

The problem now is, that when the LuCI status page is  open in the browser, this removed message in the PR is show every 3 second on status query. In my opinion, this floods the log and is not necessary.