### PR TITLE
ipvs: Update status code of misc checker if changes while in fault state

### DIFF
--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -403,7 +403,8 @@ misc_check_child_thread(thread_ref_t thread)
 				checker->cur_weight = 0;
 				misck_checker->last_exit_code = status;
 			}
-		}
+		} else	//  if (status != misck_checker->last_exit_code)
+			misck_checker->last_exit_code = status;
 	}
 	else if (WIFSIGNALED(wait_status)) {
 		if (misck_checker->state == SCRIPT_STATE_REQUESTING_TERMINATION && WTERMSIG(wait_status) == SIGTERM) {


### PR DESCRIPTION
The exit code of a misc checker can be read via SNMP. The misc check code was not updating the last exit code if the checker was not dynamic, the checker was already down (i.e. returned a non 0 exit code), and the exit code changed from the previous exit code. This meant that the exit code reported via SNMP was not the latest exit code, but the exit code that caused the status of the checker to change.

This commit now updates the last exit code, even if the checker is already down.