### PR TITLE
all: add --ignore-sigint option

### DIFF
--- a/doc/man/man8/keepalived.8.in
+++ b/doc/man/man8/keepalived.8.in
@@ -44,6 +44,7 @@ keepalived \- load\-balancing and high\-availability service
 [\fB\-\-perf\fP[={all|run|end}]]
 [\fB\-\-debug\fP[=debug-options]]
 [\fB\-\-no-mem-check\fP]
+[\fB\-\-ignore-sigint\fP]
 [\fB\-v\fP|\fB\-\-version\fP]
 [\fB\-h\fP|\fB\-\-help\fP]
 
@@ -215,6 +216,10 @@ The data recorded is for use with the perf tool.
 .TP
 \fB --no-mem-check\fP
 Disable malloc() etc mem-checks if they have been compiled into keepalived.
+.TP
+\fB --ignore-sigint\fP
+Disable SIGINT handling (defaults to terminating keepalived). This is needed
+for running keepalived under GDB.
 .TP
 \fB --debug\fP[=debug-options]]
 Enables debug options if they have been compiled into keepalived.

--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -240,7 +240,10 @@ static void
 bfd_signal_init(void)
 {
 	signal_set(SIGHUP, sigreload_bfd, NULL);
-	signal_set(SIGINT, sigend_bfd, NULL);
+	if (ignore_sigint)
+		signal_ignore(SIGINT);
+	else
+		signal_set(SIGINT, sigend_bfd, NULL);
 	signal_set(SIGTERM, sigend_bfd, NULL);
 	signal_set(SIGUSR1, sigdump_bfd, NULL);
 #ifdef THREAD_DUMP

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -565,7 +565,10 @@ static void
 check_signal_init(void)
 {
 	signal_set(SIGHUP, sigreload_check, NULL);
-	signal_set(SIGINT, sigend_check, NULL);
+	if (ignore_sigint)
+		signal_ignore(SIGINT);
+	else
+		signal_set(SIGINT, sigend_check, NULL);
 	signal_set(SIGTERM, sigend_check, NULL);
 	signal_set(SIGUSR1, sigusr1_check, NULL);
 #ifdef THREAD_DUMP

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -82,6 +82,8 @@ extern unsigned os_major;		/* Kernel version */
 extern unsigned os_minor;
 extern unsigned os_release;
 
+extern bool ignore_sigint;
+
 extern void free_parent_mallocs_startup(bool);
 extern void free_parent_mallocs_exit(void);
 extern const char *make_syslog_ident(const char*);

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -789,7 +789,10 @@ static void
 vrrp_signal_init(void)
 {
 	signal_set(SIGHUP, sigreload_vrrp, NULL);
-	signal_set(SIGINT, sigend_vrrp, NULL);
+	if (ignore_sigint)
+		signal_ignore(SIGINT);
+	else
+		signal_set(SIGINT, sigend_vrrp, NULL);
 	signal_set(SIGTERM, sigend_vrrp, NULL);
 	signal_set(SIGUSR1, sigusr1_vrrp, NULL);
 	signal_set(SIGUSR2, sigusr2_vrrp, NULL);


### PR DESCRIPTION
This is needed for running keepalived under GDB (see https://bugzilla.kernel.org/show_bug.cgi?id=9039#c8).