### PR TITLE
core: ensure only one instance of keepalived can run per config_id

### DIFF
--- a/keepalived/bfd/bfd_daemon.c
+++ b/keepalived/bfd/bfd_daemon.c
@@ -82,7 +82,7 @@ stop_bfd(int status)
 		return;
 
 	/* Stop daemon */
-	pidfile_rm(bfd_pidfile);
+	pidfile_rm(&bfd_pidfile);
 
 	/* Clean data */
 	free_global_data(global_data);
@@ -407,6 +407,8 @@ start_bfd_child(void)
 
 	prog_type = PROG_TYPE_BFD;
 
+	close_other_pidfiles();
+
 	/* Close the read end of the event notification pipes, and the track_process fd */
 #ifdef _WITH_VRRP_
 	close(bfd_vrrp_event_pipe[0]);
@@ -456,7 +458,7 @@ start_bfd_child(void)
 	separate_config_file();
 
 	/* Child process part, write pidfile */
-	if (!pidfile_write(bfd_pidfile, getpid())) {
+	if (!pidfile_write(&bfd_pidfile)) {
 		/* Fatal error */
 		log_message(LOG_INFO,
 			    "BFD child process: cannot write pidfile");

--- a/keepalived/check/check_daemon.c
+++ b/keepalived/check/check_daemon.c
@@ -177,7 +177,7 @@ checker_terminate_phase2(void)
 	ipvs_stop();
 
 	/* Stop daemon */
-	pidfile_rm(checkers_pidfile);
+	pidfile_rm(&checkers_pidfile);
 
 	/* Clean data */
 	if (global_data)
@@ -710,6 +710,8 @@ start_check_child(void)
 	deregister_thread_addresses();
 #endif
 
+	close_other_pidfiles();
+
 #ifdef _WITH_BFD_
 	/* Close the write end of the BFD checker event notification pipe and the track_process fd */
 	close(bfd_checker_event_pipe[1]);
@@ -758,7 +760,7 @@ start_check_child(void)
 	separate_config_file();
 
 	/* Child process part, write pidfile */
-	if (!pidfile_write(checkers_pidfile, getpid())) {
+	if (!pidfile_write(&checkers_pidfile)) {
 		log_message(LOG_INFO, "Healthcheck child process: cannot write pidfile");
 		exit(KEEPALIVED_EXIT_FATAL);
 	}

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 
 #include "scheduler.h"
+#include "pidfile.h"
 
 /* State flags */
 enum daemon_bits {
@@ -58,21 +59,21 @@ extern unsigned long daemon_mode;	/* Which child processes are run */
 extern const char *conf_file;		/* Configuration file */
 #ifdef _WITH_VRRP_
 extern pid_t vrrp_child;		/* VRRP child process ID */
-extern const char *vrrp_pidfile;	/* overrule default pidfile */
+extern pidfile_t vrrp_pidfile;		/* overrule default pidfile */
 extern bool have_vrrp_instances;	/* vrrp instances configured */
 #endif
 #ifdef _WITH_LVS_
 extern pid_t checkers_child;		/* Healthcheckers child process ID */
-extern const char *checkers_pidfile;	/* overrule default pidfile */
+extern pidfile_t checkers_pidfile;	/* overrule default pidfile */
 extern bool have_virtual_servers;	/* virtual servers configured */
 #endif
 #ifdef _WITH_BFD_
 extern pid_t bfd_child;			/* BFD child process ID */
-extern const char *bfd_pidfile;		/* overrule default pidfile */
+extern pidfile_t bfd_pidfile;		/* overrule default pidfile */
 extern bool have_bfd_instances;		/* bfd instances configured */
 #endif
 extern bool reload;			/* Set during a reload */
-extern const char *main_pidfile;	/* overrule default pidfile */
+extern pidfile_t main_pidfile;		/* overrule default pidfile */
 #ifdef _WITH_SNMP_
 extern bool snmp_option;		/* Enable SNMP support */
 extern const char *snmp_socket;		/* Socket to use for SNMP agent */

--- a/keepalived/include/pidfile.h
+++ b/keepalived/include/pidfile.h
@@ -45,14 +45,22 @@
 #define	PID_EXTENSION		".pid"
 #define	RELOAD_EXTENSION	".reload"
 
+typedef struct pidfile {
+	const char *	path;
+	bool		free_path;
+	int		fd;
+} pidfile_t;
+
 extern const char *pid_directory;
 
 /* Prototypes */
 extern void create_pid_dir(void);
 extern void remove_pid_dir(void);
 extern char *make_pidfile_name(const char *, const char *, const char *);
-extern bool pidfile_write(const char *, int);
-extern void pidfile_rm(const char *);
+extern void pidfile_close(pidfile_t *, bool);
+extern bool pidfile_write(const pidfile_t *);
+extern void pidfile_rm(pidfile_t *);
+extern void close_other_pidfiles(void);
 extern bool keepalived_running(unsigned long);
 
 #endif

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -351,7 +351,7 @@ vrrp_terminate_phase2(int exit_status)
 	close_std_fd();
 
 	/* Stop daemon */
-	pidfile_rm(vrrp_pidfile);
+	pidfile_rm(&vrrp_pidfile);
 
 	exit(exit_status);
 }
@@ -1074,6 +1074,8 @@ start_vrrp_child(void)
 	deregister_thread_addresses();
 #endif
 
+	close_other_pidfiles();
+
 #ifdef _WITH_BFD_
 	/* Close the write end of the BFD vrrp event notification pipe */
 	close(bfd_vrrp_event_pipe[1]);
@@ -1115,7 +1117,7 @@ start_vrrp_child(void)
 	separate_config_file();
 
 	/* Child process part, write pidfile */
-	if (!pidfile_write(vrrp_pidfile, getpid())) {
+	if (!pidfile_write(&vrrp_pidfile)) {
 		/* Fatal error */
 		log_message(LOG_INFO, "VRRP child process: cannot write pidfile");
 		exit(0);


### PR DESCRIPTION
There was a window when keepalived starts up when if two (or more) instances were starting at the same time, they might not detect the other instance is running.

This commit add advisort file locking on the PID files to ensure that only one instance can run at a time.