### PR TITLE
vrrp: check ifindex != 0 before using the interface

### DIFF
--- a/keepalived/vrrp/vrrp_iproute.c
+++ b/keepalived/vrrp/vrrp_iproute.c
@@ -953,6 +953,7 @@ format_iproute(const ip_route_t *route, char *buf, size_t buf_len)
 
 		if (route->set &&
 		    !route->dont_track &&
+		    route->configured_ifindex &&
 		    (!route->oif || route->oif->ifindex != route->configured_ifindex)) {
 			if ((ifp = if_get_by_ifindex(route->configured_ifindex))) {
 				if ((op += (size_t)snprintf(op, (size_t)(buf_end - op), " [dev %s]", ifp->ifname)) >= buf_end - 1)


### PR DESCRIPTION
If an interface is deleted, it is identified by the ifindex being set to 0, so we must ignore any interfaces with a 0 ifindex.