### PR TITLE
all: Ensure pid file exists when respawning child process

### DIFF
--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -169,6 +169,7 @@ const char *snmp_socket;				/* Socket to use for SNMP agent */
 #endif
 static const char *syslog_ident;			/* syslog ident if not default */
 bool use_pid_dir;					/* Put pid files in /run/keepalived or @localstatedir@/run/keepalived */
+bool children_started;					/* Set once children have been run first time */
 
 unsigned os_major;					/* Kernel version */
 unsigned os_minor;
@@ -559,6 +560,8 @@ start_keepalived(__attribute__((unused)) thread_ref_t thread)
 	} else
 		pidfile_rm(&bfd_pidfile);
 #endif
+
+	children_started = true;
 
 #ifndef _ONE_PROCESS_DEBUG_
 	/* Do we have a reload file to monitor */

--- a/keepalived/include/main.h
+++ b/keepalived/include/main.h
@@ -79,6 +79,7 @@ extern bool snmp_option;		/* Enable SNMP support */
 extern const char *snmp_socket;		/* Socket to use for SNMP agent */
 #endif
 extern bool use_pid_dir;		/* pid files in /run/keepalived */
+extern bool children_started;		/* Set once children have been run first time */
 extern unsigned os_major;		/* Kernel version */
 extern unsigned os_minor;
 extern unsigned os_release;

--- a/keepalived/include/pidfile.h
+++ b/keepalived/include/pidfile.h
@@ -58,7 +58,7 @@ extern void create_pid_dir(void);
 extern void remove_pid_dir(void);
 extern char *make_pidfile_name(const char *, const char *, const char *);
 extern void pidfile_close(pidfile_t *, bool);
-extern bool pidfile_write(const pidfile_t *);
+extern bool pidfile_write(pidfile_t *);
 extern void pidfile_rm(pidfile_t *);
 extern void close_other_pidfiles(void);
 extern bool keepalived_running(unsigned long);


### PR DESCRIPTION
If a child process is respawned, the old pidfile may or may not still exist. If it doesn't exist, we need to recreate it. If it still exists we need to reset our file offset and truncate the file before re-wrighting it.