### PR TITLE
bfd: use time_t to avoid implicit ptr type casting

### DIFF
--- a/keepalived/bfd/bfd_data.c
+++ b/keepalived/bfd/bfd_data.c
@@ -110,7 +110,7 @@ static void
 conf_write_sands(FILE *fp, const char *text, unsigned long sands)
 {
 	char time_str[26];
-	long secs;
+	time_t secs;
 
 	if (sands == TIMER_NEVER) {
 		conf_write(fp, "   %s = [disabled]", text);


### PR DESCRIPTION
This fixes an incompatible pointer type [-Wincompatible-pointer-types] issue when compiling keepalived with GCC 14 [1] in 32-bit architectures where time_t size is 64 bits.

[1] https://gcc.gnu.org/gcc-14/porting_to.html

The issue was found when compiling keepalived in Ubuntu  24.10 for armhf with gcc 14  (https://launchpadlibrarian.net/749244069/buildlog_ubuntu-oracular-armhf.keepalived_1%3A2.3.1-1_BUILDING.txt.gz)