### PR TITLE
vrrp: always add a keepalived entry to rt_addrprotos is none exists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -238,8 +238,6 @@ AC_ARG_WITH(iproute-usr-dir,
   [AS_HELP_STRING([--with-iproute-usr-dir=PATH_TO_CONFIG_FILES], [specify usr directory iproute2 uses for config files])])
 AC_ARG_WITH(iproute-etc-dir,
   [AS_HELP_STRING([--with-iproute-etc-dir=PATH_TO_CONFIG_FILES], [specify etc directory iproute2 uses for config files])])
-AC_ARG_ENABLE(update-rt-addrprotos-file,
-  [AS_HELP_STRING([--enable-update-rt-addrprotos-file], [update iproute rt_addrprotos file if no entry for keepalived])])
 AC_ARG_ENABLE(strict-config-checks,
   [AS_HELP_STRING([--enable-strict-config-checks], [build with strict configuration checking])])
 AC_ARG_ENABLE(hardening,
@@ -2795,14 +2793,6 @@ AS_IF([test .${iproute_usr_dir} != . ],
     add_config_opt([IPROUTE_USR_DIR=$iproute_usr_dir])
   ])
 
-AS_IF([test .${enable_update_rt_addrprotos_file} = ."yes"],
-  [
-    AC_DEFINE([UPDATE_RT_ADDRPROTOS_FILE], [ 1 ], [update iproute2 rt_addrprotos file])
-    echo You probably do not want to use this option\; it is better to create an
-    echo entry in /etc/iproute2/rt_addrprotos, or add keepalived.conf with a relevant
-    echo entry in /etc/iproute2/rt_addrprotos.d if your version of iproute2 is \>= 6.12.
-  ])
-
 dnl - Check type of rlim_t for printf() - this check needs to be late on
 dnl - since _FILE_OFFSET_BITS (set when using netsnmp) alters sizeof(rlim_t)
 SAV_CFLAGS="$CFLAGS"
@@ -3533,9 +3523,6 @@ echo "Strict config checks     : ${STRICT_CONFIG}"
 echo "Build documentation      : ${HAVE_SPHINX_BUILD}"
 echo "iproute usr directory    : ${iproute_usr_dir}"
 echo "iproute etc directory    : ${iproute_etc_dir}"
-if test .${enable_update_rt_addrprotos_file} = .yes; then
-  echo "update rt_addrprotos     : Yes"
-fi
 if test ${ENABLE_STACKTRACE} = Yes; then
   echo "Stacktrace support       : Yes"
 fi

--- a/keepalived/vrrp/vrrp_daemon.c
+++ b/keepalived/vrrp/vrrp_daemon.c
@@ -318,10 +318,6 @@ vrrp_terminate_phase2(int exit_status)
 
 	clear_rt_names();
 
-#if HAVE_DECL_IFA_PROTO && defined UPDATE_RT_ADDRPROTOS_FILE
-	remove_created_addrprotos_file();
-#endif
-
 	if (global_data->vrrp_notify_fifo.fd != -1)
 		notify_fifo_close(&global_data->notify_fifo, &global_data->vrrp_notify_fifo);
 

--- a/lib/rttables.h
+++ b/lib/rttables.h
@@ -47,8 +47,5 @@ extern const char *get_rttables_scope(uint32_t);
 extern const char *get_rttables_group(uint32_t);
 #endif
 extern const char *get_rttables_rtntype(uint8_t);
-#if HAVE_DECL_IFA_PROTO && defined UPDATE_RT_ADDRPROTOS_FILE
-extern void remove_created_addrprotos_file(void);
-#endif
 
 #endif


### PR DESCRIPTION
A request to add an entry to /usr/share/iproute2/rt_addrprotos.d for keepalived to use for an address protocol was rejected with the following reason:

iproute2 now allows apps to drop custom files in
/etc/iproute2/rt_addrprotos.d, so this can be managed within keepalived.

(see https://lore.kernel.org/netdev/ca8a1945-3a02-4830-b39d-5e90c0515c91@kernel.org/T/#t)

So this commit now adds an entry to
/etc/iproute2/rt_addrprotos.d/keepalived.conf if the version of iproute2 >= 6.12, or to /etc/iproute2/rt_addrprotos if the version is between 6.3 and 6.11.