### PR TITLE
Install linux-headers pkg to build in Docker

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -31,6 +31,7 @@ RUN apk --no-cache add \
 @NFTABLES_TRUE@	libnftnl-dev \
 	libnl3 \
 	libnl3-dev \
+	linux-headers \
 	make \
 	musl-dev \
 @SNMP_TRUE@	net-snmp-dev \


### PR DESCRIPTION
Avoids this error when building on Alpine in Docker:
```
9.540 configure: error: Missing/unusable kernel header file <linux/types.h> - is kernel headers package installed?
```
Of course, this still requires you comment out `#include <linux/if_ether.h>` first.