### PR TITLE
Updates re unicast_src_ip

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1419,6 +1419,15 @@ AC_CHECK_DECLS([ETHERTYPE_IPV6], [],
   ],
   [[#include <net/ethernet.h>]])
 
+# IPV6_FREEBIND - added Linux v4.15
+AS_IF([test .$enable_vrrp != .no],
+  [
+    AC_CHECK_DECLS([IPV6_FREEBIND],
+      [add_system_opt([IPV6_FREEBIND])],
+      [],
+      [[#include <linux/in6.h>]])
+  ])
+
 # IPV6_MULTICAST_ALL - added Linux v4.20
 AC_CHECK_DECLS([IPV6_MULTICAST_ALL],
   [

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2394,9 +2394,15 @@ chk_min_cfg(vrrp_t *vrrp)
 		report_config_error(CONFIG_GENERAL_ERROR, "(%s) the virtual router id must be set", vrrp->iname);
 		return false;
 	}
-	if (!vrrp->ifp && !__test_bit(VRRP_FLAG_UNICAST_CONFIGURED, &vrrp->flags)) {
-		report_config_error(CONFIG_GENERAL_ERROR, "(%s) Unknown interface!", vrrp->iname);
-		return false;
+	if (!vrrp->ifp) {
+		if (!__test_bit(VRRP_FLAG_UNICAST_CONFIGURED, &vrrp->flags)) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) Unknown interface!", vrrp->iname);
+			return false;
+		}
+		if (__test_bit(VRRP_VMAC_BIT, &vrrp->flags)) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) cannot use VMAC if no interface specified", vrrp->iname);
+			return false;
+		}
 	}
 
 	return true;

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1536,6 +1536,9 @@ vrrp_send_adv(vrrp_t * vrrp, uint8_t prio)
 {
 	unicast_peer_t *peer;
 
+	if (!vrrp->sockets)
+		return;
+
 #ifdef _HAVE_VRRP_VMAC_
 	if (vrrp->saddr.ss_family == AF_UNSPEC &&
 	    vrrp->family == AF_INET6 &&

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2399,10 +2399,12 @@ chk_min_cfg(vrrp_t *vrrp)
 			report_config_error(CONFIG_GENERAL_ERROR, "(%s) Unknown interface!", vrrp->iname);
 			return false;
 		}
+#ifdef _HAVE_VRRP_VMAC_
 		if (__test_bit(VRRP_VMAC_BIT, &vrrp->flags)) {
 			report_config_error(CONFIG_GENERAL_ERROR, "(%s) cannot use VMAC if no interface specified", vrrp->iname);
 			return false;
 		}
+#endif
 	}
 
 	return true;


### PR DESCRIPTION
Fix segfault if unicast_src_ip is not configured on interface, and allow bind() to work when address in not configured on interface.