### PR TITLE
parser: Fix error handling for HEX_STR parsing in UDP_CHECK

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -729,6 +729,7 @@ read_hex_str(const char *str, uint8_t **data, uint8_t **data_mask)
 	uint8_t mask_val;
 	bool using_mask = false;
 	uint16_t len;
+	bool has_error = false;
 
 	/* The output octet string cannot be longer than (strlen(str) + 1)/2 */
 	str_len = (strlen(str) + 1) / 2;
@@ -745,8 +746,10 @@ read_hex_str(const char *str, uint8_t **data, uint8_t **data_mask)
 			break;
 
 		val = hex_val(*p++, !!data_mask);
-		if (val == 0xff)
+		if (val == 0xff) {
+			has_error = true;
 			break;
+		}
 		if (val == 0xfe) {
 			mask_val = 0x0f;
 			val = 0;
@@ -758,8 +761,10 @@ read_hex_str(const char *str, uint8_t **data, uint8_t **data_mask)
 			val1 = val << 4;
 			mask_val <<= 4;
 			val = hex_val(*p++, !!data_mask);
-			if (val == 0xff)
+			if (val == 0xff) {
+				has_error = true;
 				break;
+			}
 			if (val == 0xfe) {
 				mask_val |= 0x0f;
 				val = 0;
@@ -773,7 +778,7 @@ read_hex_str(const char *str, uint8_t **data, uint8_t **data_mask)
 		len++;
 	}
 
-	if (val == 0xff || !len) {
+	if (has_error || !len) {
 		FREE_ONLY(buf);
 		FREE_ONLY(mask);
 		return 0;


### PR DESCRIPTION
**Description:**
This pull request resolves a bug in the HEX_STR parsing logic for the UDP_CHECK feature. Previously, HEX_STR values ending with 0xff were incorrectly flagged as errors. This impacted configurations that used HEX_STR in UDP_CHECK payload and require_reply fields, potentially leading to configuration failures or misbehavior.

**Issue Example:**
The following configuration file, which demonstrates a UDP_CHECK with a payload containing 0xFFFF, failed to load in earlier versions due to a parsing error:

```
! Configuration File for keepalived
! This example demonstrates UDP_CHECK, a component of LVS configuration.

global_defs {
   notification_email {
     acassen
   }
   notification_email_from Alexandre.Cassen@firewall.loc
   smtp_server 192.168.200.1
   smtp_connect_timeout 30
   router_id LVS_DEVEL
}

virtual_server 10.10.10.2 1358 {
    delay_loop 6
    lb_algo rr
    lb_kind NAT
    persistence_timeout 50
    protocol UDP

    real_server 192.168.200.6 1358 {
        weight 1
        UDP_CHECK {
                payload 1234 FFFF
                connect_timeout 3
                retry 3
                delay_before_retry 3
!                require_reply
        }
    }
}
```
