### PR TITLE
refactor misc shell script tweaks

### DIFF
--- a/goodies/check_conditional_tests
+++ b/goodies/check_conditional_tests
@@ -1,9 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get a count of each defined term used in #if directives
 # This can be useful to check for typos in the names
 
-grep "#[ \t]*if" $(find . -name "*.[ch]") | \
+declare -a c_src_files=()
+mapfile -t c_src_files < <(find . -name "*.[ch]")
+
+grep "#[ \t]*if" "${c_src_files[@]}" | \
 	grep -v "_H$" | \
 	sed -e "s/.*://" | \
 	sed -e "s/#ifn*def *//" -e "s/#if  *//" | \

--- a/snap-tools/keepalived-wrapper
+++ b/snap-tools/keepalived-wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 MAJ_VER=$(uname -r | cut -d'.' -f1)
 MIN_VER=$(uname -r | cut -d'.' -f2)
@@ -22,6 +22,7 @@ exit 1
 fi
 
 # The magic file must be the one in the snap
-export MAGIC=${SNAP}/usr/share/misc/magic
+MAGIC="${SNAP}/usr/share/misc/magic"
+export MAGIC
 
-exec ${SNAP}/usr/sbin/${BINARY} "$@"
+exec "${SNAP}/usr/sbin/${BINARY}" "$@"


### PR DESCRIPTION
some non-critical refactors of BASH/SH scripts

* snap-tools: use sh as interpreter; misc tweaks
    * use sh as interpreter since we already have sh compatibility,
    * sh-compat: only change export to be on 2 lines,
    * set SNAP if somehow unset
    * quote MAGIC and exec call
* goodies: use bash mapfile and array to store found C files