### PR TITLE
vrrp: interface add should call setup_interface()

### DIFF
--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -1720,7 +1720,10 @@ update_added_interface(interface_t *ifp)
 		/* Reopen any socket on this interface if necessary */
 		if (
 #ifdef _HAVE_VRRP_VMAC_
-		    !vrrp->flags &&
+		    !__test_bit(VRRP_VMAC_BIT, &vrrp->flags) &&
+#ifdef _HAVE_VRRP_IPVLAN_
+		    !__test_bit(VRRP_IPVLAN_BIT, &vrrp->flags) &&
+#endif
 #endif
 		    vrrp->sockets->fd_in == -1)
 			setup_interface(vrrp);


### PR DESCRIPTION
When an interface is (re-)added, setup_interface() should be called even if vrrp->flags is set (eg VRRP_FLAG_NOPREEMPT).

Tests to avoid setup_interface() before commit a0ce04a checked vrrp->vmac_flags, but the change mistakenly mixed the test with other vrrp flags.

The bug manifests in cases where the only vrrp_instance on an interface uses a feature that sets a vrrp->flags bit (eg nopreempt), and then the interface is deleted and re-added (eg nmcli con down <intf>, nmcli con up <intf>).  The vrrp->flags value causes setup_interface() to not be called, and the vrrp interface never times-out to reach master state.

If other vrrp_instance's exist for the same interface, then the bug doesn't manifest (the other instance calls setup_interface, and the (eg nopreempt) instance will transition to master.

The patch reduces the tests to just the vmac/ipvlan bits

NOTE: I tried the code without any vrrp->flags tests, and at least the use_vmac mode appears to work perfectly (I didn't try ipvlan) -- I'm not sure why the vmac/ipvlan test is there really...
