### PR TITLE
vrrp: check specific flags in vrrp-flags

### DIFF
--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -1688,7 +1688,14 @@ update_added_interface(interface_t *ifp)
 			}
 		}
 
-		if (vrrp->flags) {
+		if (
+#ifdef _HAVE_VRRP_VMAC_
+		    __test_bit(VRRP_VMAC_BIT, &vrrp->flags) ||
+#ifdef _HAVE_VRRP_IPVLAN_
+		    __test_bit(VRRP_IPVLAN_BIT, &vrrp->flags)
+#endif
+#endif
+								) {
 			if (top->type & TRACK_VRRP) {
 				add_vrrp_to_interface(vrrp, ifp->base_ifp, top->weight, top->weight_multiplier == -1, false, TRACK_VRRP_DYNAMIC);
 				if (!IF_ISUP(vrrp->configured_ifp->base_ifp) && !__test_bit(VRRP_FLAG_DONT_TRACK_PRIMARY, &vrrp->flags)) {


### PR DESCRIPTION
Commit 1383336 - "vrrp: interface add should call setup_interface()" identified that the change in commit a0ce04a from if (vrrp->vmac_flags) to if (vrrp->flags) was incorrect, and specific bits needed to be checked.

This commit resolves another instance of the same error.