### PR TITLE
core: add O_CLOEXEC flag to pidfiles

### DIFF
--- a/keepalived/core/pidfile.c
+++ b/keepalived/core/pidfile.c
@@ -167,7 +167,7 @@ create_pidfile(pidfile_t *pidf)
 		if (umask_val & (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH))
 			umask(umask_val & ~(S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH));
 
-		while ((pidf->fd = open(pidf->path, O_NOFOLLOW | O_CREAT | O_WRONLY | O_NONBLOCK, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) == -1 && errno == EINTR);
+		while ((pidf->fd = open(pidf->path, O_NOFOLLOW | O_CREAT | O_WRONLY | O_NONBLOCK | O_CLOEXEC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) == -1 && errno == EINTR);
 		error = errno;
 
 		/* Restore the default umask */


### PR DESCRIPTION
Patch to add O_CLOEXEC flag when opening pidfiles.

Commit 2c4cd3b introduced the use of pid files for instance locking, which keeps the pidfile descriptors open.  However, the O_CLOEXEC flag was missing so the open descriptors are passed to all exec'd processes (scripts etc).

I noticed this when adding SELinux permissions for keepalived to use ping as a vrrp_script, and saw the following denial:
```
type=AVC msg=audit(1738090198.716:585): avc:  denied  { write } for  pid=21305 comm="ping" 
  path="/run/vrrp.pid" dev="tmpfs" ino=3178 scontext=system_u:system_r:ping_t:s0 
  tcontext=system_u:object_r:keepalived_var_run_t:s0 tclass=file permissive=0
```

I created a test script to dump the open file descriptors, and found one extra descriptor for /run/vrrp.pid

Ideally, the code that exec's any external program should close all open descriptors (except stdin/out/err which might be optional), but it's also simple enough to just ensure all descriptors have O_CLOEXEC so it's automatic.
