### PR TITLE
snap: Remove architectures keyword from snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,13 +12,13 @@ confinement: classic
 base: core22
 
 # Note: When change base to core24 or later, architectures needs to be changed to platforms
-architectures:
-  - build-on: [amd64]
-  - build-on: [arm64]
-  - build-on: [armhf]
-  - build-on: [ppc64el]
-  - build-on: [s390x]
-  - build-on: [riscv64]
+#architectures:
+#  - build-on: [amd64]
+#  - build-on: [arm64]
+#  - build-on: [armhf]
+#  - build-on: [ppc64el]
+#  - build-on: [s390x]
+#  - build-on: [riscv64]
 #platforms:
 #  amd64:
 #  arm64:


### PR DESCRIPTION
Following a suggestion at
https://answers.launchpad.net/launchpad/+question/820140
to get builds working for riscv64, the commit comments out the architectures keyword to see if that will make it build for riscv64.