### PR TITLE
Revert "snap: Remove architectures keyword from snapcraft.yaml"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,13 +12,13 @@ confinement: classic
 base: core22
 
 # Note: When change base to core24 or later, architectures needs to be changed to platforms
-#architectures:
-#  - build-on: [amd64]
-#  - build-on: [arm64]
-#  - build-on: [armhf]
-#  - build-on: [ppc64el]
-#  - build-on: [s390x]
-#  - build-on: [riscv64]
+architectures:
+  - build-on: [amd64]
+  - build-on: [arm64]
+  - build-on: [armhf]
+  - build-on: [ppc64el]
+  - build-on: [s390x]
+  - build-on: [riscv64]
 #platforms:
 #  amd64:
 #  arm64:


### PR DESCRIPTION
This reverts commit ff8e84f526e54ab84117dccf6ae759a6397f5c1c.

Removing the architectures keyword did not resolve the problem.