### PR TITLE
Fix segfault caused double erase from child_pid rb tree

### DIFF
--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -2210,7 +2210,6 @@ process_child_termination(pid_t pid, int status)
 		 * and it is still on the thread->ready queue. Since we have now got
 		 * the termination, just handle the termination instead. */
 		thread->type = THREAD_CHILD_TERMINATED;
-		rb_erase(&thread->rb_data, &master->child_pid);
 	}
 	else
 		thread_move_ready(m, &m->child, thread, THREAD_CHILD_TERMINATED);


### PR DESCRIPTION
In a situation when a child was timed out, but not yet processed, the thread is THREAD_CHILD_TIMEOUT type and remains on ready queue. If it gets terminated in this state, it needs to be removed from rb tree child_pid and transitioned to THREAD_CHILD_TERMINATED, but without additional moving it to ready queue as it is already there.

The erase from child_pid tree is required to clean up pid from not terminated childs tree, but it needs to be done exactly once as rb tree implementation is not guarded against double removal. Erasing or adding same element multiple times, leads to malformed red-black tree and segmentation faults.

This patch removes double erase in described scenario.

Might fix #2548
