### PR TITLE
vrrp: support route propagation delay

### DIFF
--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -373,7 +373,17 @@ typedef struct _vrrp_t {
 							 * preemption based on higher prio over lower
 							 * prio is allowed.  0 means no delay.
 							 */
+	unsigned long		route_propagation_delay;/* Seconds*TIMER_HZ to wait at startup until
+							 * MDT timer can start.  0 means no delay.
+							 */
 	timeval_t		preempt_time;		/* Time after which preemption can happen */
+	timeval_t		route_propagated_time;	/* Time at which all routes are propagated.
+							 * VRRP packets to this interface are dropped before
+							 * all routes are propagated.
+							 */
+	bool			apply_route_propagation;/* Apply the route propagation delay the next time when
+							 * instance tries to become master.
+							 */
 	int			state;			/* internal state (init/backup/master/fault) */
 #ifdef _WITH_SNMP_VRRP_
 	int			configured_state;	/* the configured state of the instance */

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1973,6 +1973,16 @@ vrrp_state_leave_fault(vrrp_t * vrrp)
 	/* Set the down timer */
 	vrrp->master_adver_int = vrrp->adver_int;
 	vrrp->ms_down_timer = VRRP_MS_DOWN_TIMER(vrrp);
+	if (vrrp->state == VRRP_STATE_BACK && vrrp->route_propagation_delay > 0)
+	{
+		vrrp->apply_route_propagation = true;
+		vrrp->route_propagated_time = timer_add_long(time_now, vrrp->route_propagation_delay);
+	}
+	if (vrrp->state == VRRP_STATE_FAULT)
+	{
+		vrrp->apply_route_propagation = false;
+		vrrp->route_propagated_time = time_now;
+	}
 	vrrp_init_instance_sands(vrrp);
 	vrrp->last_transition = timer_now();
 }
@@ -3355,6 +3365,10 @@ vrrp_complete_instance(vrrp_t * vrrp)
 								, vrrp->iname);
 			vrrp->preempt_delay = false;
 		}
+		if (vrrp->route_propagation_delay) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) Warning - route propagation delay will not work with initial state MASTER - clearing", vrrp->iname);
+			vrrp->route_propagation_delay = 0;
+		}
 	}
 	if (vrrp->preempt_delay) {
 		if (vrrp->strict_mode) {
@@ -3368,6 +3382,12 @@ vrrp_complete_instance(vrrp_t * vrrp)
 								  " nopreempt mode - resetting"
 								, vrrp->iname);
 			vrrp->preempt_delay = 0;
+		}
+	}
+	if (vrrp->route_propagation_delay) {
+		if (vrrp->strict_mode) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) route_propagation_delay is incompatible with strict mode - resetting", vrrp->iname);
+			vrrp->route_propagation_delay = 0;
 		}
 	}
 

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -1144,6 +1144,18 @@ vrrp_preempt_delay_handler(const vector_t *strvec)
 		current_vrrp->preempt_delay = preempt_delay;
 }
 static void
+vrrp_route_propagation_delay_handler(const vector_t *strvec)
+{
+	unsigned route_propagation_delay;
+
+	if (!read_decimal_unsigned_strvec(strvec, 1, &route_propagation_delay, 0, TIMER_MAX_SEC * TIMER_HZ, TIMER_HZ_DIGITS, true)) {
+		report_config_error(CONFIG_GENERAL_ERROR, "(%s) route_propagation_delay not valid! must be between 0-%u", current_vrrp->iname, TIMER_MAX_SEC);
+		current_vrrp->route_propagation_delay = 0;
+	}
+	else
+		current_vrrp->route_propagation_delay = route_propagation_delay;
+}
+static void
 vrrp_notify_backup_handler(const vector_t *strvec)
 {
 	if (current_vrrp->script_backup) {
@@ -2211,6 +2223,7 @@ init_vrrp_keywords(bool active)
 	install_keyword("preempt", &vrrp_preempt_handler);
 	install_keyword("nopreempt", &vrrp_nopreempt_handler);
 	install_keyword("preempt_delay", &vrrp_preempt_delay_handler);
+	install_keyword("route_propagation_delay", &vrrp_route_propagation_delay_handler);
 	install_keyword("debug", &vrrp_debug_handler);
 	install_keyword_quoted("notify_backup", &vrrp_notify_backup_handler);
 	install_keyword_quoted("notify_master", &vrrp_notify_master_handler);

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -239,6 +239,12 @@ vrrp_init_state(list_head_t *l)
 				 * very quickly (1usec) */
 				vrrp->state = VRRP_STATE_BACK;
 				vrrp->ms_down_timer = 1;
+				if (vrrp->route_propagation_delay > 0)
+				{
+					vrrp->apply_route_propagation = true;
+					vrrp->route_propagated_time = timer_add_long(time_now, vrrp->route_propagation_delay);
+				}
+
 			}
 
 // TODO Do we need ->	vrrp_restore_interface(vrrp, false, false);
@@ -249,6 +255,12 @@ vrrp_init_state(list_head_t *l)
 				vrrp->ms_down_timer = vrrp->master_adver_int + VRRP_TIMER_SKEW_MIN(vrrp);
 			} else
 				vrrp->ms_down_timer = VRRP_MS_DOWN_TIMER(vrrp);
+
+			if (vrrp->route_propagation_delay > 0)
+			{
+				vrrp->apply_route_propagation = true;
+				vrrp->route_propagated_time = timer_add_long(time_now, vrrp->route_propagation_delay);
+			}
 
 #ifdef _WITH_SNMP_RFCV3_
 			vrrp->stats->next_master_reason = VRRPV3_MASTER_REASON_MASTER_NO_RESPONSE;
@@ -323,6 +335,14 @@ vrrp_init_instance_sands(vrrp_t *vrrp)
 			vrrp->sands = timer_add_long(vrrp_delayed_start_time, vrrp->ms_down_timer);
 		else
 			vrrp->sands = timer_add_long(time_now, vrrp->ms_down_timer);
+		if (vrrp->apply_route_propagation)
+		{
+			log_message(LOG_INFO, "Applied vrrp route propagation delay of %lu on instance (%s)",
+				    vrrp->route_propagation_delay, vrrp->iname);
+			vrrp->sands = timer_add_long(vrrp->sands, vrrp->route_propagation_delay);
+			vrrp->apply_route_propagation = false;
+			vrrp->route_propagated_time = vrrp->sands;
+		}
 	}
 	else if (vrrp->state == VRRP_STATE_FAULT || vrrp->state == VRRP_STATE_INIT)
 		vrrp->sands.tv_sec = TIMER_DISABLED;
@@ -1086,6 +1106,15 @@ vrrp_dispatcher_read(sock_t *sock)
 			continue;
 		}
 
+		if (vrrp->route_propagation_delay > 0)
+		{
+			/* Ignore the message if it is received before all the routes are
+			 * propagated */
+			set_time_now();
+			if (timercmp(&time_now, &vrrp->route_propagated_time, <)) {
+				return sock->fd_in;
+			}
+		}
 		/* Save non packet data */
 		vrrp->pkt_saddr = src_addr;
 		vrrp->rx_ttl_hl = -1;           /* Default to not received */


### PR DESCRIPTION
When vrrp state moves out of a fault state, we would like to wait for an additional route propagated delay time, before doing a vrrp master election.
During this interval, the packets that are received from other vrrp nodes, which can alter the state of the vrrp instance are dropped. The present nodes, does not pass to participate in leader election which can result in it becoming the master and taking over the VRRP IP.