### PR TITLE
Skip running not idle vrrp scripts

### DIFF
--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -1220,6 +1220,7 @@ vrrp_script_thread(thread_ref_t thread)
 		/* We don't want the system to be overloaded with scripts that we are executing */
 		log_message(LOG_INFO, "Track script %s is %s, expect idle - skipping run",
 			    vscript->sname, vscript->state == SCRIPT_STATE_RUNNING ? "already running" : "being timed out");
+		return;
 	}
 
 	/* Execute the script in a child process. Parent returns, child doesn't */


### PR DESCRIPTION
This is a fix for a bug introduced during refactoring thread functions in: https://github.com/acassen/keepalived/pull/1626

When a vrrp script is to be run (initially or after specified interval), first it is checked if it's in IDLE state. If not a log message is printed informing about skipping run due to script being either running or timed out. However despite not being idle the code continues to run new script process.

In heavily loaded systems this caused running multiple instances of vrrp script at the same time.

This patch brings back missing return, which was lost during refactoring.