### PR TITLE
vrrp: add fault_init_exit_delay to vrrp configuration

### DIFF
--- a/doc/KEEPALIVED-MIB.txt
+++ b/doc/KEEPALIVED-MIB.txt
@@ -946,6 +946,7 @@ VrrpInstanceEntry ::= SEQUENCE {
     vrrpInstanceMulticastAddressType InetAddressType,
     vrrpInstanceMulticastAddress InetAddress,
     vrrpInstanceV3ChecksumAsV2 INTEGER
+    vrrpInstanceFaultInitExitDelay Unsigned32
 }
 
 vrrpInstanceIndex OBJECT-TYPE
@@ -1250,6 +1251,15 @@ vrrpInstanceV3ChecksumAsV2 OBJECT-TYPE
     DESCRIPTION
         "True if VRRPv3 IPv4 checksum excludes pseudo-header."
     ::= { vrrpInstanceEntry 36 }
+
+vrrpInstanceFaultInitExitDelay OBJECT-TYPE
+    SYNTAX Unsigned32
+    UNITS "seconds"
+    MAX-ACCESS read-only
+    STATUS current
+    DESCRIPTION
+        "Delay after a fault after which the instance participates in master election. 0 means that there is no delay."
+    ::= { vrrpInstanceEntry 37 }
 
 vrrpTrackedInterfaceTable OBJECT-TYPE
     SYNTAX SEQUENCE OF VrrpTrackedInterfaceEntry
@@ -5102,6 +5112,7 @@ vrrpInstanceGroup OBJECT-GROUP
     vrrpInstanceMulticastAddressType,
     vrrpInstanceMulticastAddress,
     vrrpInstanceV3ChecksumAsV2,
+    vrrpInstanceFaultInitExitDelay,
     vrrpTrackedInterfaceName,
     vrrpTrackedInterfaceWeight,
     vrrpTrackedInterfaceWgtRev,

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -374,6 +374,10 @@ typedef struct _vrrp_t {
 							 * prio is allowed.  0 means no delay.
 							 */
 	timeval_t		preempt_time;		/* Time after which preemption can happen */
+	unsigned long		fault_init_exit_delay;  /* Additional seconds*TIMER_HZ to
+							 * remain in Fault or Init state before transitioning to
+							 * another state. 0 means no delay.
+							 */
 	int			state;			/* internal state (init/backup/master/fault) */
 #ifdef _WITH_SNMP_VRRP_
 	int			configured_state;	/* the configured state of the instance */

--- a/keepalived/include/vrrp.h
+++ b/keepalived/include/vrrp.h
@@ -378,6 +378,15 @@ typedef struct _vrrp_t {
 							 * remain in Fault or Init state before transitioning to
 							 * another state. 0 means no delay.
 							 */
+	timeval_t		fault_init_exit_time;	/* Time after which transitioning from INIT or
+							 * FAULT state can happen.
+							 */
+	thread_ref_t		fault_init_exit_thread; /* Thread to schedule the end of the
+											   * fault_init_exit_delay timer
+											   */
+	bool			fault_exit_delay_apply; /* Apply fault_init_exit_delay before
+											 * transitioning from the FAULT state
+											 */
 	int			state;			/* internal state (init/backup/master/fault) */
 #ifdef _WITH_SNMP_VRRP_
 	int			configured_state;	/* the configured state of the instance */

--- a/keepalived/include/vrrp_scheduler.h
+++ b/keepalived/include/vrrp_scheduler.h
@@ -56,6 +56,7 @@ extern bool do_recvmsg_debug_dump;
 #endif
 
 /* extern prototypes */
+extern void fault_init_exit_thread(thread_ref_t thread);
 extern void vrrp_init_instance_sands(vrrp_t *);
 extern void vrrp_thread_requeue_read(vrrp_t *);
 extern void vrrp_thread_add_read(vrrp_t *);

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3355,6 +3355,10 @@ vrrp_complete_instance(vrrp_t * vrrp)
 								, vrrp->iname);
 			vrrp->preempt_delay = false;
 		}
+		if (vrrp->fault_init_exit_delay) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) Warning - fault init exit delay will not work with initial state MASTER - clearing", vrrp->iname);
+			vrrp->fault_init_exit_delay = false;
+		}
 	}
 	if (vrrp->preempt_delay) {
 		if (vrrp->strict_mode) {
@@ -3368,6 +3372,12 @@ vrrp_complete_instance(vrrp_t * vrrp)
 								  " nopreempt mode - resetting"
 								, vrrp->iname);
 			vrrp->preempt_delay = 0;
+		}
+	}
+	if (vrrp->fault_init_exit_delay) {
+		if (vrrp->strict_mode) {
+			report_config_error(CONFIG_GENERAL_ERROR, "(%s) fault_init_exit_delay is incompatible with strict mode - resetting", vrrp->iname);
+			vrrp->fault_init_exit_delay = 0;
 		}
 	}
 

--- a/keepalived/vrrp/vrrp_data.c
+++ b/keepalived/vrrp/vrrp_data.c
@@ -768,6 +768,9 @@ dump_vrrp(FILE *fp, const vrrp_t *vrrp)
 	if (vrrp->preempt_delay)
 		conf_write(fp, "   Preempt delay = %g secs",
 		       vrrp->preempt_delay / TIMER_HZ_DOUBLE);
+	if (vrrp->fault_init_exit_delay)
+		conf_write(fp, "   Fault Init Exit delay = %g secs",
+		       vrrp->fault_init_exit_delay / TIMER_HZ_DOUBLE);
 	conf_write(fp, "   Promote_secondaries = %s", __test_bit(VRRP_FLAG_PROMOTE_SECONDARIES, &vrrp->flags) ? "enabled" : "disabled");
 #if defined _WITH_VRRP_AUTH_
 	if (vrrp->auth_type) {

--- a/keepalived/vrrp/vrrp_json.c
+++ b/keepalived/vrrp/vrrp_json.c
@@ -195,6 +195,7 @@ vrrp_json_data_dump(json_writer_t *wr, vrrp_t *vrrp)
 #endif
 	jsonw_bool_field(wr, "nopreempt", __test_bit(VRRP_FLAG_NOPREEMPT, &vrrp->flags));
 	jsonw_uint_field(wr, "preempt_delay", vrrp->preempt_delay / TIMER_HZ);
+	jsonw_uint_field(wr, "fault_init_exit_delay", vrrp->fault_init_exit_delay / TIMER_HZ);
 	jsonw_uint_field(wr, "state", vrrp->state);
 	jsonw_uint_field(wr, "wantstate", vrrp->wantstate);
 	jsonw_uint_field(wr, "version", vrrp->version);

--- a/keepalived/vrrp/vrrp_parser.c
+++ b/keepalived/vrrp/vrrp_parser.c
@@ -1144,6 +1144,16 @@ vrrp_preempt_delay_handler(const vector_t *strvec)
 		current_vrrp->preempt_delay = preempt_delay;
 }
 static void
+vrrp_fault_init_exit_delay_handler(const vector_t *strvec)
+{
+	unsigned fault_init_exit_delay;
+
+	if (!read_decimal_unsigned_strvec(strvec, 1, &fault_init_exit_delay, 0, TIMER_MAX_SEC * TIMER_HZ, TIMER_HZ_DIGITS, true))
+		report_config_error(CONFIG_GENERAL_ERROR, "(%s) fault_init_exit_delay not valid! must be between 0-%u", current_vrrp->iname, TIMER_MAX_SEC);
+	else
+		current_vrrp->fault_init_exit_delay = fault_init_exit_delay;
+}
+static void
 vrrp_notify_backup_handler(const vector_t *strvec)
 {
 	if (current_vrrp->script_backup) {
@@ -2211,6 +2221,7 @@ init_vrrp_keywords(bool active)
 	install_keyword("preempt", &vrrp_preempt_handler);
 	install_keyword("nopreempt", &vrrp_nopreempt_handler);
 	install_keyword("preempt_delay", &vrrp_preempt_delay_handler);
+	install_keyword("fault_init_exit_delay", &vrrp_fault_init_exit_delay_handler);
 	install_keyword("debug", &vrrp_debug_handler);
 	install_keyword_quoted("notify_backup", &vrrp_notify_backup_handler);
 	install_keyword_quoted("notify_master", &vrrp_notify_master_handler);

--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -226,6 +226,7 @@ enum snmp_vrrp_magic {
 	VRRP_SNMP_INSTANCE_MULTICAST_ADDRESSTYPE,
 	VRRP_SNMP_INSTANCE_MULTICAST_ADDRESS,
 	VRRP_SNMP_INSTANCE_V3_CHECKSUM_AS_V2,
+	VRRP_SNMP_INSTANCE_FAULTINITEXITDELAY,
 	VRRP_SNMP_TRACKEDINTERFACE_NAME,
 	VRRP_SNMP_TRACKEDINTERFACE_WEIGHT,
 	VRRP_SNMP_TRACKEDINTERFACE_WEIGHT_REVERSE,
@@ -2236,6 +2237,9 @@ vrrp_snmp_instance(struct variable *vp, oid *name, size_t *length,
 	case VRRP_SNMP_INSTANCE_V3_CHECKSUM_AS_V2:
 		long_ret.u = (__test_bit(VRRP_FLAG_V3_CHECKSUM_AS_V2, &rt->flags)) ? 1 : 2;
 		return PTR_CAST(u_char, &long_ret);
+	case VRRP_SNMP_INSTANCE_FAULTINITEXITDELAY:
+		long_ret.u = rt->fault_init_exit_delay / TIMER_HZ;
+		return PTR_CAST(u_char, &long_ret);
 	default:
 		return NULL;
 	}
@@ -2680,6 +2684,8 @@ static struct variable3 vrrp_vars[] = {
 	 vrrp_snmp_instance, 3, {3, 1, 35}},
 	{VRRP_SNMP_INSTANCE_V3_CHECKSUM_AS_V2, ASN_INTEGER, RONLY,
 	 vrrp_snmp_instance, 3, {3, 1, 36}},
+	{VRRP_SNMP_INSTANCE_FAULTINITEXITDELAY, ASN_UNSIGNED, RONLY,
+	 vrrp_snmp_instance, 3, {3, 1, 37}},
 
 	/* vrrpTrackedInterfaceTable */
 	{VRRP_SNMP_TRACKEDINTERFACE_NAME, ASN_OCTET_STR, RONLY,


### PR DESCRIPTION
When vrrp state moves out of a fault state, we would like to wait for an additional route propagated delay time, before doing a vrrp master election.
During this interval, the packets that are received from other vrrp nodes, which can alter the state of the vrrp instance are dropped. The present nodes, does not pass to participate in leader election which can result in it becoming the master and taking over the VRRP IP.

Addressing comments from PR 2556