### PR TITLE
snap: set LD_LIBRARY_PATH for daemon

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,8 @@ apps:
   daemon:
     daemon: forking
     command: bin/keepalived-wrapper
+    environment:
+      LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAP_ARCH-linux-gnu"
   keepalived:
     command: bin/keepalived-wrapper
   "519":        # First post Linux 5.18 version - Ubuntu 22.10


### PR DESCRIPTION
Though libraries are staged the daemon fails to search them in the snap path.

Closes #2561