### PR TITLE
vrrp: allow interface up debounce timer to exceed 2 * advert interval

### DIFF
--- a/doc/man/man5/keepalived.conf.5.in
+++ b/doc/man/man5/keepalived.conf.5.in
@@ -2192,8 +2192,8 @@ The syntax for vrrp_instance is :
 
     If up_delay is omitted, it is set to be the same as the down delay.
 
-    The delay on an interface must be less than two (or more precisely one less than
-    down_timer_adverts (default 3)) times the advert interval of any VRRP instance
+    The down delay on an interface must be less than two (or more precisely one less
+    than down_timer_adverts (default 3)) times the advert interval of any VRRP instance
     using that interface (otherwise a backup instance, while not receiving adverts
     may time out and become master before this instance transitions to FAULT state).
     Consequently the up/down delays can be dynamically reduced if another instance is

--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -1981,30 +1981,29 @@ static bool
 check_debounce_timers(vrrp_t *vrrp, unsigned advert_int)
 {
 	bool changed = false;
+	unsigned max_timer;
 
 	if (vrrp->down_timer_adverts == 1 || !vrrp->ifp) {
 		/* There can be no debounce timer */
 		return false;
 	}
 
-	if (IF_BASE_IFP(vrrp->ifp)->up_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int ||
-	    IF_BASE_IFP(vrrp->ifp)->down_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int) {
+	max_timer = (vrrp->down_timer_adverts - 1) * advert_int - advert_int / 256;
+
+	if (IF_BASE_IFP(vrrp->ifp)->down_debounce_timer > max_timer) {
 		changed = true;
-		if (IF_BASE_IFP(vrrp->ifp)->up_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int)
-			IF_BASE_IFP(vrrp->ifp)->up_debounce_timer = (vrrp->down_timer_adverts - 1) * advert_int - advert_int / 256;
-		if (IF_BASE_IFP(vrrp->ifp)->down_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int)
-			IF_BASE_IFP(vrrp->ifp)->down_debounce_timer = (vrrp->down_timer_adverts - 1) * advert_int - advert_int / 256;
+		if (IF_BASE_IFP(vrrp->ifp)->up_debounce_timer == IF_BASE_IFP(vrrp->ifp)->down_debounce_timer)
+			IF_BASE_IFP(vrrp->ifp)->up_debounce_timer = max_timer;
+		IF_BASE_IFP(vrrp->ifp)->down_debounce_timer = max_timer;
 	}
 
 #ifdef _HAVE_VRRP_VMAC_
 	if (vrrp->ifp != vrrp->ifp->base_ifp) {
-		if (vrrp->ifp->up_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int ||
-		    vrrp->ifp->down_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int) {
+		if (vrrp->ifp->down_debounce_timer > max_timer) {
 			changed = true;
-			if (vrrp->ifp->down_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int)
-				vrrp->ifp->down_debounce_timer = vrrp->ifp->base_ifp->down_debounce_timer;
-			if (vrrp->ifp->up_debounce_timer >= (vrrp->down_timer_adverts - 1) * advert_int)
-				vrrp->ifp->up_debounce_timer = vrrp->ifp->base_ifp->up_debounce_timer;
+			if (vrrp->ifp->up_debounce_timer == vrrp->ifp->down_debounce_timer)
+				vrrp->ifp->up_debounce_timer = max_timer;
+			vrrp->ifp->down_debounce_timer = max_timer;
 		}
 	}
 #endif


### PR DESCRIPTION
There was no need to limit the up debounce timer in the same way that the down debounce timer has to be limited, so this commit removes the 2 * advert interval upper limit.