### PR TITLE
snap: try and get snap executable to see LD_LIBRARY_PATH

### DIFF
--- a/snap-tools/keepalived-wrapper
+++ b/snap-tools/keepalived-wrapper
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+logger LD_LIBRARY_PATH $LD_LIBRARY_PATH
+export LD_LIBRARY_PATH
+
 MAJ_VER=$(uname -r | cut -d'.' -f1)
 MIN_VER=$(uname -r | cut -d'.' -f2)
 RUNNING_KERNEL_VER=$(printf "%d%2.2d\n" $MAJ_VER $MIN_VER)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -124,6 +124,7 @@ parts:
       - libnfnetlink0
       - libipset13
       - libglib2.0-0
+      - libpcre3
       - libmagic1
       - libmnl0
       - libnftnl11


### PR DESCRIPTION
LD_LIBRARY_PATH is now being correctly set, but the binary executables don't seem to be using it.