### PR TITLE
snap: Construct and set LD_LIBRARY_PATH

### DIFF
--- a/snap-tools/keepalived-wrapper
+++ b/snap-tools/keepalived-wrapper
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-logger LD_LIBRARY_PATH $LD_LIBRARY_PATH
-export LD_LIBRARY_PATH
+if [[ -z $LD_LIBRARY_PATH ]]; then
+	LP=$(ldd /usr/bin/sh | grep " => " | head -1 | sed -e "s/.*=> *//" -e "s/ *(.*//" -e "s:/[^/]*$::")
+	LP=${LP#/usr}
+
+	export LD_LIBRARY_PATH=${SNAP}${LP}:${SNAP}/usr${LP}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+	logger Set LD_LIBRARY_PATH to $LD_LIBRARY_PATH
+fi
 
 MAJ_VER=$(uname -r | cut -d'.' -f1)
 MIN_VER=$(uname -r | cut -d'.' -f2)


### PR DESCRIPTION
Although LD_LIBRARY_PATH is now set in the environment, it is not being exported to keepalived-wrapper.