### PR TITLE
snap: Fix keepalived-wrapper changes

### DIFF
--- a/snap-tools/keepalived-wrapper
+++ b/snap-tools/keepalived-wrapper
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [[ -z $LD_LIBRARY_PATH ]]; then
+if [ -z $LD_LIBRARY_PATH ]; then
 	LP=$(ldd /usr/bin/sh | grep " => " | head -1 | sed -e "s/.*=> *//" -e "s/ *(.*//" -e "s:/[^/]*$::")
 	LP=${LP#/usr}
 


### PR DESCRIPTION
/bin/sh on Ubuntu is a link to dash, which doesn't support [[ ... ]].