### PR TITLE
Fix build warnings with clang

### DIFF
--- a/keepalived/core/track_process.c
+++ b/keepalived/core/track_process.c
@@ -799,8 +799,8 @@ static int set_proc_ev_listen(int nl_sd, bool enable)
 	struct __attribute__ ((aligned(NLMSG_ALIGNTO))) {
 		struct nlmsghdr nl_hdr;
 		struct __attribute__ ((__packed__)) {
-			struct cn_msg cn_msg;
 			enum proc_cn_mcast_op cn_mcast;
+			struct cn_msg cn_msg;
 		};
 	} nlcn_msg;
 

--- a/lib/assert_debug.h
+++ b/lib/assert_debug.h
@@ -24,6 +24,10 @@
 
 #include "config.h"
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
 #ifndef _ENABLE_ASSERT_
 #define  NDEBUG
 #endif


### PR DESCRIPTION
Fix build warnings(with clang 18.2):
- ./assert_debug.h:28:10: warning: 'NDEBUG' macro redefined [-Wmacro-redefined]
- track_process.c:802:18: warning: field 'cn_msg' with variable sized type 'struct cn_msg' not at the end of a struct or class is a GNU extension [-Wgnu-variable-sized-type-not-at-end]