### PR TITLE
Fix build error when HAVE_CLOSE_RANGE not defined

### DIFF
--- a/lib/notify.c
+++ b/lib/notify.c
@@ -27,10 +27,10 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE         /* for close_range() */
 #endif
-#include <unistd.h>
 #endif
 #include <linux/close_range.h>
 #endif
+#include <unistd.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>


### PR DESCRIPTION
unistd.h should't inside macro HAVE_CLOSE_RANGE