### PR TITLE
track_file: fix memory leak

### DIFF
--- a/keepalived/trackers/track_file.c
+++ b/keepalived/trackers/track_file.c
@@ -409,6 +409,7 @@ track_file_end_handler(void)
 				  errno, track_file->fname);
 
 		FREE_CONST(track_file->fname);
+		FREE_CONST(track_file->file_path);
 		FREE(track_file);
 
 		return;


### PR DESCRIPTION
If a track_file was configured, but the configured file did not exist, then the track_file structure was freed, but the path to the (non existent) file was not freed.