### PR TITLE
vrrp: remove redundant not NULL check

### DIFF
--- a/keepalived/vrrp/vrrp_iptables.c
+++ b/keepalived/vrrp/vrrp_iptables.c
@@ -320,6 +320,8 @@ check_chains_exist(uint8_t family)
 	return ret;
 }
 
+/* This function is always called with global_data->vrrp_iptables_inchain pointing to a valid
+ * chain name. */
 static void
 handle_iptable_rule_to_vip(ip_address_t *ipaddress, int cmd, struct ipt_handle *h, bool force)
 {
@@ -343,7 +345,7 @@ handle_iptable_rule_to_vip(ip_address_t *ipaddress, int cmd, struct ipt_handle *
 	    IN6_IS_ADDR_LINKLOCAL(&ipaddress->u.sin6_addr))
 		ifname = ipaddress->ifp->ifname;
 
-	if (family == AF_INET6 && global_data->vrrp_iptables_inchain) {
+	if (family == AF_INET6) {
 		if (global_data->vrrp_iptables_outchain) {
 			iptables_entry(h, AF_INET6, global_data->vrrp_iptables_outchain, APPEND_RULE,
 					XTC_LABEL_ACCEPT, ipaddress, NULL, NULL, ifname,


### PR DESCRIPTION
Github issue #2627 reported that there was a potential null pointer dereference in handle_iptable_rule_to_vip() due to global_data->vrrp_iptables_inchain being checked to be not null, but subsequently used without such a check.

Since handle_iptable_rule_to_vip() is only called if the pointer is non NULL, the check for non NULL is removed, and a comment added at the beginning of the function to state that it is always non NULL.