### PR TITLE
Fix address sanitizer error in find_definition

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -1903,9 +1903,10 @@ find_definition(const char *name, size_t len, bool definition)
 			return NULL;
 	}
 
+	size_t name_len = strlen(name);
 	if (definition ||
-	    (!using_braces && name[len] == '\0') ||
-	    (using_braces && name[len+1] == '\0'))
+		(!using_braces && len < name_len && name[len] == '\0') ||
+		(using_braces && len + 1 < name_len && name[len+1] == '\0'))
 		allow_multiline = true;
 	else
 		allow_multiline = false;


### PR DESCRIPTION
The error is that an element is being accessed beyond the right limit of the array allocated on the heap. That is, first we find out the length of the string, and only then we access its elements by indexes, checking the range to which these indexes belong.