### PR TITLE
Fixed UB sanitizer error in check_definition

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -2166,6 +2166,7 @@ check_definition(const char *buf)
 	/* Skip leading whitespace */
 	p += strspn(p + 1, " \t") + 1;
 	def->value_len = strlen(p);
+	if (def->value_len - 1 < 0) { return NULL; }
 	if (p[def->value_len - 1] == '\\') {
 		/* Remove trailing whitespace */
 		while (def->value_len >= 2 &&


### PR DESCRIPTION
The error lies in the fact that inside the curly brackets of the array, the number def->value_len - 1 first turns out to be negative, and then through integer-promotion to size_t it turns into a huge positive number.