### PR TITLE
Fix UB sanitizer error in add_seq

### DIFF
--- a/lib/parser.c
+++ b/lib/parser.c
@@ -1432,6 +1432,11 @@ add_seq(char *buf)
 	p++;
 	p += strspn(p, " \t");
 	end_seq = strchr(p, ')');
+	if (!end_seq) {
+		char *buf1 = "Unsupported format data";
+		report_config_error(CONFIG_GENERAL_ERROR, "Error", buf1);
+		return false;
+	}
 	if ((size_t)(end_seq + 1 - p + 1) > sizeof(seq_buf)) {
 		report_config_error(CONFIG_GENERAL_ERROR, "~SEQ parameter strings too long '%s'", buf);
 		return false;


### PR DESCRIPTION
The error is that a null ptr is returned from strchr(), which is subsequently used in a subsequent expression.