### PR TITLE
ipvs: Remove duplicate virtual servers during config validation

### DIFF
--- a/keepalived/check/ipwrapper.c
+++ b/keepalived/check/ipwrapper.c
@@ -42,7 +42,7 @@
 #include "check_data.h"
 #endif
 
-static bool __attribute((pure))
+bool __attribute((pure))
 vs_iseq(const virtual_server_t *vs_a, const virtual_server_t *vs_b)
 {
 	if (!vs_a->vsgname != !vs_b->vsgname)

--- a/keepalived/include/ipwrapper.h
+++ b/keepalived/include/ipwrapper.h
@@ -48,6 +48,7 @@ rs_iseq(const real_server_t *rs_a, const real_server_t *rs_b)
 {
 	return sockstorage_equal(&rs_a->addr, &rs_b->addr);
 }
+extern bool __attribute__((pure)) vs_iseq(const virtual_server_t *, const virtual_server_t *);
 
 /* prototypes */
 extern void update_svr_wgt(int64_t, virtual_server_t *, real_server_t *, bool);


### PR DESCRIPTION
The current IPVS implementation allows duplicate virtual server (VS) configurations. While IPVS ensures only the first VS takes effect, the presence of redundant VS entries in the keepalived state can be confusing. Furthermore, checkers for these remaining duplicate VS still perform unnecessary work.

This commit actively detects and removes duplicate virtual servers during configuration validation. To maintain compatibility with existing configurations that might implicitly rely on this behavior, this change preserves the first encountered VS.