### PR TITLE
vrrp: fix instance up without vrrp_scripts

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -5116,6 +5116,14 @@ vrrp_complete_init(void)
 
 	alloc_vrrp_buffer(max_mtu_len ? max_mtu_len : DEFAULT_MTU);
 
+	/* Bring vrrp instances up if there are no vrrp_scripts monitored */
+	list_for_each_entry(vrrp, &vrrp_data->vrrp, e_list) {
+		if (!vrrp->num_script_init &&
+		    (!vrrp->sync || !vrrp->sync->num_member_init)) {
+			try_up_instance(vrrp, true, VRRP_FAULT_FL_TRACKER);
+		}
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Normally, VRRP instance is brought up when the last of monitored track script leaves `SCRIPT_INIT_STATE_INIT` state and
`process_script_update_priority` is executed.

However, in a configuration scenario where VRRP instance does not monitor any track scripts, the `try_up_instance` function is not called. This patch addresses that scenario and ensures the VRRP instances are brought up correctly.

Might fix: https://github.com/acassen/keepalived/issues/2647
