### PR TITLE
check: send systemd READY even with no runnable config

### DIFF
--- a/keepalived/core/main.c
+++ b/keepalived/core/main.c
@@ -43,6 +43,7 @@
 #include "main.h"
 #include "global_data.h"
 #include "daemon.h"
+#include "config_notify.h"
 #ifndef _ONE_PROCESS_DEBUG_
 #include "config_notify.h"
 #endif
@@ -572,6 +573,9 @@ start_keepalived(__attribute__((unused)) thread_ref_t thread)
 
 	if (!have_child)
 		log_message(LOG_INFO, "Warning - keepalived has no configuration to run");
+#ifdef _USE_SYSTEMD_NOTIFY_
+		systemd_notify_running();
+#endif
 }
 
 static bool


### PR DESCRIPTION
When keepalived starts without any VRRP/LVS/BFD blocks, it does not spawn any child processes. In this case, systemd never receives a READY=1 notification, and the service eventually times out during startup.

Fix this by explicitly calling systemd_notify_running() when there are no children, so that systemd always gets a readiness signal, even with an empty configuration.