### PR TITLE
vrrp: restore multicast membership on interface up

### DIFF
--- a/keepalived/vrrp/vrrp_if.c
+++ b/keepalived/vrrp/vrrp_if.c
@@ -1372,8 +1372,56 @@ if_setsockopt_no_receive(int *sd)
 void
 interface_up(interface_t *ifp)
 {
+	tracking_obj_t *top;
+	vrrp_t *vrrp;
+
 	/* We need to re-add static addresses and static routes */
 	static_track_group_reinstate_config(ifp);
+
+	/* When an interface goes down and back up (e.g., driver restart),
+	 * the kernel drops multicast group membership. We need to close
+	 * and reopen VRRP sockets to restore multicast membership.
+	 * Without this, keepalived stops receiving VRRP advertisements
+	 * and stays stuck in BACKUP state. */
+	list_for_each_entry(top, &ifp->tracking_vrrp, e_list) {
+		vrrp = top->obj.vrrp;
+
+		if (!vrrp->ifp || !vrrp->sockets)
+			continue;
+
+		/* Skip if this is just a tracked interface, not the main one */
+		if (vrrp->ifp != ifp
+#ifdef _HAVE_VRRP_VMAC_
+		    && IF_BASE_IFP(vrrp->ifp) != ifp
+#endif
+		)
+			continue;
+
+#ifdef _HAVE_VRRP_VMAC_
+		/* Skip VMACs and IPVLANs - they are handled separately */
+		if (__test_bit(VRRP_VMAC_BIT, &vrrp->flags)
+#ifdef _HAVE_VRRP_IPVLAN_
+		    || __test_bit(VRRP_IPVLAN_BIT, &vrrp->flags)
+#endif
+		)
+			continue;
+#endif
+
+		/* Close existing sockets to force recreation with fresh
+		 * multicast group membership */
+		if (vrrp->sockets->fd_in != -1) {
+			thread_cancel_read(master, vrrp->sockets->fd_in);
+			close(vrrp->sockets->fd_in);
+			vrrp->sockets->fd_in = -1;
+		}
+		if (vrrp->sockets->fd_out != -1) {
+			close(vrrp->sockets->fd_out);
+			vrrp->sockets->fd_out = -1;
+		}
+
+		/* Reopen sockets with restored multicast membership */
+		setup_interface(vrrp);
+	}
 }
 
 void


### PR DESCRIPTION
## Summary

When a network interface goes down and back up (e.g., network driver restart like Mellanox mcab), the kernel drops multicast group membership. However, keepalived doesn't re-add the membership because VRRP sockets remain open (`fd_in != -1`).

This causes VRRP instances to stop receiving advertisements and stay stuck in BACKUP state indefinitely, even though the interface is back up and functional.

## Changes

- Modify `interface_up()` to close and reopen VRRP sockets when interface comes back up
- This restores multicast group membership (`IP_ADD_MEMBERSHIP`) 
- Logic mirrors socket handling in `cleanup_lost_interface()` but triggers on interface state change rather than deletion

## Test plan

- [ ] Start keepalived with VRRP instance on interface
- [ ] Bring interface down: `ip link set eth0 down`
- [ ] Bring interface up: `ip link set eth0 up`
- [ ] Verify keepalived receives VRRP packets and transitions correctly
- [ ] Verify multicast membership restored: `ip maddr show` should show 224.0.0.18

## Related

Fixes: https://github.com/acassen/keepalived/issues/1847