### PR TITLE
build: make OpenSSL pkg-config flags drive header checks and link flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1570,6 +1570,18 @@ if test "$enable_lvs" != no; then
   NEED_EVP=yes
   NEED_SSL=yes
 fi
+
+$PKG_CONFIG --exists openssl
+if test $? -eq 0; then
+  add_pkg_config([openssl], [OPENSSL])
+  add_to_var([KA_CPPFLAGS], [$OPENSSL_CPPFLAGS])
+  add_to_var([KA_CFLAGS], [$OPENSSL_CFLAGS])
+else
+  OPENSSL_LIBS="-lssl -lcrypto"
+fi
+
+SAV_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="$OPENSSL_CPPFLAGS $CPPFLAGS"
 AC_CHECK_HEADERS([openssl/ssl.h openssl/err.h], [],
   [
     if test $NEED_SSL = yes; then
@@ -1586,14 +1598,8 @@ AC_CHECK_HEADERS([openssl/md5.h openssl/evp.h], [],
   !!! Can not include OpenSSL EVP headers files.        !!!])
     fi
   ])
+CPPFLAGS="$SAV_CPPFLAGS"
 unset LIBS
-
-$PKG_CONFIG --exists openssl
-if test $? -eq 0; then
-  add_pkg_config([openssl], [OPENSSL])
-else
-  OPENSSL_LIBS="-lssl -lcrypto"
-fi
 
 EXTRA_LIBS=`echo $OPENSSL_LIBS | sed -e "s/-lssl//"`
 AC_CHECK_LIB(ssl, SSL_CTX_new, [],
@@ -1602,9 +1608,6 @@ AC_CHECK_LIB(ssl, SSL_CTX_new, [],
       AC_MSG_ERROR([OpenSSL libraries are required])
     fi
   ], [$EXTRA_LIBS])
-if test $NEED_SSL = yes; then
-  add_to_var([KA_LIBS], [$LIBS])
-fi
 unset LIBS
 
 EXTRA_LIBS=`echo $OPENSSL_LIBS | sed -e "s/-lcrypto//"`
@@ -1615,7 +1618,11 @@ AC_CHECK_LIB(crypto, EVP_DigestInit_ex, [],
     fi
   ], [$EXTRA_LIBS])
 if test $NEED_EVP = yes; then
-  add_to_var([KA_LIBS], [$LIBS])
+  if test $NEED_SSL = yes; then
+    add_to_var([KA_LIBS], [$OPENSSL_LIBS])
+  else
+    add_to_var([KA_LIBS], [`echo $OPENSSL_LIBS | sed -e "s/-lssl//"`])
+  fi
   AC_CHECK_LIB(crypto, EVP_MD_CTX_new, [],
     [
       AC_DEFINE([EVP_MD_CTX_new()], [EVP_MD_CTX_create()], [Named changed in OpenSSL v1.1.0])
@@ -1623,6 +1630,8 @@ if test $NEED_EVP = yes; then
       AC_DEFINE([EVP_MD_CTX_reset(ctx)], [EVP_MD_CTX_init(ctx)], [Named changed in OpenSSL v1.1.0])
     ],
     [$EXTRA_LIBS])
+elif test $NEED_SSL = yes; then
+  add_to_var([KA_LIBS], [`echo $OPENSSL_LIBS | sed -e "s/-lcrypto//"`])
 fi
 unset LIBS
 


### PR DESCRIPTION
The OpenSSL detection in configure.ac performed header probes before pkg-config and only propagated the transient LIBS from AC_CHECK_LIB to KA_LIBS. This causes OpenSSL auto-detection to fail when it is in a nonstandard prefix, even though pkg-config knows the correct paths.

Run pkg-config before the OpenSSL probes. For the header checks, temporarily add OPENSSL_CPPFLAGS to CPPFLAGS and record OPENSSL_CFLAGS in KA_CFLAGS. For linking, use OPENSSL_LIBS directly in KA_LIBS. When only EVP is needed, add OPENSSL_LIBS without -lssl.