### PR TITLE
snmp: fix operator precedence

### DIFF
--- a/keepalived/vrrp/vrrp_snmp.c
+++ b/keepalived/vrrp/vrrp_snmp.c
@@ -3418,7 +3418,7 @@ snmp_rfcv2_header_list_table(struct variable *vp, oid *name, size_t *length,
 		if (!suitable_for_rfc2787(vrrp))
 			continue;
 
-		if (target_len && (vrrp->ifp ? IF_BASE_INDEX(vrrp->ifp) : 0 < target[0]))
+		if (target_len && ((vrrp->ifp ? IF_BASE_INDEX(vrrp->ifp) : 0) < target[0]))
 			continue; /* Optimization: cannot be part of our set */
 
 		current[0] = vrrp->ifp ? IF_BASE_INDEX(vrrp->ifp) : 0;


### PR DESCRIPTION
This patch fixes an issue that, under certain conditions, prevented RFC2787 tables from working correctly for v2 instances.

The comparison in question is performed correctly e.g. in https://github.com/acassen/keepalived/blob/master/keepalived/vrrp/vrrp_snmp.c#L4070 but in the v2 tables, the missing parenthesis leads to unintended behavior.