### PR TITLE
ipvs: tolerate distinct VSGs resolving to the same kernel service tuple

### DIFF
--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -199,6 +199,27 @@ ipvs_talk(int cmd, ipvs_service_t *srule, ipvs_dest_t *drule, ipvs_daemon_t *dae
 #endif
 		case IP_VS_SO_SET_ADDDEST:
 			result = ipvs_add_dest(srule, drule);
+			if (result && errno == ENOENT) {
+				/*
+				 * The parent IPVS service is missing in the
+				 * kernel: this can happen when several VSGs
+				 * resolve to the same (proto,addr,port) tuple
+				 * and an earlier diff issued a LVS_CMD_DEL on
+				 * the shared service while the surviving VSG
+				 * was just marked "reloaded". Re-create the
+				 * service from srule and retry the dest add
+				 * once.
+				 */
+				int saved_errno = errno;
+
+				if (!ipvs_add_service(srule)) {
+					log_message(LOG_INFO,
+						    "IPVS: re-created missing parent service for ADDDEST");
+					result = ipvs_add_dest(srule, drule);
+				} else {
+					errno = saved_errno;
+				}
+			}
 			break;
 		case IP_VS_SO_SET_DELDEST:
 			result = ipvs_del_dest(srule, drule);
@@ -208,6 +229,17 @@ ipvs_talk(int cmd, ipvs_service_t *srule, ipvs_dest_t *drule, ipvs_daemon_t *dae
 			    (errno == ENOENT)) {
 				cmd = IP_VS_SO_SET_ADDDEST;
 				result = ipvs_add_dest(srule, drule);
+				if (result && errno == ENOENT) {
+					int saved_errno = errno;
+
+					if (!ipvs_add_service(srule)) {
+						log_message(LOG_INFO,
+							    "IPVS: re-created missing parent service for ADDDEST (via EDITDEST)");
+						result = ipvs_add_dest(srule, drule);
+					} else {
+						errno = saved_errno;
+					}
+				}
 			}
 			break;
 		default:

--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -250,26 +250,33 @@ ipvs_talk(int cmd, ipvs_service_t *srule, ipvs_dest_t *drule, ipvs_daemon_t *dae
 		result = 0;
 	else if (result) {
 		char buf[2 + INET6_ADDRSTRLEN + 6 + 5 + 4 + INET6_ADDRSTRLEN + 1 + 5 + 1 + 1];	/* " (" + IPv6 + ":sctp:" + port + " -> " + IPV6 + ":" + port + ")" */
+		bool benign;
 
-		if (errno == EEXIST &&
-			(cmd == IP_VS_SO_SET_ADD || cmd == IP_VS_SO_SET_ADDDEST))
+		/*
+		 * EEXIST on ADD/ADDDEST and ENOENT on DEL/DELDEST are
+		 * silently turned into success because they are
+		 * informational at best and noise at worst.
+		 */
+		benign = (errno == EEXIST &&
+			  (cmd == IP_VS_SO_SET_ADD || cmd == IP_VS_SO_SET_ADDDEST)) ||
+			 (errno == ENOENT &&
+			  (cmd == IP_VS_SO_SET_DEL || cmd == IP_VS_SO_SET_DELDEST));
+		if (benign)
 			result = 0;
-		else if (errno == ENOENT &&
-			(cmd == IP_VS_SO_SET_DEL || cmd == IP_VS_SO_SET_DELDEST))
-			result = 0;
+		else {
+			buf[0] = ' ';
+			buf[1] = '(';
+			if (cmd == IP_VS_SO_SET_ADD || cmd == IP_VS_SO_SET_DEL || cmd == IP_VS_SO_SET_EDIT)
+				format_srule(buf + 2, srule);
+			else if (cmd == IP_VS_SO_SET_ADDDEST || cmd == IP_VS_SO_SET_DELDEST || cmd == IP_VS_SO_SET_EDITDEST)
+				format_drule(buf + 2 + format_srule(buf + 2, srule), drule);
+			else
+				buf[0] = '\0';
+			if (buf[0])
+				strcat(buf, ")");
 
-		buf[0] = ' ';
-		buf[1] = '(';
-		if (cmd == IP_VS_SO_SET_ADD || cmd == IP_VS_SO_SET_DEL || cmd == IP_VS_SO_SET_EDIT)
-			format_srule(buf + 2, srule);
-		else if (cmd == IP_VS_SO_SET_ADDDEST || cmd == IP_VS_SO_SET_DELDEST || cmd == IP_VS_SO_SET_EDITDEST)
-			format_drule(buf + 2 + format_srule(buf + 2, srule), drule);
-		else
-			buf[0] = '\0';
-		if (buf[0])
-			strcat(buf, ")");
-
-		log_message(LOG_INFO, "IPVS cmd %s(%d) error: %s(%d)%s", ipvs_cmd_str(cmd), cmd, ipvs_strerror(errno), errno, buf);
+			log_message(LOG_INFO, "IPVS cmd %s(%d) error: %s(%d)%s", ipvs_cmd_str(cmd), cmd, ipvs_strerror(errno), errno, buf);
+		}
 	}
 	return result;
 }
@@ -463,10 +470,19 @@ ipvs_group_cmd(int cmd, ipvs_service_t *srule, ipvs_dest_t *drule, virtual_serve
 
 	/* visit addr_range list */
 	list_for_each_entry(vsg_entry, &vsg->addr_range, e_list) {
-		if (cmd == IP_VS_SO_SET_ADD && reload && vsg_entry->reloaded)
-			continue;
-
-		if (ipvs_change_needed(cmd, vsg_entry, vs, rs)) {
+		/*
+		 * For LVS_CMD_ADD always reach the kernel as neither
+		 * vsg_entry->reloaded nor !is_vsge_alive() are
+		 * authoritative about kernel state. Distinct VSGs can
+		 * resolve to the same (proto,vip,port) tuple and one of
+		 * them tearing down on diff would silently delete the
+		 * shared service while the others were just marked
+		 * "reloaded" and so skipped. ipvs_talk() now
+		 * unconditionally re-issues the command, safe and
+		 * idempotent.
+		 */
+		if (cmd == IP_VS_SO_SET_ADD ||
+		    ipvs_change_needed(cmd, vsg_entry, vs, rs)) {
 			srule->user.port = inet_sockaddrport(&vsg_entry->addr);
 			if (rs) {
 				if (rs->forwarding_method != IP_VS_CONN_F_MASQ)
@@ -494,9 +510,6 @@ ipvs_group_cmd(int cmd, ipvs_service_t *srule, ipvs_dest_t *drule, virtual_serve
 	}
 
 	list_for_each_entry(vsg_entry, &vsg->vfwmark, e_list) {
-		if (cmd == IP_VS_SO_SET_ADD && reload && vsg_entry->reloaded)
-			continue;
-
 		srule->user.fwmark = vsg_entry->vfwmark;
 
 		if (vsg_entry->fwm_family != AF_UNSPEC)
@@ -508,7 +521,8 @@ ipvs_group_cmd(int cmd, ipvs_service_t *srule, ipvs_dest_t *drule, virtual_serve
 		srule->user.netmask = (srule->af == AF_INET6) ? 128 : ((uint32_t) 0xffffffff);
 
 		/* Talk to the IPVS channel */
-		if (ipvs_change_needed(cmd, vsg_entry, vs, rs)) {
+		if (cmd == IP_VS_SO_SET_ADD ||
+		    ipvs_change_needed(cmd, vsg_entry, vs, rs)) {
 			if (ipvs_talk(cmd, srule, drule, NULL, false))
 				return -1;
 		}


### PR DESCRIPTION
The docs ([`doc/man/man5/keepalived.conf.5.in:2280`](https://github.com/acassen/keepalived/blob/b3631012262e7156aef0a47069204b84dc7156cd/doc/man/man5/keepalived.conf.5.in#L2280-L2283)) forbid two VSes using the same VSG with the same protocol/family.
The same kernel constraint - one IPVS service per `(proto, vip, port)` or `(proto, family, fwmark)` - applies when **distinct** VSGs emit entries that collide on that tuple.

While that should not happen, in practice (provisioning streams, churn between renders on automation system) it sometimes does, and keepalived currently lets it silently desync from the kernel and never recovers.
Typically, every reload then logs `IP_VS_SO_SET_ADDDEST(1159) ENOENT(2)` / `IP_VS_SO_SET_DELDEST ENOENT` against a service the kernel no longer has but the surviving VSG still expects.

These patches makes keepalived hopefully deal with that case:
1. **`ipvs: recover from missing parent service on ADDDEST/EDITDEST`**: when the kernel returns `ENOENT` on a dest add, recreate the parent service from the same `srule` and retry once. No behavior change is expected on healthy reloads.
2. **`ipvs: do not trust per-vsge "reloaded" mark on LVS_CMD_ADD`**: drop the `reloaded` skip and `is_vsge_alive` shortcut on the ADD path; `EEXIST` is already idempotent in `ipvs_talk()`, so unconditionally re-issuing it prevents the wedge from forming. 

#### Reproducer
Two VSGs (`A`, `B`) both containing e.g. `2001:db8::1 80` with `protocol tcp`, alive RSes.
Reload after dropping the entry from `B` only. Without the series: the kernel service for `(tcp, 2001:db8::1, 80)` disappears, syslog starts streaming `ADDDEST/DELDEST ENOENT`, and the wedge survives next reloads.

With patch 1 the next `ADDDEST` repairs it. With patch 2 it never forms.