### PR TITLE
vrrp: avoid reload crash before socket pool setup

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -3703,7 +3703,8 @@ vrrp_complete_instance(vrrp_t * vrrp)
 				if (!old_vmac_deleted) {
 					strcpy(vrrp->vmac_ifname, ifp->ifname);
 					vrrp->ifp = ifp;
-					__set_bit(VRRP_VMAC_UP_BIT, &vrrp->flags);
+					if (IF_FLAGS_UP(ifp))
+						__set_bit(VRRP_VMAC_UP_BIT, &vrrp->flags);
 					ifp->is_ours = true;
 
 					/* The interface existed, so it may have config set on it */

--- a/keepalived/vrrp/vrrp_scheduler.c
+++ b/keepalived/vrrp/vrrp_scheduler.c
@@ -331,6 +331,9 @@ vrrp_init_instance_sands(vrrp_t *vrrp)
 	else if (vrrp->state == VRRP_STATE_FAULT || vrrp->state == VRRP_STATE_INIT)
 		vrrp->sands.tv_sec = TIMER_DISABLED;
 
+	if (!vrrp->sockets)
+		return;
+
 	rb_move_cached(&vrrp->rb_sands, &vrrp->sockets->rb_sands, vrrp_timer_less);
 }
 
@@ -378,6 +381,9 @@ vrrp_compute_timer(const sock_t *sock)
 void
 vrrp_thread_requeue_read(vrrp_t *vrrp)
 {
+	if (!vrrp->sockets || vrrp->sockets->fd_in == -1)
+		return;
+
 	thread_requeue_read(master, vrrp->sockets->fd_in, vrrp_compute_timer(vrrp->sockets));
 }
 


### PR DESCRIPTION
### Summary

This patch fixes two reload failure modes observed in the same incident:

- a VRRP child crash when an instance is moved to `BACKUP` before its socket
  pool has been assigned;
- a reused VMAC being treated as up even when the existing interface is actually
  down.

### Details

During reload, netlink processing can call `try_up_instance()` before
`vrrp_dispatcher_init()` has assigned `vrrp->sockets`.

`try_up_instance()` updates the instance sands and requeues the VRRP read
thread. Both operations normally need `vrrp->sockets`. In the early reload
window, however, `vrrp->sockets` can still be `NULL`, so the read requeue path
can dereference a NULL socket pointer via `vrrp_compute_timer()`.

The patch makes these two helper paths tolerate that early window:

- `vrrp_init_instance_sands()` still updates `vrrp->sands`, but skips moving the
  rb-tree node until `vrrp->sockets` exists;
- `vrrp_thread_requeue_read()` returns if `vrrp->sockets` is not assigned or
  the input fd is not valid.

The dispatcher initialization path still adds instances to the socket rb-tree
and initializes timers once sockets have been created.

The patch also changes VMAC reuse handling so `VRRP_VMAC_UP_BIT` is only set
when the existing VMAC interface is actually up. This allows the normal VMAC
setup path to bring a reused-but-down VMAC back up after a child crash or other
partial initialization.