### PR TITLE
fix: prevent segmentation fault in ipvs_group_sync_entry

### DIFF
--- a/keepalived/check/ipvswrapper.c
+++ b/keepalived/check/ipvswrapper.c
@@ -665,7 +665,7 @@ ipvs_group_sync_entry(virtual_server_t *vs, virtual_server_group_entry_t *vsge)
 		if (rs->reloaded && (rs->alive || (rs->inhibit && rs->set))) {
 			/* Prepare the IPVS drule */
 			ipvs_set_drule(IP_VS_SO_SET_ADDDEST, &drule, rs);
-			drule.user.weight = ((rs->inhibit && !rs->alive) || vs->s_svr->alive) ? 0 : real_weight(rs->effective_weight);
+			drule.user.weight = ((rs->inhibit && !rs->alive) || (vs->s_svr && vs->s_svr->alive)) ? 0 : real_weight(rs->effective_weight);
 
 			if (rs->forwarding_method != IP_VS_CONN_F_MASQ)
 				drule.user.port = inet_sockaddrport(&vsge->addr);


### PR DESCRIPTION
## Problem
When adding a new IP address to a `virtual_server_group` and reloading keepalived, the checker child segfaults if the virtual server does **not** have a `sorry_server`.

Sample configuration that triggers the crash:

```text
global_defs {
        lvs_flush
}
virtual_server_group VG_80 {
        203.0.113.35 80
        203.0.113.32 80
        203.0.113.49 80
        203.0.113.56 80
        203.0.113.33 80
}
```

Stack trace:

```text
#0  ipvs_group_sync_entry (keepalived + 0x20f6a)
#1  sync_service_vsg_entry (keepalived + 0x1d8d4)
#2  sync_service_vsg (keepalived + 0x1eb06)
#3  start_check (keepalived + 0xf591)
#4  reload_check_thread (keepalived + 0xf8c3)
...
```

## Root Cause
In `ipvs_group_sync_entry()`, the weight of a real server is computed as:

```c
drule.user.weight = ((rs->inhibit && !rs->alive) || vs->s_svr->alive) ? 0 : real_weight(rs->effective_weight);
```

If no `sorry_server` is configured, `vs->s_svr` is `NULL`, so accessing `vs->s_svr->alive` causes a null pointer dereference.

The later block in the same function already checks `if (vs->s_svr && ...)` before dereferencing it, so this was just a missing check.


## Testing
- Reproduced the crash by adding a new IP to a VSG without `sorry_server` and reloading.
- Verified the crash no longer occurs after the fix.
