### PR TITLE
Say which limit a child hit when an allocation fails

### DIFF
--- a/doc/man/man5/keepalived.conf.5.in
+++ b/doc/man/man5/keepalived.conf.5.in
@@ -621,6 +621,15 @@ possibly following any cleanup actions needed.
     # Set the BFD child process priority
     \fBbfd_priority \fR<-20 to 19>
 
+    # The following options lock the vrrp, checker and bfd processes in
+    # memory.
+    # --
+    # RLIMIT_MEMLOCK must allow for the process to grow, since later mappings
+    # are charged against it; a process that reaches the limit fails an
+    # allocation and exits. The limit is not enforced for a process with
+    # CAP_IPC_LOCK, so this normally only matters where capabilities are
+    # reduced, such as in a container.
+
     # Set the vrrp child process non swappable
     \fBvrrp_no_swap\fR
 

--- a/lib/process.c
+++ b/lib/process.c
@@ -29,6 +29,8 @@
 #define RLIMIT_RTTIME	15
 #endif
 #include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <stdbool.h>
@@ -68,6 +70,36 @@ pid_t main_pid;
  * it can simply be referenced. */
 pid_t our_pid;
 
+/* mlockall(MCL_FUTURE) charges later mappings against RLIMIT_MEMLOCK, so report the
+ * limit; a process that outgrows it fails an allocation and exits. */
+static void
+report_memlock_limit(void)
+{
+	struct rlimit rlim;
+	rlim_t locked_kb = 0;
+	char buf[128];
+	FILE *fp;
+
+	if (getrlimit(RLIMIT_MEMLOCK, &rlim) < 0 || rlim.rlim_cur == RLIM_INFINITY)
+		return;
+
+	if (!(fp = fopen("/proc/self/status", "re")))
+		return;
+	while (fgets(buf, sizeof(buf), fp)) {
+		if (!strncmp(buf, "VmLck:", 6)) {
+			locked_kb = strtoul(buf + 6, NULL, 10);
+			break;
+		}
+	}
+	fclose(fp);
+
+	log_message(LOG_INFO, "Locked %" PRI_rlim_t " kB of the %" PRI_rlim_t " kB RLIMIT_MEMLOCK",
+			      locked_kb, rlim.rlim_cur / 1024);
+}
+
+/* NOTE: This function generates a "stack protector not protecting local variables:
+   variable length buffer" warning */
+RELAX_STACK_PROTECTOR_START
 static void
 set_process_dont_swap(size_t stack_reserve)
 {
@@ -96,7 +128,10 @@ set_process_dont_swap(size_t stack_reserve)
 	}
 
 	cur_stack_reserve = stack_reserve;
+
+	report_memlock_limit();
 }
+RELAX_STACK_PROTECTOR_END
 
 static void
 reset_process_dont_swap(void)

--- a/lib/scheduler.c
+++ b/lib/scheduler.c
@@ -575,6 +575,8 @@ report_child_status(int status, pid_t pid, char const *prog_name)
 
 		if (exit_status != EXIT_SUCCESS)
 			log_message(LOG_INFO, "%s exited with status %d", prog_id, exit_status);
+		if (exit_status == KEEPALIVED_EXIT_NO_MEMORY)
+			log_message(LOG_INFO, "  An allocation failed - if a *_no_swap option is set, check RLIMIT_MEMLOCK");
 	} else if (WIFSIGNALED(status)) {
 		if (WTERMSIG(status) == SIGSEGV) {
 			struct utsname uname_buf;

--- a/www/docs/documentation/keepalived-conf.md
+++ b/www/docs/documentation/keepalived-conf.md
@@ -563,6 +563,15 @@ global_defs {
     # Set the BFD child process priority
     bfd_priority <-20 to 19>
 
+    # The following options lock the vrrp, checker and bfd processes in
+    # memory.
+    # --
+    # RLIMIT_MEMLOCK must allow for the process to grow, since later mappings
+    # are charged against it; a process that reaches the limit fails an
+    # allocation and exits. The limit is not enforced for a process with
+    # CAP_IPC_LOCK, so this normally only matters where capabilities are
+    # reduced, such as in a container.
+
     # Set the vrrp child process non swappable
     vrrp_no_swap
 


### PR DESCRIPTION
When a child exits with KEEPALIVED_EXIT_NO_MEMORY the log reports only the numeric status, so nothing says a limit rather than the machine's memory was involved. With a `*_no_swap` option set, `mlockall()` marks later mappings for locking too, and where RLIMIT_MEMLOCK is enforced for the process the child fails an allocation and exits while the machine still has free memory. That took a while to find on a container host, where the limit is enforced because IPC_LOCK is not in the default capability set.

So: log what is locked and what the limit is once a process is locked in memory, add one line naming RLIMIT_MEMLOCK when a child exits on that status, and say so next to the options in keepalived.conf(5). The existing `exited with status` line and the respawn behaviour are unchanged, and the request to open an issue stays: exit 204 can also come from a real defect, so suppressing it for that status is your call.

Reproduced on the v2.4.3 tag with `vrrp_no_swap`, a memlock limit just above the child's startup footprint, and a veth add/delete loop; the growth that drove it is #2709. Before:

```
Keepalived: Cannot allocate memory
Tue Aug 11 13:39:12 2026: pid 351 exited with status 204
Tue Aug 11 13:39:12 2026: VRRP child process(351) died: Respawning
```

After:

```
Tue Aug 11 13:55:34 2026: Locked 10316 kB of the 11264 kB RLIMIT_MEMLOCK
[...]
Tue Aug 11 13:56:47 2026: pid 351 exited with status 204
Tue Aug 11 13:56:47 2026:   An allocation failed - if a *_no_swap option is set, check RLIMIT_MEMLOCK
Tue Aug 11 13:56:47 2026: VRRP child process(351) died: Respawning
```
