### PR TITLE
vrrp: prevent sync group demotion on member add

### DIFF
--- a/keepalived/vrrp/vrrp.c
+++ b/keepalived/vrrp/vrrp.c
@@ -2267,6 +2267,12 @@ vrrp_state_backup(vrrp_t *vrrp, const vrrphdr_t *hd, const char *buf, ssize_t bu
 			 * ms_down_timer had expired, we would have wanted MASTER state.
 			 * Now we have received a higher priority advert, we want to be in BACKUP state. */
 			vrrp->wantstate = VRRP_STATE_BACK;
+
+			/* A member added to the group by a reload runs its own
+			 * election. If it cannot win, the group cannot stay
+			 * MASTER. */
+			if (vrrp->sync && GROUP_STATE(vrrp->sync) == VRRP_STATE_MAST)
+				vrrp_sync_backup(vrrp);
 		} else {
 			/* !nopreempt and lower priority advert and any preempt delay timer has expired */
 			log_message(LOG_INFO, "(%s) received lower priority (%d) advert from %s - discarding", vrrp->iname, hd->priority, inet_sockaddrtos(&vrrp->pkt_saddr));
@@ -5235,12 +5241,18 @@ vrrp_complete_init(void)
 			if (sgroup->num_member_fault || sgroup->num_member_init)
 				continue;
 
-			have_master = true;
+			have_master = false;
 			list_for_each_entry(vrrp, &sgroup->vrrp_instances, s_list) {
+				/* An instance still in INIT state has no state to
+				 * contribute, it has not taken part in an election */
+				if (VRRP_ISUP(vrrp) && vrrp->state == VRRP_STATE_INIT)
+					continue;
 				if (vrrp->state != VRRP_STATE_MAST) {
 					have_master = false;
 					break;
 				}
+
+				have_master = true;
 			}
 			if (have_master)
 				sgroup->state = VRRP_STATE_MAST;


### PR DESCRIPTION
When a new interface is created, it default to BACKUP state. This caused
interface created and added to a group to demote it to backup, forcing existing
master members down until the new member completed its election.

Fix this by ignoring instances still in the INIT state during group
evaluation. Allow the new member to run its election independently.
Maintain the group's master state if it wins, and demote the group only

## Test plan

### Setup

```sh
ip netns add vrrptest
ip netns exec vrrptest ip link add eth0 type dummy
ip netns exec vrrptest ip addr add 192.168.100.1/24 dev eth0
ip netns exec vrrptest ip link set eth0 up multicast on
ip netns exec vrrptest ip link set lo up
```

### before.conf

```
vrrp_sync_group G {
  group {
    v1
    v2
  }
}
vrrp_instance v1 {
  state BACKUP
  interface eth0
  virtual_router_id 1
  priority 150
  advert_int 1
  virtual_ipaddress { 10.0.0.1/24 }
}
vrrp_instance v2 {
  state BACKUP
  interface eth0
  virtual_router_id 2
  priority 150
  advert_int 1
  virtual_ipaddress { 10.0.0.2/24 }
}
```

`after.conf` is the same with `v3` added to the group and a matching
`vrrp_instance v3` on `virtual_router_id 3`, `virtual_ipaddress 10.0.0.3/24`.

### Run

```sh
cp before.conf live.conf
ip netns exec vrrptest ../bin/keepalived -n -l -f $PWD/live.conf -p /run/vrrptest.pid &
KA=$!
sleep 5                       # v1 and v2 become MASTER

cp after.conf live.conf
kill -HUP $KA
sleep 2                       # <-- look here
```

### Result

Before the fix the whole group is demoted and every virtual address is
withdrawn until the new member wins its own election, about six seconds later:

```
(v1) Entering BACKUP STATE (init)
(v2) Entering BACKUP STATE (init)
(v3) Entering BACKUP STATE (init)
(v3) Entering MASTER STATE
VRRP_Group(G) Syncing instances to MASTER state
(v1) Entering MASTER STATE
(v2) Entering MASTER STATE
```

After the fix only the new member transitions; v1 and v2 are untouched:

```
(v3) Entering BACKUP STATE (init)
(v3) Entering MASTER STATE
```

Fixes: #2715