### PR TITLE
vrrp: Allow a static_ipaddress to enable an interface to leave fault …

### DIFF
--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -1419,7 +1419,9 @@ netlink_parse_info(int (*filter) (struct sockaddr_nl *, struct nlmsghdr *),
 			    h->nlmsg_type != RTM_NEWLINK &&
 			    h->nlmsg_type != RTM_DELLINK &&
 			    h->nlmsg_type != RTM_NEWROUTE &&
-// Allow NEWADDR/DELADDR for ipvlans
+			    h->nlmsg_type != RTM_NEWADDR &&
+			    h->nlmsg_type != RTM_DELADDR &&
+// Allow NEWADDR/DELADDR for ipvlans - and for static_ipaddress for first address on interface
 			    nl != &nl_cmd && h->nlmsg_pid == nl_cmd.nl_pid)
 				continue;
 #endif


### PR DESCRIPTION
…state

If the interface of a VRRP instance does not have an IP address, then the VRRP instance will be put into fault state. However, if the configuration has a static_ipaddress for that interface, then that should be sufficient for the VRRP instance to leave fault state.

This commit allow static_ipaddresses to be considered to be the primary address of an interface, and hence allow a VRRP instance to come up.