### PR TITLE
ipvs: Fix RS effective weight calculation after timeouts

### DIFF
--- a/keepalived/check/check_misc.c
+++ b/keepalived/check/check_misc.c
@@ -378,7 +378,7 @@ misc_check_child_thread(thread_ref_t thread)
 			 * Catch legacy case of status being 0 but misc_dynamic being set.
 			 */
 			if (status != misck_checker->last_exit_code) {
-				effective_weight = checker->rs->effective_weight - checker->cur_weight;
+				effective_weight = checker->rs->effective_weight - (misck_checker->last_exit_code ? misck_checker->last_exit_code - 2 - checker->rs->iweight : 0);
 				checker->cur_weight = status ? status - 2 - checker->rs->iweight : 0;
 				effective_weight += checker->cur_weight;
 				update_svr_wgt(effective_weight, checker->vs, checker->rs, true);

--- a/keepalived/core/keepalived_netlink.c
+++ b/keepalived/core/keepalived_netlink.c
@@ -57,6 +57,7 @@
 #include "keepalived_netlink.h"
 #ifdef _WITH_LVS_
 #include "check_api.h"
+#include "check_daemon.h"
 #endif
 #ifdef _WITH_VRRP_
 #include "vrrp_scheduler.h"
@@ -2664,7 +2665,10 @@ kernel_netlink_init(void)
 		init_interface_queue();
 #endif
 
-	netlink_address_lookup();
+#if !defined _ONE_PROCESS_DEBUG_ && defined _WITH_LVS_
+	if (prog_type != PROG_TYPE_CHECKER || using_ha_suspend)
+#endif
+		netlink_address_lookup();
 
 #if !defined _ONE_PROCESS_DEBUG_ && defined _WITH_LVS_
 	if (prog_type == PROG_TYPE_CHECKER)
@@ -2687,11 +2691,7 @@ kernel_netlink_read_interfaces(void)
 {
 	int ret;
 
-#ifdef _WITH_VRRP_
 	netlink_socket(&nl_cmd, global_data->vrrp_netlink_cmd_rcv_bufs, global_data->vrrp_netlink_cmd_rcv_bufs_force, 0, 0);
-#else
-	netlink_socket(&nl_cmd, global_data->lvs_netlink_cmd_rcv_bufs, global_data->lvs_netlink_cmd_rcv_bufs_force, 0, 0);
-#endif
 
 	if (nl_cmd.fd < 0)
 		fprintf(stderr, "Error while registering Kernel netlink cmd channel\n");


### PR DESCRIPTION
If MISC_CHECK scripts with misc_dynamic timed out, the effective weight of the RS kept increasing without limit, because the last exit status of the script was not being subtracted from the effective weight before the new exit status was added.

This commit corrects the calculation of effective weight by subtracting the previous exit status, rather than the current weight of the checker, since the current weight is set to 0 when a script times out.